### PR TITLE
fix share wrong link

### DIFF
--- a/components/Token/Buttons.tsx
+++ b/components/Token/Buttons.tsx
@@ -14,7 +14,7 @@ const Buttons = () => {
   const share = async () => {
     const shortNetworkName = getShortNetworkName(CHAIN.name.toLowerCase());
     await navigator.clipboard.writeText(
-      `https://inprocess.myco.wtf/collect/${shortNetworkName}:${token.token.contract.address}/1`,
+      `https://inprocess.myco.wtf/collect/${shortNetworkName}:${token.token.contract.address}/${token.token.tokenId}`,
     );
     toast.success("copied!");
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the token sharing functionality so that the URL now dynamically reflects the correct token identifier rather than a static value. This ensures that shared links accurately point to the intended token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->