### PR TITLE
Add Vercel analytics tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Providers } from "@/providers/Providers";
 import { Toaster } from "@/components/ui/sonner";
 import { Suspense } from "react";
 import Layout from "@/components/Layout";
+import { Analytics } from "@vercel/analytics/react";
 
 export default function RootLayout({
   children,
@@ -19,6 +20,7 @@ export default function RootLayout({
           </Providers>
           <Toaster />
         </Suspense>
+        <Analytics />
       </body>
     </html>
   );

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node-telegram-bot-api": "^0.64.8",
     "@uniswap/sdk-core": "^7.7.2",
     "@uniswap/v3-sdk": "^3.25.2",
+    "@vercel/analytics": "^1.5.0",
     "@vercel/og": "^0.6.5",
     "@xyflow/react": "^12.4.3",
     "@zoralabs/protocol-deployments": "^0.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@uniswap/v3-sdk':
         specifier: ^3.25.2
         version: 3.25.2(hardhat@2.23.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10))
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(next@15.0.3(@babel/core@7.26.10)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       '@vercel/og':
         specifier: ^0.6.5
         version: 0.6.8
@@ -3780,6 +3783,32 @@ packages:
 
   '@vanilla-extract/private@1.0.6':
     resolution: {integrity: sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw==}
+
+  '@vercel/analytics@1.5.0':
+    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/og@0.6.8':
     resolution: {integrity: sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==}
@@ -15496,6 +15525,11 @@ snapshots:
       - babel-plugin-macros
 
   '@vanilla-extract/private@1.0.6': {}
+
+  '@vercel/analytics@1.5.0(next@15.0.3(@babel/core@7.26.10)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+    optionalDependencies:
+      next: 15.0.3(@babel/core@7.26.10)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+      react: 19.0.0-rc-66855b96-20241106
 
   '@vercel/og@0.6.8':
     dependencies:


### PR DESCRIPTION
The `@vercel/analytics` package was installed to enable site analytics tracking.

*   The `package.json` file was updated to include `"@vercel/analytics": "^1.5.0"` as a dependency, and `pnpm-lock.yaml` was updated accordingly.
*   The `app/layout.tsx` file was modified to integrate the analytics component.
    *   `import { Analytics } from "@vercel/analytics/react";` was added.
    *   The `<Analytics />` component was placed within the `<body>` tag of the `RootLayout`.

These changes ensure that page views and user interactions are automatically tracked across the application when deployed to Vercel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated Vercel Analytics to enable application-wide analytics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->