### PR TITLE
Fix embed code typo

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -85,7 +85,28 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Scratchpad
 
-## Current Task: HideButton - update icon shown based on API response (MYC-2319)
+## Current Task: Fix Typo - "past embed code" → "paste embed code" (MYC-2320)
+
+Status: ✅ Complete ✅
+
+**Requirement**: ✅ COMPLETED
+
+- Fix typo in create/embed interface: "past embed code" should be "paste embed code" ✅
+
+**Problem RESOLVED**:
+
+- Located typo on line 42 in `components/EmbedPage/EmbedPage.tsx`
+- Text said "past embed code" which was confusing for users
+- Should say "paste embed code" which matches the actual functionality
+
+**Implementation Changes COMPLETED**:
+[X] **Updated `EmbedPage.tsx`** (`components/EmbedPage/EmbedPage.tsx`):
+- Changed line 42 from: `<p className="font-archivo-medium text-center">past embed code</p>`
+- To: `<p className="font-archivo-medium text-center">paste embed code</p>`
+
+**Status**: ✅ **TYPO FIX COMPLETE**
+
+## Previous Task: HideButton - update icon shown based on API response (MYC-2319)
 
 Status: ✅ Complete ✅ Implementation Verified
 

--- a/components/EmbedPage/EmbedPage.tsx
+++ b/components/EmbedPage/EmbedPage.tsx
@@ -40,7 +40,7 @@ const EmbedPage = () => {
               height={66}
               className="block md:hidden"
             />
-            <p className="font-archivo-medium text-center">past embed code</p>
+            <p className="font-archivo-medium text-center">paste embed code</p>
           </div>
           <textarea
             className="bg-grey-moss-50 w-full grow !outline-none !ring-0 p-2 font-spectral"


### PR DESCRIPTION
A typo was corrected in the `EmbedPage.tsx` file.

*   The text "past embed code" on line 42 of `components/EmbedPage/EmbedPage.tsx` was updated to "paste embed code".
*   This change clarifies the instruction for users, ensuring the interface accurately reflects the action of pasting embed code into the textarea.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the embed interface text, changing "past embed code" to "paste embed code".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->