### PR TITLE
Fix missing image field in moments

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -84,62 +84,72 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 - For components that need to update visual state based on API responses, use local state (useState) initialized with prop values and update the state with API response data to ensure UI reflects server state immediately
 - When using parseUnits/parseEther for USDC price handling, always convert BigInt results to strings using .toString() before JSON serialization to prevent "Do not know how to serialize a BigInt" errors
 - When adding new USDC routes that mirror existing ETH routes, check all pathname-dependent logic to ensure both routes are handled - especially in hooks like useCreateMetadata that generate different metadata based on the route path
+- For writing/text-based NFTs, the metadata `image` field should contain a generated text preview thumbnail, not be left empty - use canvas-based text rendering to create preview images and upload them to Arweave for proper metadata population
 
 # Scratchpad
 
-## Current Task: Fix USDC Writing Empty Metadata (MYC-2341)
+## Current Task: Fix Missing Image Field in Writing Metadata (MYC-2342)
 
 Status: ✅ Complete ✅
 
 **Requirement**: 
-- `/create/usdc/writing` route creates moments with empty metadata fields
-- Only `name` (title) is populated correctly
-- Missing `image` and `content` fields that should be populated
-- Need to fix metadata generation for USDC writing route
+- Both `/create/usdc/writing` AND `/create/writing/` routes create moments with empty `image` field
+- All other metadata fields are populated correctly (`name`, `animation_url`, `content`)
+- Need to populate `image` field with preview image (like shown on collection pages)
+- Ticket: https://linear.app/mycowtf/issue/MYC-2342/createusdcwriting-missing-image
 
 **Problem**:
-- Current behavior: USDC writing route produces empty metadata:
+- Current behavior: Writing routes produce empty `image` field:
 ```json
 {
-  "name": "today i tried writing for usdc",
+  "name": "today i am writing for USDC",
   "description": "", 
   "external_url": "",
-  "image": "",
-  "animation_url": "",
+  "image": "",  // ← EMPTY!
+  "animation_url": "ar://gJc_9A-1eU9RJDzM2Y36NcmbOWZhvHiYPwLS_JQIJo0",
   "content": {
-    "mime": "",
-    "uri": ""
+    "mime": "text/plain",
+    "uri": "ar://gJc_9A-1eU9RJDzM2Y36NcmbOWZhvHiYPwLS_JQIJo0"
   }
 }
 ```
-- Expected: Should have populated `image` and `content` fields like regular writing route
+- Expected: Should have populated `image` field like collection pages display
 
-**Investigation Plan**:
-[X] **Explore existing `/create/writing` route**: Understand how metadata is generated
-[X] **Analyze metadata generation logic**: Find where metadata fields are populated
-[X] **Compare ETH vs USDC metadata generation**: Identify differences
-[X] **Locate USDC detection logic**: Understand how USDC mode affects metadata
-[X] **Identify root cause**: Find why USDC writing has empty metadata
-[X] **Implement fix**: Ensure USDC writing generates correct metadata
-[ ] **Test fix**: Verify USDC writing route works correctly
+**Investigation & Root Cause**:
+[X] **Analyzed metadata generation**: `useCreateMetadata.tsx` → `getUri()` function
+[X] **Found issue**: `image: previewUri` but `previewUri` is empty for writing routes
+[X] **Identified solution**: Need to generate text preview image for writing content
+[X] **Found existing logic**: `lib/protocolSdk/ipfs/text-metadata.ts` has `generateTextPreview()`
 
-**Root Cause IDENTIFIED & FIXED**:
-- **Issue**: `useCreateMetadata.tsx` → `getUri()` function (lines 57-63)
-- **Problem**: Pathname conditions only checked ETH routes:
-  - `if (pathname === "/create/writing")` - missing USDC route
-  - `if (pathname === "/create/embed")` - missing USDC route
-- **Impact**: USDC routes never got proper metadata handling → empty `mime`, `animation_url`, and `content` fields
+**Root Cause IDENTIFIED**:
+- **Issue**: `useCreateMetadata.tsx` → `getUri()` function (line 66)
+- **Problem**: `image: previewUri` but `previewUri` is never set for writing routes
+- **Impact**: Both ETH and USDC writing routes have empty `image` field
 
 **Fix IMPLEMENTED**:
-- **Updated `hooks/useCreateMetadata.tsx`** (lines 57-63):
-  - Line 57: `if (pathname === "/create/writing" || pathname === "/create/usdc/writing")`
-  - Line 61: `if (pathname === "/create/embed" || pathname === "/create/usdc/embed")`
-- **Result**: Both ETH and USDC routes now get proper metadata handling
+[X] **Updated `hooks/useWriting.ts`**:
+- Added `generateTextPreview()` function (adapted from `text-metadata.ts`)
+- Added `generateAndUploadPreview()` method to generate and upload text preview image
+- Added `previewImageUri` state to track generated preview
+- Modified `write()` to clear preview when text changes
+
+[X] **Updated `hooks/useCreateMetadata.tsx`**:
+- Modified `getUri()` function to generate text preview for writing routes
+- Added `let image = previewUri` variable to track image URL
+- For writing routes: `image = await writinig.generateAndUploadPreview()`
+- Changed `image: previewUri` to `image: image` to use the generated preview
+
+**Technical Solution**:
+1. **Text Preview Generation**: Canvas-based preview (500x500px) with text wrapped and styled
+2. **Upload to Arweave**: Preview image uploaded and URI returned
+3. **Metadata Population**: `image` field now populated with preview URI
+4. **Route Coverage**: Both `/create/writing` and `/create/usdc/writing` routes fixed
 
 **Technical Impact**:
-- **USDC Writing**: Now generates `mime: "text/plain"`, proper `animation_url`, and correct `content.uri`
-- **USDC Embed**: Now generates `mime: "text/html"`, proper `animation_url`, and correct `content.uri`
-- **Backwards Compatibility**: ETH routes continue to work as before
+- **Both Writing Routes**: Now generate proper text preview images
+- **Image Field**: Fully populated with Arweave URI of generated preview
+- **Collection Pages**: Will now display preview images correctly
+- **Backwards Compatibility**: Other routes (link, embed, file upload) unaffected
 
 **Status**: ✅ **TASK COMPLETE - READY FOR TESTING**
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -140,7 +140,11 @@ Status: ✅ Complete ✅
 - Changed `image: previewUri` to `image: image` to use the generated preview
 
 **Technical Solution**:
-1. **Text Preview Generation**: Canvas-based preview (500x500px) with text wrapped and styled
+1. **Text Preview Generation**: Canvas-based preview (500x333px) matching production OG route styling
+   - Background: `#E0DDD8` (beige/tan, same as production)
+   - Font: Spectral (same as production OG route)
+   - Dynamic sizing: 32px for short text (≤3 lines), 16px for longer text
+   - Layout: 32px padding, centered alignment for short text, top alignment for longer text
 2. **Upload to Arweave**: Preview image uploaded and URI returned
 3. **Metadata Population**: `image` field now populated with preview URI
 4. **Route Coverage**: Both `/create/writing` and `/create/usdc/writing` routes fixed

--- a/.cursorrules
+++ b/.cursorrules
@@ -85,6 +85,7 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 - When using parseUnits/parseEther for USDC price handling, always convert BigInt results to strings using .toString() before JSON serialization to prevent "Do not know how to serialize a BigInt" errors
 - When adding new USDC routes that mirror existing ETH routes, check all pathname-dependent logic to ensure both routes are handled - especially in hooks like useCreateMetadata that generate different metadata based on the route path
 - For writing/text-based NFTs, the metadata `image` field should contain a generated text preview thumbnail, not be left empty - use canvas-based text rendering to create preview images and upload them to Arweave for proper metadata population
+- When functions grow complex within hooks, extract them into standalone lib files following Single Responsibility Principle - hooks should focus on state management while lib functions handle business logic
 
 # Scratchpad
 
@@ -127,11 +128,21 @@ Status: ✅ Complete ✅
 - **Impact**: Both ETH and USDC writing routes have empty `image` field
 
 **Fix IMPLEMENTED**:
+[X] **Created `lib/writing/generateTextPreview.ts`**:
+- Standalone function for generating text preview images
+- Matches production OG route styling exactly
+- Extracted from useWriting hook following SRP
+
+[X] **Created `lib/writing/generateAndUploadPreview.ts`**:
+- Standalone function for generating and uploading previews to Arweave
+- Imports generateTextPreview function
+- Handles error logging and empty text cases
+
 [X] **Updated `hooks/useWriting.ts`**:
-- Added `generateTextPreview()` function (adapted from `text-metadata.ts`)
-- Added `generateAndUploadPreview()` method to generate and upload text preview image
-- Added `previewImageUri` state to track generated preview
-- Modified `write()` to clear preview when text changes
+- Removed local function definitions (following SRP)
+- Imports generateAndUploadPreview from lib folder
+- Added wrapper function to maintain state management
+- Cleaned up to focus only on writing-specific state management
 
 [X] **Updated `hooks/useCreateMetadata.tsx`**:
 - Modified `getUri()` function to generate text preview for writing routes

--- a/.cursorrules
+++ b/.cursorrules
@@ -87,6 +87,7 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 - For writing/text-based NFTs, the metadata `image` field should contain a generated text preview thumbnail, not be left empty - use canvas-based text rendering to create preview images and upload them to Arweave for proper metadata population
 - When functions grow complex within hooks, extract them into standalone lib files following Single Responsibility Principle - hooks should focus on state management while lib functions handle business logic
 - Follow YAGNI (You Ain't Gonna Need It) - remove unused state variables, exports, and code even if they might be "useful later" - keep only what's actually being used
+- Avoid unnecessary indirection - import functions directly where they're used rather than importing into intermediate hooks just to re-export them
 
 # Scratchpad
 
@@ -139,18 +140,17 @@ Status: ✅ Complete ✅
 - Imports generateTextPreview function
 - Handles error logging and empty text cases
 
-[X] **Updated `hooks/useWriting.ts`**:
-- Removed local function definitions (following SRP)
-- Imports generateAndUploadPreview from lib folder
-- Added wrapper function to maintain state management
-- Cleaned up to focus only on writing-specific state management
-- Removed unused previewImageUri state (following YAGNI)
+[X] **Reverted `hooks/useWriting.ts`**:
+- Removed all changes to keep it focused only on writing state management
+- No unnecessary imports or wrapper functions
+- Clean, minimal hook with single responsibility
 
 [X] **Updated `hooks/useCreateMetadata.tsx`**:
+- Added direct import: `import { generateAndUploadPreview } from "@/lib/writing/generateAndUploadPreview"`
 - Modified `getUri()` function to generate text preview for writing routes
 - Added `let image = previewUri` variable to track image URL
-- For writing routes: `image = await writinig.generateAndUploadPreview()`
-- Changed `image: previewUri` to `image: image` to use the generated preview
+- For writing routes: `image = await generateAndUploadPreview(writinig.writingText)`
+- Direct function call without unnecessary indirection
 
 **Technical Solution**:
 1. **Text Preview Generation**: Canvas-based preview (500x333px) matching production OG route styling

--- a/.cursorrules
+++ b/.cursorrules
@@ -86,6 +86,7 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 - When adding new USDC routes that mirror existing ETH routes, check all pathname-dependent logic to ensure both routes are handled - especially in hooks like useCreateMetadata that generate different metadata based on the route path
 - For writing/text-based NFTs, the metadata `image` field should contain a generated text preview thumbnail, not be left empty - use canvas-based text rendering to create preview images and upload them to Arweave for proper metadata population
 - When functions grow complex within hooks, extract them into standalone lib files following Single Responsibility Principle - hooks should focus on state management while lib functions handle business logic
+- Follow YAGNI (You Ain't Gonna Need It) - remove unused state variables, exports, and code even if they might be "useful later" - keep only what's actually being used
 
 # Scratchpad
 
@@ -143,6 +144,7 @@ Status: ✅ Complete ✅
 - Imports generateAndUploadPreview from lib folder
 - Added wrapper function to maintain state management
 - Cleaned up to focus only on writing-specific state management
+- Removed unused previewImageUri state (following YAGNI)
 
 [X] **Updated `hooks/useCreateMetadata.tsx`**:
 - Modified `getUri()` function to generate text preview for writing routes

--- a/hooks/useCreateMetadata.tsx
+++ b/hooks/useCreateMetadata.tsx
@@ -59,9 +59,12 @@ const useCreateMetadata = () => {
   const getUri = async () => {
     let mime = mimeType;
     let animation = animationUri || imageUri;
+    let image = previewUri;
+    
     if (pathname === "/create/writing" || pathname === "/create/usdc/writing") {
       mime = "text/plain";
       animation = await writinig.uploadWriting();
+      image = await writinig.generateAndUploadPreview();
     }
     if (pathname === "/create/embed" || pathname === "/create/usdc/embed") {
       mime = "text/html";
@@ -72,7 +75,7 @@ const useCreateMetadata = () => {
       name,
       description,
       external_url: link.link,
-      image: previewUri,
+      image: image,
       animation_url: animation,
       content: {
         mime,

--- a/hooks/useCreateMetadata.tsx
+++ b/hooks/useCreateMetadata.tsx
@@ -4,6 +4,7 @@ import useLinkPreview from "./useLinkPreview";
 import useEmbedCode from "./useEmbedCode";
 import useWriting from "./useWriting";
 import useMetadataValues from "./useMetadataValues";
+import { generateAndUploadPreview } from "@/lib/writing/generateAndUploadPreview";
 import { usePathname } from "next/navigation";
 
 const useCreateMetadata = () => {
@@ -64,7 +65,7 @@ const useCreateMetadata = () => {
     if (pathname === "/create/writing" || pathname === "/create/usdc/writing") {
       mime = "text/plain";
       animation = await writinig.uploadWriting();
-      image = await writinig.generateAndUploadPreview();
+      image = await generateAndUploadPreview(writinig.writingText);
     }
     if (pathname === "/create/embed" || pathname === "/create/usdc/embed") {
       mime = "text/html";

--- a/hooks/useWriting.ts
+++ b/hooks/useWriting.ts
@@ -4,7 +4,6 @@ import { useState } from "react";
 
 const useWriting = () => {
   const [writingText, setWritingText] = useState<string>("");
-  const [previewImageUri, setPreviewImageUri] = useState<string>("");
 
   const uploadWriting = async () => {
     const blob = new Blob([writingText], { type: "text/plain" });
@@ -15,14 +14,11 @@ const useWriting = () => {
 
   const generateAndUploadPreviewWrapper = async () => {
     const previewUri = await generateAndUploadPreview(writingText);
-    setPreviewImageUri(previewUri);
     return previewUri;
   };
 
   const write = (value: string) => {
     setWritingText(value);
-    // Clear preview when text changes
-    setPreviewImageUri("");
   };
 
   return {
@@ -31,7 +27,6 @@ const useWriting = () => {
     write,
     uploadWriting,
     generateAndUploadPreview: generateAndUploadPreviewWrapper,
-    previewImageUri,
   };
 };
 

--- a/hooks/useWriting.ts
+++ b/hooks/useWriting.ts
@@ -14,7 +14,6 @@ const useWriting = () => {
   const write = (value: string) => {
     setWritingText(value);
   };
-
   return {
     writingText,
     setWritingText,

--- a/hooks/useWriting.ts
+++ b/hooks/useWriting.ts
@@ -1,5 +1,4 @@
 import clientUploadToArweave from "@/lib/arweave/clientUploadToArweave";
-import { generateAndUploadPreview } from "@/lib/writing/generateAndUploadPreview";
 import { useState } from "react";
 
 const useWriting = () => {
@@ -12,11 +11,6 @@ const useWriting = () => {
     return uri;
   };
 
-  const generateAndUploadPreviewWrapper = async () => {
-    const previewUri = await generateAndUploadPreview(writingText);
-    return previewUri;
-  };
-
   const write = (value: string) => {
     setWritingText(value);
   };
@@ -26,7 +20,6 @@ const useWriting = () => {
     setWritingText,
     write,
     uploadWriting,
-    generateAndUploadPreview: generateAndUploadPreviewWrapper,
   };
 };
 

--- a/hooks/useWriting.ts
+++ b/hooks/useWriting.ts
@@ -1,8 +1,99 @@
 import clientUploadToArweave from "@/lib/arweave/clientUploadToArweave";
 import { useState } from "react";
 
+// Text preview generation function (adapted from text-metadata.ts)
+const generateTextPreview = async (text: string): Promise<File> => {
+  const CHAR_LIMIT = 1111;
+  const trimmedText = text.trim().slice(0, CHAR_LIMIT);
+
+  const [width, height] = [500, 500];
+  const padding = 20;
+  const dpr = 2;
+
+  const fontFamily = "Inter";
+  const [fontSize, lineHeight] = [16, 24];
+  const [textColor, backgroundColor] = ["black", "white"];
+
+  const wrapText = ({
+    ctx,
+    text,
+    x,
+    y,
+    maxWidth,
+    lineHeight,
+  }: {
+    ctx: CanvasRenderingContext2D;
+    text: string;
+    x: number;
+    y: number;
+    maxWidth: number;
+    lineHeight: number;
+  }) => {
+    let words = text.replaceAll("\n", " \n ").split(/ +/);
+    let line = "";
+    let testLine = "";
+    const lineArray = [];
+
+    for (let n = 0; n < words.length; n++) {
+      testLine += `${words[n]} `;
+      const metrics = ctx.measureText(testLine);
+      const testWidth = metrics.width;
+      
+      if (words[n]?.includes("\n") || (testWidth > maxWidth && n > 0)) {
+        lineArray.push({ text: line, x, y });
+        y += lineHeight;
+        
+        if (words[n]?.includes("\n")) {
+          line = ``;
+          testLine = ``;
+        } else {
+          line = `${words[n]} `;
+          testLine = `${words[n]} `;
+        }
+      } else {
+        line += `${words[n]} `;
+      }
+      
+      if (n === words.length - 1) {
+        lineArray.push({ text: line, x, y });
+      }
+    }
+    return lineArray;
+  };
+
+  return new Promise((resolve, reject) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return reject(new Error("Could not create canvas context"));
+    }
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, width * dpr, height * dpr);
+    ctx.fillStyle = textColor;
+    ctx.font = `${fontSize * dpr}px ${fontFamily}`;
+    const wrapped = wrapText({
+      ctx,
+      text: trimmedText,
+      x: padding * dpr,
+      y: fontSize * dpr + padding * dpr,
+      maxWidth: width * dpr - padding * 2 * dpr,
+      lineHeight: lineHeight * dpr,
+    });
+    wrapped.forEach((line) => ctx.fillText(line.text, line.x, line.y));
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        return reject(new Error("Could not create blob"));
+      }
+      resolve(new File([blob], "text-preview.png", { type: "image/png" }));
+    });
+  });
+};
+
 const useWriting = () => {
   const [writingText, setWritingText] = useState<string>("");
+  const [previewImageUri, setPreviewImageUri] = useState<string>("");
 
   const uploadWriting = async () => {
     const blob = new Blob([writingText], { type: "text/plain" });
@@ -11,14 +102,33 @@ const useWriting = () => {
     return uri;
   };
 
+  const generateAndUploadPreview = async () => {
+    if (!writingText.trim()) return "";
+    
+    try {
+      const previewFile = await generateTextPreview(writingText);
+      const previewUri = await clientUploadToArweave(previewFile);
+      setPreviewImageUri(previewUri);
+      return previewUri;
+    } catch (error) {
+      console.error("Failed to generate text preview:", error);
+      return "";
+    }
+  };
+
   const write = (value: string) => {
     setWritingText(value);
+    // Clear preview when text changes
+    setPreviewImageUri("");
   };
+
   return {
     writingText,
     setWritingText,
     write,
     uploadWriting,
+    generateAndUploadPreview,
+    previewImageUri,
   };
 };
 

--- a/hooks/useWriting.ts
+++ b/hooks/useWriting.ts
@@ -1,106 +1,6 @@
 import clientUploadToArweave from "@/lib/arweave/clientUploadToArweave";
+import { generateAndUploadPreview } from "@/lib/writing/generateAndUploadPreview";
 import { useState } from "react";
-
-// Text preview generation function (matching production OG route styling)
-const generateTextPreview = async (text: string): Promise<File> => {
-  const trimmedText = text.trim();
-
-  // Use same dimensions as OG route
-  const width = 500;
-  const height = 333;
-  const padding = 32;
-  const dpr = 2;
-
-  // Calculate total lines using same logic as OG route
-  const paragraphs = trimmedText.split("\n");
-  let totalLines = 0;
-  paragraphs.forEach((paragraph) => {
-    totalLines += Math.max(1, parseInt(Number(paragraph.length / 64).toFixed()) + 1);
-  });
-
-  // Dynamic font size based on line count (same logic as OG route)
-  const WRITING_SHORT_LINES = 3;
-  const fontSize = totalLines <= WRITING_SHORT_LINES ? 32 : 16;
-  const lineHeight = fontSize * 1.2; // Reasonable line height
-
-  // Production colors and fonts
-  const backgroundColor = "#E0DDD8"; // Same beige/tan as production
-  const textColor = "#000000";
-  const fontFamily = "Spectral, serif"; // Same font as production
-
-  return new Promise((resolve, reject) => {
-    const canvas = document.createElement("canvas");
-    canvas.width = width * dpr;
-    canvas.height = height * dpr;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      return reject(new Error("Could not create canvas context"));
-    }
-
-    // Set background to match production
-    ctx.fillStyle = backgroundColor;
-    ctx.fillRect(0, 0, width * dpr, height * dpr);
-
-    // Set text styling to match production
-    ctx.fillStyle = textColor;
-    ctx.font = `${fontSize * dpr}px ${fontFamily}`;
-    ctx.textBaseline = "top";
-
-    // Calculate text placement (matching OG route layout)
-    const textX = padding * dpr;
-    const availableWidth = (width - padding * 2) * dpr;
-    const availableHeight = (height - padding * 2) * dpr;
-
-    // Simple text wrapping that respects newlines
-    const lines: string[] = [];
-    paragraphs.forEach((paragraph) => {
-      if (paragraph === "") {
-        lines.push("");
-        return;
-      }
-      
-      const words = paragraph.split(" ");
-      let currentLine = "";
-      
-      words.forEach((word) => {
-        const testLine = currentLine + (currentLine ? " " : "") + word;
-        const metrics = ctx.measureText(testLine);
-        
-        if (metrics.width > availableWidth && currentLine) {
-          lines.push(currentLine);
-          currentLine = word;
-        } else {
-          currentLine = testLine;
-        }
-      });
-      
-      if (currentLine) {
-        lines.push(currentLine);
-      }
-    });
-
-    // Calculate starting Y position for centering (for short text) or top alignment
-    const totalTextHeight = lines.length * lineHeight * dpr;
-    const startY = totalLines <= WRITING_SHORT_LINES 
-      ? padding * dpr + Math.max(0, (availableHeight - totalTextHeight) / 2)
-      : padding * dpr;
-
-    // Draw text lines
-    lines.forEach((line, index) => {
-      const y = startY + (index * lineHeight * dpr);
-      if (y < height * dpr - padding * dpr) { // Don't draw below bottom padding
-        ctx.fillText(line, textX, y);
-      }
-    });
-
-    canvas.toBlob((blob) => {
-      if (!blob) {
-        return reject(new Error("Could not create blob"));
-      }
-      resolve(new File([blob], "text-preview.png", { type: "image/png" }));
-    });
-  });
-};
 
 const useWriting = () => {
   const [writingText, setWritingText] = useState<string>("");
@@ -113,18 +13,10 @@ const useWriting = () => {
     return uri;
   };
 
-  const generateAndUploadPreview = async () => {
-    if (!writingText.trim()) return "";
-    
-    try {
-      const previewFile = await generateTextPreview(writingText);
-      const previewUri = await clientUploadToArweave(previewFile);
-      setPreviewImageUri(previewUri);
-      return previewUri;
-    } catch (error) {
-      console.error("Failed to generate text preview:", error);
-      return "";
-    }
+  const generateAndUploadPreviewWrapper = async () => {
+    const previewUri = await generateAndUploadPreview(writingText);
+    setPreviewImageUri(previewUri);
+    return previewUri;
   };
 
   const write = (value: string) => {
@@ -138,7 +30,7 @@ const useWriting = () => {
     setWritingText,
     write,
     uploadWriting,
-    generateAndUploadPreview,
+    generateAndUploadPreview: generateAndUploadPreviewWrapper,
     previewImageUri,
   };
 };

--- a/lib/writing/generateAndUploadPreview.ts
+++ b/lib/writing/generateAndUploadPreview.ts
@@ -1,0 +1,15 @@
+import clientUploadToArweave from "@/lib/arweave/clientUploadToArweave";
+import { generateTextPreview } from "./generateTextPreview";
+
+export const generateAndUploadPreview = async (writingText: string): Promise<string> => {
+  if (!writingText.trim()) return "";
+  
+  try {
+    const previewFile = await generateTextPreview(writingText);
+    const previewUri = await clientUploadToArweave(previewFile);
+    return previewUri;
+  } catch (error) {
+    console.error("Failed to generate text preview:", error);
+    return "";
+  }
+};

--- a/lib/writing/generateTextPreview.ts
+++ b/lib/writing/generateTextPreview.ts
@@ -1,0 +1,100 @@
+// Text preview generation function (matching production OG route styling)
+export const generateTextPreview = async (text: string): Promise<File> => {
+  const trimmedText = text.trim();
+
+  // Use same dimensions as OG route
+  const width = 500;
+  const height = 333;
+  const padding = 32;
+  const dpr = 2;
+
+  // Calculate total lines using same logic as OG route
+  const paragraphs = trimmedText.split("\n");
+  let totalLines = 0;
+  paragraphs.forEach((paragraph) => {
+    totalLines += Math.max(1, parseInt(Number(paragraph.length / 64).toFixed()) + 1);
+  });
+
+  // Dynamic font size based on line count (same logic as OG route)
+  const WRITING_SHORT_LINES = 3;
+  const fontSize = totalLines <= WRITING_SHORT_LINES ? 32 : 16;
+  const lineHeight = fontSize * 1.2; // Reasonable line height
+
+  // Production colors and fonts
+  const backgroundColor = "#E0DDD8"; // Same beige/tan as production
+  const textColor = "#000000";
+  const fontFamily = "Spectral, serif"; // Same font as production
+
+  return new Promise((resolve, reject) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return reject(new Error("Could not create canvas context"));
+    }
+
+    // Set background to match production
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, width * dpr, height * dpr);
+
+    // Set text styling to match production
+    ctx.fillStyle = textColor;
+    ctx.font = `${fontSize * dpr}px ${fontFamily}`;
+    ctx.textBaseline = "top";
+
+    // Calculate text placement (matching OG route layout)
+    const textX = padding * dpr;
+    const availableWidth = (width - padding * 2) * dpr;
+    const availableHeight = (height - padding * 2) * dpr;
+
+    // Simple text wrapping that respects newlines
+    const lines: string[] = [];
+    paragraphs.forEach((paragraph) => {
+      if (paragraph === "") {
+        lines.push("");
+        return;
+      }
+      
+      const words = paragraph.split(" ");
+      let currentLine = "";
+      
+      words.forEach((word) => {
+        const testLine = currentLine + (currentLine ? " " : "") + word;
+        const metrics = ctx.measureText(testLine);
+        
+        if (metrics.width > availableWidth && currentLine) {
+          lines.push(currentLine);
+          currentLine = word;
+        } else {
+          currentLine = testLine;
+        }
+      });
+      
+      if (currentLine) {
+        lines.push(currentLine);
+      }
+    });
+
+    // Calculate starting Y position for centering (for short text) or top alignment
+    const totalTextHeight = lines.length * lineHeight * dpr;
+    const startY = totalLines <= WRITING_SHORT_LINES 
+      ? padding * dpr + Math.max(0, (availableHeight - totalTextHeight) / 2)
+      : padding * dpr;
+
+    // Draw text lines
+    lines.forEach((line, index) => {
+      const y = startY + (index * lineHeight * dpr);
+      if (y < height * dpr - padding * dpr) { // Don't draw below bottom padding
+        ctx.fillText(line, textX, y);
+      }
+    });
+
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        return reject(new Error("Could not create blob"));
+      }
+      resolve(new File([blob], "text-preview.png", { type: "image/png" }));
+    });
+  });
+};


### PR DESCRIPTION
The `image` field in metadata for writing routes (`/create/usdc/writing`, `/create/writing/`) was empty because `previewUri` was not generated for text content.

To resolve this:
*   In `hooks/useWriting.ts`:
    *   A `generateTextPreview` function was added, using canvas to render text into a 500x500px image.
    *   A `generateAndUploadPreview` method was introduced to create this image and upload it to Arweave, returning its URI.
    *   `previewImageUri` state was added, cleared when `writingText` changes.
*   In `hooks/useCreateMetadata.tsx`:
    *   The `getUri` function was modified to call `writing.generateAndUploadPreview()` for writing routes.
    *   The `image` field in the generated metadata now uses the URI returned from this new function.

This ensures the `image` field is populated with a visual preview of the written content, improving metadata completeness and display on collection pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed missing preview images for writing NFTs, ensuring that collection pages now display generated text preview images for both ETH and USDC writing routes.

- **New Features**
	- Automatically generates and uploads a styled text preview image for writing NFTs, which is included in the NFT metadata and shown in relevant previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->