### PR TITLE
Add subroutes for USDC feature

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -86,33 +86,42 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Scratchpad
 
-## Current Task: Fix BigInt Serialization Error in /create/usdc (MYC-2323)
+## Current Task: Add USDC Subroutes for /create/usdc (MYC-2324)
 
-Status: ✅ Complete ✅
+Status: ✅ Complete ✅ 
 
-**Requirement**: ✅ COMPLETED
-- Fix BigInt serialization error on `/create/usdc` page when clicking create button ✅
-- Error: "TypeError: Do not know how to serialize a BigInt at JSON.stringify" ✅
-- Need to identify and convert BigInt values to strings before JSON serialization ✅
+**Requirement**: 
+- Add missing USDC subroutes to match existing ETH-based routes at `/create/`
+- Required routes: `/create/usdc/writing`, `/create/usdc/embed`, `/create/usdc/link`
+- Reference existing ETH routes: `/create/writing`, `/create/link`, `/create/embed`
+- Add parity for `/create/usdc` routes with `/create/` existing routes
 
-**Problem RESOLVED**:
-- In `lib/zora/getSalesConfig.tsx` on line 17: `pricePerToken: parseUnits(price, 6)`
-- `parseUnits()` returns a BigInt but it was not converted to string like other fields
-- The `saleStart` and `saleEnd` fields were correctly converted with `.toString()`
-- But `pricePerToken` was left as BigInt, causing JSON.stringify to fail
-- The schema expects `pricePerToken` to be a string
+**Investigation COMPLETED**:
+[X] **Explored existing route structure**: Found `/create/writing`, `/create/link`, `/create/embed` routes
+[X] **Analyzed existing components**: Each route has simple page component that renders corresponding component
+[X] **Discovered USDC detection logic**: System automatically detects USDC mode via `pathname.includes("/usdc")`
+[X] **Confirmed component compatibility**: Existing components work for both ETH and USDC modes based on URL path
+
+**Architecture Understanding**:
+- **Route Pattern**: `/create/[type]/page.tsx` → `[Type]Page` component
+- **USDC Detection**: `useZoraCreateParameters` & `useMetadataValues` check `pathname.includes("/usdc")`
+- **Auto-switching**: Components automatically switch ETH/USDC mode based on URL path
+- **Existing Components**: `WritingPage`, `LinkPage`, `EmbedPage` work for both modes
 
 **Implementation Changes COMPLETED**:
-[X] **Updated `getSalesConfig.tsx`**: Changed `pricePerToken: parseUnits(price, 6)` to `pricePerToken: parseUnits(price, 6).toString()`
-- Now all BigInt values in the USDC sale config are properly converted to strings
-- Matches the pattern used for `saleStart` and `saleEnd` fields
-- Aligns with schema expectation that `pricePerToken` should be a string
+[X] **Create `/create/usdc/writing/`** → directory + `page.tsx` → renders `WritingPage`
+[X] **Create `/create/usdc/link/`** → directory + `page.tsx` → renders `LinkPage`  
+[X] **Create `/create/usdc/embed/`** → directory + `page.tsx` → renders `EmbedPage`
+[X] **Updated Navigation Components**: Modified `DesktopSelect` and `MobileSelect` to handle USDC routes
+[X] **Verified Route Structure**: All USDC subroutes created successfully
 
-**Technical Fix**:
-- **Before**: `pricePerToken: parseUnits(price, 6)` (BigInt - causes JSON.stringify error)
-- **After**: `pricePerToken: parseUnits(price, 6).toString()` (string - serializes correctly)
+**Navigation Updates**:
+- **DesktopSelect**: Added USDC route detection and dynamic base route handling
+- **MobileSelect**: Added USDC route detection and dynamic base route handling  
+- **Active State**: Navigation now correctly shows active state for USDC routes
+- **Context Preservation**: When on USDC routes, navigation stays within USDC context
 
-**Status**: ✅ **BIGINT SERIALIZATION ERROR FIXED**
+**Status**: ✅ **ALL USDC SUBROUTES CREATED AND NAVIGATION UPDATED**
 
 ## Previous Task: Fix Typo - "past embed code" → "paste embed code" (MYC-2320)
 

--- a/app/create/usdc/embed/page.tsx
+++ b/app/create/usdc/embed/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import EmbedPage from "@/components/EmbedPage";
+
+const Embed = () => <EmbedPage />;
+
+export default Embed;

--- a/app/create/usdc/link/page.tsx
+++ b/app/create/usdc/link/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import LinkPage from "@/components/LinkPage";
+
+const Linking = () => <LinkPage />;
+
+export default Linking;

--- a/app/create/usdc/writing/page.tsx
+++ b/app/create/usdc/writing/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import WritingPage from "@/components/WritingPage";
+
+const Writing = () => <WritingPage />;
+
+export default Writing;

--- a/components/CreateModeSelect/DesktopSelect.tsx
+++ b/components/CreateModeSelect/DesktopSelect.tsx
@@ -8,35 +8,37 @@ const DesktopSelect = () => {
   const { push } = useRouter();
   const searchParams = useSearchParams();
   const urlParams = searchParams.toString();
-  const isCreatePage = pathname === "/create";
-  const isWritingPage = pathname === "/create/writing";
-  const isLinkPage = pathname === "/create/link";
-  const isEmbedPage = pathname === "/create/embed";
+  const isUsdc = pathname.includes("/usdc");
+  const baseRoute = isUsdc ? "/create/usdc" : "/create";
+  const isCreatePage = pathname === "/create" || pathname === "/create/usdc";
+  const isWritingPage = pathname === "/create/writing" || pathname === "/create/usdc/writing";
+  const isLinkPage = pathname === "/create/link" || pathname === "/create/usdc/link";
+  const isEmbedPage = pathname === "/create/embed" || pathname === "/create/usdc/embed";
   const urlQuery = urlParams ? `?${urlParams}` : "";
   return (
     <div className="w-full lg:max-w-[250px] xl:max-w-[300px] h-fit">
       <div ref={titleRef} className="flex flex-col gap-3 pb-3">
         <CTAButton
           isActive={isCreatePage}
-          onClick={() => push(`/create${urlQuery}`)}
+          onClick={() => push(`${baseRoute}${urlQuery}`)}
         >
           new moment
         </CTAButton>
         <CTAButton
           isActive={isWritingPage}
-          onClick={() => push(`/create/writing${urlQuery}`)}
+          onClick={() => push(`${baseRoute}/writing${urlQuery}`)}
         >
           new thought
         </CTAButton>
         <CTAButton
           isActive={isLinkPage}
-          onClick={() => push(`/create/link${urlQuery}`)}
+          onClick={() => push(`${baseRoute}/link${urlQuery}`)}
         >
           new link
         </CTAButton>
         <CTAButton
           isActive={isEmbedPage}
-          onClick={() => push(`/create/embed${urlQuery}`)}
+          onClick={() => push(`${baseRoute}/embed${urlQuery}`)}
         >
           new embed
         </CTAButton>

--- a/components/CreateModeSelect/MobileSelect.tsx
+++ b/components/CreateModeSelect/MobileSelect.tsx
@@ -8,11 +8,13 @@ const MobileSelect = () => {
   const [isOpenSelect, setIsOpenSelect] = useState<boolean>(false);
   const { push } = useRouter();
   const pathname = usePathname();
+  const isUsdc = pathname.includes("/usdc");
+  const baseRoute = isUsdc ? "/create/usdc" : "/create";
   const selectedValue = useMemo(() => {
-    if (pathname === "/create") return "moment";
-    if (pathname === "/create/writing") return "thought";
-    if (pathname === "/create/link") return "link";
-    if (pathname === "/create/embed") return "embed";
+    if (pathname === "/create" || pathname === "/create/usdc") return "moment";
+    if (pathname === "/create/writing" || pathname === "/create/usdc/writing") return "thought";
+    if (pathname === "/create/link" || pathname === "/create/usdc/link") return "link";
+    if (pathname === "/create/embed" || pathname === "/create/usdc/embed") return "embed";
   }, [pathname]);
 
   const values = useMemo(() => {
@@ -25,10 +27,9 @@ const MobileSelect = () => {
   }, [selectedValue]);
 
   const handleClick = (value: string) => {
-    const link = "/create";
-    if (value === "moment") push(link);
-    if (value === "thought") push(`${link}/writing`);
-    if (value !== "moment" && value !== "thought") push(`${link}/${value}`);
+    if (value === "moment") push(baseRoute);
+    if (value === "thought") push(`${baseRoute}/writing`);
+    if (value !== "moment" && value !== "thought") push(`${baseRoute}/${value}`);
     setIsOpenSelect(false);
   };
   return (


### PR DESCRIPTION
To achieve parity with existing ETH-based routes, new USDC subroutes were added:

*   New `page.tsx` files were created under `app/create/usdc/`:
    *   `app/create/usdc/writing/page.tsx` now renders the `WritingPage` component.
    *   `app/create/usdc/link/page.tsx` now renders the `LinkPage` component.
    *   `app/create/usdc/embed/page.tsx` now renders the `EmbedPage` component.

Navigation components were updated to correctly handle these new routes:

*   In `components/CreateModeSelect/DesktopSelect.tsx` and `components/CreateModeSelect/MobileSelect.tsx`:
    *   A `isUsdc` flag was introduced, determined by checking if `pathname.includes("/usdc")`.
    *   A `baseRoute` variable was added, dynamically set to `/create/usdc` or `/create` based on `isUsdc`.
    *   Route matching logic was updated to include both ETH and USDC paths for active state detection.
    *   Navigation `onClick` handlers were modified to use the `baseRoute`, ensuring navigation stays within the correct ETH or USDC context.

These changes ensure that the `/create/usdc` routes now have the same functionality and navigation experience as their `/create` counterparts.