### PR TITLE
add year and month dropdowns

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -145,3 +145,6 @@
 .plus-lighter {
   mix-blend-mode: plus-lighter;
 }
+div[aria-hidden="true"].text-sm.font-medium {
+  display: none !important;
+}

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -22,7 +22,7 @@ function Calendar({
       classNames={{
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
+        caption: "flex items-center justify-center gap-4",
         caption_label: "text-sm font-medium",
         nav: "space-x-1 flex items-center",
         nav_button: cn(
@@ -32,10 +32,10 @@ function Calendar({
         nav_button_previous: "absolute left-1",
         nav_button_next: "absolute right-1",
         table: "w-full border-collapse space-y-1",
-        head_row: "flex",
+        head_row: "flex justify-center",
         head_cell:
           "text-neutral-500 rounded-md w-8 font-normal text-[0.8rem] dark:text-neutral-400",
-        row: "flex w-full mt-2",
+        row: "flex w-full mt-2 justify-center",
         cell: cn(
           "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-neutral-100 [&:has([aria-selected].day-outside)]:bg-neutral-100/50 [&:has([aria-selected].day-range-end)]:rounded-r-md dark:[&:has([aria-selected])]:bg-neutral-800 dark:[&:has([aria-selected].day-outside)]:bg-neutral-800/50",
           props.mode === "range"
@@ -58,6 +58,7 @@ function Calendar({
         day_range_middle:
           "aria-selected:bg-neutral-100 aria-selected:text-neutral-900 dark:aria-selected:bg-neutral-800 dark:aria-selected:text-neutral-50",
         day_hidden: "invisible",
+        dropdown: "rounded-md border border-neutral-300 bg-white px-3 py-1 text-base mx-1 min-w-[110px] shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/50 transition-all duration-150",
         ...classNames,
       }}
       components={{

--- a/components/ui/date-time-picker.tsx
+++ b/components/ui/date-time-picker.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { CalendarIcon } from "@radix-ui/react-icons";
 import { format } from "date-fns";
+import "react-day-picker/dist/style.css";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -66,6 +67,9 @@ export function DateTimePicker({ date, setDate }: DatetimePickerProps) {
             selected={date}
             onSelect={handleDateSelect}
             initialFocus
+            captionLayout="dropdown"
+            fromYear={1969}
+            toYear={2030}
           />
           <div className="flex flex-col sm:flex-row sm:h-[300px] divide-y sm:divide-y-0 sm:divide-x">
             <ScrollArea className="w-64 sm:w-auto">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The calendar now displays a dropdown for selecting years, with a selectable range from 1969 to 2030.

- **Style**
  - Improved the layout and spacing of the calendar component for better visual alignment.
  - Updated CSS to hide certain text elements for enhanced accessibility and cleaner UI.
  - Ensured consistent styling for the calendar by importing necessary external styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->