### PR TITLE
/api/timeline - do not filter if address passed as prop

### DIFF
--- a/app/api/timeline/route.ts
+++ b/app/api/timeline/route.ts
@@ -41,7 +41,7 @@ export async function GET(req: NextRequest) {
       createdAt: row.createdAt,
       username: profiles[i]?.username || "",
     }))
-    .filter((moment) => !!moment.username);
+    .filter((moment) => artist || !!moment.username);
 
   return Response.json({
     status: "success",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering of timeline moments to include all moments when an artist is specified, even if some lack a username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->