### PR TITLE
sweetmantech/myc-2305-invalid-manifest-subtitle-description-primarycategory

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -82,14 +82,20 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Scratchpad
 
-## Current Task: Ready for new task
+## Current Task: Fix Invalid Manifest - Step 73
 
-Status: 🟢 Ready
+Status: 🟢 Complete
 
-Previous task (Update Agent to Use ChatAnthropic) completed with following key outcomes:
+Task completed: Fixed Farcaster manifest validation errors by adding missing required fields:
 
-1. Successfully integrated ChatAnthropic for basic message handling
-2. Implemented proper stream transformation for different message types
-3. Added comprehensive logging for debugging
-4. Fixed model name to use correct version
-5. Improved error handling for tool responses
+### What was done:
+[X] Identified missing manifest fields: subtitle, description, primaryCategory
+[X] Updated `/app/.well-known/farcaster.json/route.ts` with proper values:
+  - subtitle: "Artists own their timeline" (29 chars, within 30 limit)
+  - description: "A living archive where artists document their creative process onchain. Own your evolution, not just your art. Every sketch, verse, sound is permanent." (153 chars, within 170 limit)  
+  - primaryCategory: "art-creativity" (matches project's digital art focus)
+
+### Key insights:
+- Project is "In Process By LATASHÁ" - a digital art timeline platform
+- Manifest follows Farcaster Mini Apps spec with proper field constraints
+- Fields align with project's core mission of artist ownership and creative documentation

--- a/app/.well-known/farcaster.json/route.ts
+++ b/app/.well-known/farcaster.json/route.ts
@@ -20,6 +20,9 @@ export async function GET() {
       splashImageUrl: process.env.NEXT_PUBLIC_SPLASH_IMAGE_URL,
       splashBackgroundColor: `#${process.env.NEXT_PUBLIC_SPLASH_BACKGROUND_COLOR}`,
       webhookUrl: `${URL}/api/webhook`,
+      subtitle: "Artists own their timeline",
+      description: "A living archive where artists document their creative process onchain. Own your evolution, not just your art. Every sketch, verse, sound is permanent.",
+      primaryCategory: "art-creativity",
     },
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added subtitle, description, and primary category information to the Farcaster manifest, enhancing project metadata and compliance with Farcaster Mini Apps requirements.

- **Documentation**
  - Updated the Scratchpad section to reflect the completion of the manifest validation task and documented the new manifest fields and their alignment with project goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->