### PR TITLE
feat: login truncated size 9

### DIFF
--- a/components/LoginButton/PrivyButton.tsx
+++ b/components/LoginButton/PrivyButton.tsx
@@ -7,6 +7,7 @@ import { usePrivy } from "@privy-io/react-auth";
 import { Address } from "viem";
 import Image from "next/image";
 import { useLayoutProvider } from "@/providers/LayoutProvider";
+import truncated from "@/lib/truncated";
 
 interface PrivyButtonProps {
   className?: string;
@@ -43,7 +44,8 @@ export function PrivyButton({ className = "" }: PrivyButtonProps) {
         {connectedWallet ? (
           <>
             <p className="min-w-20 text-left">
-              {data?.username || truncateAddress(connectedWallet as string)}
+              {truncated(data?.username || "", 9) ||
+                truncateAddress(connectedWallet as string)}
             </p>
             <Image
               src="/images/down-arrow.svg"

--- a/components/LoginButton/WarpcastButton.tsx
+++ b/components/LoginButton/WarpcastButton.tsx
@@ -6,6 +6,7 @@ import { useFrameProvider } from "@/providers/FrameProvider";
 import { config } from "@/providers/WagmiProvider";
 import { useAccount, useConnect } from "wagmi";
 import { useLayoutProvider } from "@/providers/LayoutProvider";
+import truncated from "@/lib/truncated";
 
 interface WarpcastButtonProps {
   className?: string;
@@ -40,7 +41,8 @@ export function WarpcastButton({ className = "" }: WarpcastButtonProps) {
         />
         {isConnected ? (
           <p className="min-w-20 text-left">
-            {context?.user.displayName || truncateAddress(address as string)}
+            {truncated(context?.user.displayName || "", 9) ||
+              truncateAddress(address as string)}
           </p>
         ) : (
           "sign in"

--- a/lib/truncated.ts
+++ b/lib/truncated.ts
@@ -1,5 +1,5 @@
-const truncated = (text: string) => {
-  return text.length > 20 ? `${text.slice(0, 20)}...` : text;
+const truncated = (text: string, visibility: number | undefined = 20) => {
+  return text.length > visibility ? `${text.slice(0, visibility)}...` : text;
 };
 
 export default truncated;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Usernames and display names shown in login buttons are now truncated for improved readability, with a maximum length of 9 characters.
- **Style**
  - Enhanced the appearance of user information in login buttons by consistently shortening long names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->