### PR TITLE
Artist Timeline- hide button - onClick - refetch feedlist (hide if no…

### DIFF
--- a/components/HorizontalFeed/Feed.tsx
+++ b/components/HorizontalFeed/Feed.tsx
@@ -1,4 +1,5 @@
-import { FC } from "react";
+import { FC, useState } from "react";
+import { motion } from "framer-motion";
 import { Token } from "@/types/token";
 import FeedHover from "./FeedHover";
 import { useClickTimelineFeed } from "@/hooks/useClickTimelineFeed";
@@ -21,17 +22,29 @@ const Feed: FC<FeedProps> = ({ feed, hovered, step, height }) => {
     useClickTimelineFeed(feed);
   const { connectedAddress } = useUserProvider();
   const { artistAddress } = useParams();
+  const [isFadingOut, setIsFadingOut] = useState(false);
+  const [isHidden, setIsHidden] = useState(false);
   const isVisibleHideButton =
     Boolean(artistAddress) &&
     Boolean(
       (artistAddress as any).toLowerCase() === connectedAddress?.toLowerCase()
     );
 
+  if (isHidden) return null;
+
   return (
-    <div
+    <motion.div
       className="relative px-0"
       style={{
         paddingLeft: `${TIMLINE_STEP_OFFSET * step}px`,
+      }}
+      initial={{ opacity: 1 }}
+      animate={{ opacity: isFadingOut ? 0 : 1 }}
+      transition={{ duration: 0.4 }}
+      onAnimationComplete={() => {
+        if (isFadingOut) {
+          setIsHidden(true);
+        }
       }}
     >
       <fieldset className="flex flex-col items-center">
@@ -60,20 +73,19 @@ const Feed: FC<FeedProps> = ({ feed, hovered, step, height }) => {
             </div>
           </div>
         </button>
-        {hovered && (
+        {hovered && isVisibleHideButton && (
           <div className="flex gap-2 items-center relative translate-y-6 pt-2">
             <p className="font-spectral-italic text-sm md:text-xl">
               {truncated(data?.name || "")}
             </p>
-            {isVisibleHideButton && (
-              <HideButton
-                moment={{
-                  owner: connectedAddress as Address,
-                  tokenContract: feed.collection,
-                  tokenId: String(feed.tokenId),
-                }}
-              />
-            )}
+            <HideButton
+              moment={{
+                owner: connectedAddress as Address,
+                tokenContract: feed.collection,
+                tokenId: String(feed.tokenId),
+              }}
+              onClick={() => setIsFadingOut(true)}
+            />
           </div>
         )}
         <p
@@ -82,7 +94,7 @@ const Feed: FC<FeedProps> = ({ feed, hovered, step, height }) => {
           {formattedDate}
         </p>
       </fieldset>
-    </div>
+    </motion.div>
   );
 };
 

--- a/components/HorizontalFeed/HideButton.tsx
+++ b/components/HorizontalFeed/HideButton.tsx
@@ -6,6 +6,7 @@ import { Moment } from "@/hooks/useTimeline";
 interface HideButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
   moment: Moment;
+  onClick?: () => void;
 }
 
 /**
@@ -15,6 +16,7 @@ interface HideButtonProps
 const HideButton: FC<HideButtonProps> = ({
   moment,
   className = "",
+  onClick,
   ...props
 }) => {
   const { hiddenMoments, toggleMoment } = useTimelineProvider();
@@ -31,6 +33,7 @@ const HideButton: FC<HideButtonProps> = ({
       onClick={(e) => {
         e.stopPropagation();
         toggleMoment(moment);
+        onClick?.();
       }}
       {...props}
     >


### PR DESCRIPTION
…w hidden)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a smooth fade-out animation when hiding feed items, enhancing the visual experience.
  - Feed items are now fully removed from view after the fade-out effect completes.

- **Improvements**
  - Hide button is only visible when hovered and when the connected user matches the artist.
  - Hide button actions now support custom behavior when clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->