### PR TITLE
feat: collections list in manage page

### DIFF
--- a/app/api/dune/artist/collections/route.ts
+++ b/app/api/dune/artist/collections/route.ts
@@ -16,7 +16,9 @@ export async function GET(req: NextRequest) {
       ...smartWalletEvents,
     ]);
     return Response.json(
-      formattedEvents.filter((e) => e.defaultAdmin === artistAddress),
+      formattedEvents.filter(
+        (e) => e.defaultAdmin.toLowerCase() === artistAddress?.toLowerCase(),
+      ),
     );
   } catch (e: any) {
     console.log(e);

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -1,0 +1,6 @@
+import { NextPage } from "next";
+import ManagePage from "@/components/ManagePage";
+
+const Manage: NextPage = () => <ManagePage />;
+
+export default Manage;

--- a/components/ArtistPage/ArtistPage.tsx
+++ b/components/ArtistPage/ArtistPage.tsx
@@ -13,7 +13,7 @@ const ArtistPage = () => {
   const { isEditing } = useProfileProvider();
 
   return (
-    <div className="w-screen grow flex flex-col pt-16 md:pt-[20vh] relative">
+    <div className="w-screen grow flex flex-col pt-16 relative">
       <div className="relative">
         {isEditing && <EditingStatus />}
         <div className="flex justify-between px-2 md:px-10 items-start pb-2">

--- a/components/ManagePage/CollectionItem.tsx
+++ b/components/ManagePage/CollectionItem.tsx
@@ -1,0 +1,39 @@
+import { useMetadata } from "@/hooks/useMetadata";
+import { Collection } from "@/types/token";
+import Image from "next/image";
+import truncateAddress from "@/lib/truncateAddress";
+import { getFetchableUrl } from "@/lib/protocolSdk/ipfs/gateway";
+
+const CollectionItem = ({ c }: { c: Collection }) => {
+  const { data, isLoading } = useMetadata(c.contractURI);
+
+  if (isLoading) return <div></div>;
+  if (data)
+    return (
+      <button
+        type="button"
+        className="col-span-1 w-full bg-grey-moss-300 rounded-lg overflow-hidden"
+      >
+        <div className="w-full aspect-video overflow-hidden relative">
+          <div className="absolute z-[10] bg-white/30 backdrop-blur-[4px] size-full left-0 top-0" />
+          <Image
+            src={getFetchableUrl(data.image) || "/images/placeholder.png"}
+            alt="not found img"
+            unoptimized
+            className="absolute z-[1]"
+            layout="fill"
+            objectFit="cover"
+            objectPosition="center center"
+          />
+        </div>
+        <div className="px-4 py-2">
+          <p className="font-archivo text-white text-left">{data?.name}</p>
+          <p className="font-archivo text-white text-left">
+            {truncateAddress(c.newContract)}
+          </p>
+        </div>
+      </button>
+    );
+};
+
+export default CollectionItem;

--- a/components/ManagePage/Collections.tsx
+++ b/components/ManagePage/Collections.tsx
@@ -1,0 +1,25 @@
+import { useMyCollections } from "@/hooks/useManageCollections";
+import Loading from "../Loading";
+import { Collection } from "@/types/token";
+import CollectionItem from "./CollectionItem";
+
+const Collections = () => {
+  const { data, isLoading } = useMyCollections();
+
+  if (isLoading)
+    return (
+      <div className="grow flex items-center justify-center">
+        <Loading className="w-[180px] aspect-[1/1] md:w-[300px]" />
+      </div>
+    );
+  if (data)
+    return (
+      <div className="grow grid grid-cols-4 gap-6 px-10">
+        {data.map((c: Collection, i) => (
+          <CollectionItem c={c} key={i} />
+        ))}
+      </div>
+    );
+};
+
+export default Collections;

--- a/components/ManagePage/ManagePage.tsx
+++ b/components/ManagePage/ManagePage.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import useConnectedWallet from "@/hooks/useConnectedWallet";
+import { useFrameProvider } from "@/providers/FrameProvider";
+import { useAccount } from "wagmi";
+import SignToInProcess from "./SignToInProcess";
+import { usePrivy } from "@privy-io/react-auth";
+import { Fragment, useEffect, useState } from "react";
+import Collections from "./Collections";
+
+const ManagePage = () => {
+  const { context } = useFrameProvider();
+  const { connectedWallet } = useConnectedWallet();
+  const { address } = useAccount();
+  const { ready } = usePrivy();
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const signedWallet = context ? address : connectedWallet;
+
+  useEffect(() => {
+    if (ready)
+      setTimeout(() => {
+        setLoaded(true);
+      }, 1000);
+  }, [ready]);
+
+  if (!loaded) return <Fragment />;
+  if (!signedWallet) return <SignToInProcess />;
+  return (
+    <div className="w-screen flex flex-col grow pt-16">
+      <Collections />
+    </div>
+  );
+};
+
+export default ManagePage;

--- a/components/ManagePage/SignToInProcess.tsx
+++ b/components/ManagePage/SignToInProcess.tsx
@@ -1,0 +1,35 @@
+import { useFrameProvider } from "@/providers/FrameProvider";
+import { config } from "@/providers/WagmiProvider";
+import { usePrivy } from "@privy-io/react-auth";
+import { useConnect } from "wagmi";
+
+const SignToInProcess = () => {
+  const { connect } = useConnect();
+  const { context } = useFrameProvider();
+  const { login } = usePrivy();
+
+  const handleSign = () => {
+    if (context) {
+      connect({
+        connector: config.connectors[0],
+      });
+      return;
+    }
+
+    login();
+  };
+  return (
+    <div className="w-screen flex flex-col items-center pt-20 gap-6">
+      <p className="font-archivo text-4xl">{`It's time to log into In Process`}</p>
+      <button
+        type="button"
+        onClick={handleSign}
+        className="bg-black text-white font-archivo text-xl min-w-[200px] rounded-md py-2"
+      >
+        sign in
+      </button>
+    </div>
+  );
+};
+
+export default SignToInProcess;

--- a/components/ManagePage/index.tsx
+++ b/components/ManagePage/index.tsx
@@ -1,0 +1,3 @@
+import ManagePage from "./ManagePage";
+
+export default ManagePage;

--- a/components/Token/ContentRenderer.tsx
+++ b/components/Token/ContentRenderer.tsx
@@ -25,17 +25,25 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
     );
   }
   if (mimeType.includes("video"))
-    return <VideoPlayer url={getFetchableUrl(metadata.animation_url) || ""} />;
+    return (
+      <div className="size-full flex justify-center items-center">
+        <VideoPlayer url={getFetchableUrl(metadata.animation_url) || ""} />
+      </div>
+    );
   return (
-    <Image
-      src={getFetchableUrl(metadata.image) || "/images/placeholder.png"}
-      alt="Token Image."
-      layout="fill"
-      objectFit="contain"
-      objectPosition="center"
-      blurDataURL={getFetchableUrl(metadata.image) || "/images/placeholder.png"}
-      unoptimized
-    />
+    <div className="grow relative size-full">
+      <Image
+        src={getFetchableUrl(metadata.image) || "/images/placeholder.png"}
+        alt="Token Image."
+        layout="fill"
+        objectFit="contain"
+        objectPosition="center"
+        blurDataURL={
+          getFetchableUrl(metadata.image) || "/images/placeholder.png"
+        }
+        unoptimized
+      />
+    </div>
   );
 };
 

--- a/hooks/useManageCollections.ts
+++ b/hooks/useManageCollections.ts
@@ -1,0 +1,27 @@
+import { Collection } from "@/types/token";
+import { useQuery } from "@tanstack/react-query";
+import useSignedAddress from "./useSignedAddress";
+
+async function fetchMyCollections(
+  address: string | string[] | undefined,
+): Promise<Collection[]> {
+  const response = await fetch(
+    `/api/dune/artist/collections?artistAddress=${address || ""}`,
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch my collections");
+  }
+  const data = await response.json();
+  return data;
+}
+
+export function useMyCollections() {
+  const address = useSignedAddress();
+  return useQuery({
+    queryKey: ["myCollections", address],
+    queryFn: () => fetchMyCollections(address),
+    enabled: Boolean(address),
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: true,
+  });
+}

--- a/hooks/useSignedAddress.tsx
+++ b/hooks/useSignedAddress.tsx
@@ -1,0 +1,13 @@
+import { useFrameProvider } from "@/providers/FrameProvider";
+import { useAccount } from "wagmi";
+import useConnectedWallet from "./useConnectedWallet";
+
+const useSignedAddress = () => {
+  const { context } = useFrameProvider();
+  const { address } = useAccount();
+  const { connectedWallet } = useConnectedWallet();
+
+  return context ? address : connectedWallet;
+};
+
+export default useSignedAddress;

--- a/providers/ArtistFeedProvider.tsx
+++ b/providers/ArtistFeedProvider.tsx
@@ -1,5 +1,4 @@
 import { useArtistCollections } from "@/hooks/useArtistCollections";
-import { useCollections } from "@/hooks/useCollections";
 import useFeeds from "@/hooks/useFeeds";
 import { createContext, useMemo, useContext } from "react";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Manage" page accessible at the `/manage` route, allowing users to view and interact with their collections.
  - Added components for displaying individual collections, handling wallet connection and authentication, and managing collection data.
  - Implemented hooks for fetching user-specific collections and retrieving the signed wallet address.

- **Improvements**
  - Enhanced filtering of artist collections to support case-insensitive address matching.
  - Updated layout and styling for artist and token pages, including improved content centering and consistent padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->