### PR TITLE
add ens name & date

### DIFF
--- a/components/EnsName.tsx
+++ b/components/EnsName.tsx
@@ -1,0 +1,36 @@
+import truncateAddress from "@/lib/truncateAddress";
+import getEnsName from "@/lib/viem/getEnsName";
+import { FC, useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
+import { Address } from "viem";
+
+interface EnsNameProps {
+  className?: string;
+  address: Address;
+}
+const EnsName: FC<EnsNameProps> = ({ className = "", address }) => {
+  const [ref, inView] = useInView();
+
+  const [ensName, setEnsName] = useState("");
+
+  useEffect(() => {
+    const fetchEnsname = async () => {
+      if (address && inView) {
+        const response = await getEnsName(address);
+        setEnsName(response);
+        return;
+      }
+
+      setEnsName("");
+    };
+    fetchEnsname();
+  }, [address, inView]);
+
+  return (
+    <p className={`${className}`} ref={ref}>
+      {ensName || truncateAddress(address)}
+    </p>
+  );
+};
+
+export default EnsName;

--- a/components/HorizontalFeed/Feed.tsx
+++ b/components/HorizontalFeed/Feed.tsx
@@ -6,6 +6,7 @@ import { FC } from "react";
 import { Skeleton } from "../ui/skeleton";
 import { getIpfsLink } from "@/lib/utils";
 import truncateAddress from "@/lib/truncateAddress";
+import EnsName from "../EnsName";
 
 interface FeedProps {
   feed: LatestFeed;
@@ -23,13 +24,17 @@ const Feed: FC<FeedProps> = ({ feed, onHover, onLeave, hovered }) => {
   };
   return (
     <div className="relative">
-      <fieldset className="flex flex-col items-center">
+      <fieldset className="flex flex-col items-center mt-11">
         <button
           className="w-5 h-5 bg-black rounded-full relative z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-opacity-75 transition-transform hover:scale-110"
           onMouseEnter={onHover}
           onMouseLeave={onLeave}
           onClick={() => handleClick(feed)}
         />
+        <EnsName address={feed.owner} className="text-sm leading-[100%] pt-1" />
+        <p className="text-xs">
+          {new Date(feed.release_date).toLocaleString()}
+        </p>
       </fieldset>
       {hovered && (
         <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 bg-white shadow-lg rounded-lg p-2 md:p-4 transition-opacity duration-200 ease-in-out">

--- a/lib/viem/getEnsName.tsx
+++ b/lib/viem/getEnsName.tsx
@@ -1,0 +1,19 @@
+import { mainnet } from "viem/chains";
+import { getPublicClient } from "./publicClient";
+import { Address } from "viem";
+
+const getEnsName = async (address: Address): Promise<string> => {
+  try {
+    const publicClient = getPublicClient(mainnet.id);
+    const ensName = await publicClient.getEnsName({
+      address,
+    });
+
+    return ensName as string;
+  } catch (error) {
+    console.error(error);
+    return "";
+  }
+};
+
+export default getEnsName;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new component that displays the Ethereum Name Service name when available, or a shortened address otherwise.
	- Enhanced the feed view to show the owner's ENS name alongside a formatted release date.
- **Style**
	- Improved vertical spacing in the feed section for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->