### PR TITLE
Update manifesto page with new content

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -87,7 +87,32 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Scratchpad
 
-## Current Task: Fix USDC Writing Empty Metadata (MYC-2341)
+## Current Task: Manifesto Page Update (MYC-2343)
+
+Status: ✅ Complete ✅
+
+**Requirement**: 
+- Update `/manifesto` page with new format and content
+- Replace existing manifesto text with new version
+- Maintain proper formatting with bold and italic styling
+
+**Implementation Changes COMPLETED**:
+[X] **Updated `ManifestoPage.tsx`** (`components/ManifestoPage/ManifestoPage.tsx`):
+- Updated title to bold: `<strong>in process: a manifesto</strong>`
+- Updated subtitle with bold italic: `<em><strong>THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.</strong></em>`
+- Replaced entire manifesto text with new content
+- Applied proper formatting: `<strong>` for bold, `<em><strong>` for bold italic
+- Fixed JSX structure to avoid linter errors by separating template literals and JSX elements
+- Updated final line: `<em><strong>ALWAYS IN PROCESS.</strong></em>`
+
+**Technical Changes**:
+- Changed from `<pre>` to `<div>` with `whitespace-pre-line` for better JSX compatibility
+- Properly structured mixed JSX/template literal content to avoid TypeScript errors
+- Maintained responsive design and existing visual styling
+
+**Status**: ✅ **MANIFESTO UPDATE COMPLETE**
+
+## Previous Task: Fix USDC Writing Empty Metadata (MYC-2341)
 
 Status: ✅ Complete ✅
 

--- a/components/ManifestoPage/ManifestoPage.tsx
+++ b/components/ManifestoPage/ManifestoPage.tsx
@@ -21,42 +21,56 @@ const ManifestoPage = () => {
       <div className="relative w-full md:w-2/4 flex justify-center text-grey-moss-900">
         <div className="w-fit relative">
           <p className="font-archivo text-2xl md:text-5xl tracking-[-1px] relative z-[2]">
-            in process: a manifesto
+            <strong>in process: a manifesto</strong>
           </p>
           <p className="font-spectral-italic pt-6 relative z-[2]">
-            THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.
+            <em><strong>THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.</strong></em>
           </p>
-          <pre className="font-spectral text-[11px] md:text-[16px] tracking-[-1px] pt-4 relative z-[2]">
-            {`They told us the artist needed the platform.
+          <div className="font-spectral text-[11px] md:text-[16px] tracking-[-1px] pt-4 relative z-[2] whitespace-pre-line">
+            <div>
+              {`They told us the artist needed the platform.
 Like we were guests at a table built from our own bones.
 Like visibility was a favor, not a debt.
-Like without them, we would vanish—scattered notes, lost rhythms, blueprints
-erased before they were ever built.
+Like without them, we would vanish—scattered notes, lost rhythms, blueprints erased before they were ever built.
 
-They lied.
+`}
+              <strong>They lied.</strong>
+              {`
 
 Platforms have always needed us.
-The algorithm starves without our stories.
+
+`}
+              <em><strong>The algorithm starves without our stories.</strong></em>
+              {`
 The stream is silent without our sound.
 The feed is nothing but a blinking cursor, waiting on us to move.
 Yet they hold the archive hostage.
 Rewrite history in real time.
-Bury what doesn’t fit their metrics.
+Bury what doesn't fit their metrics.
 And call it discovery.
+
 We refuse.
 
-This is a space for process. For lineage. For the drafts that built dynasties.
+`}
+              <em><strong>In Process is a space for process. For lineage. For the drafts that built dynasties.</strong></em>
+              {`
 For the blueprints they stole, repackaged, and resold.
 For the histories that deserve permanence, not expiration dates.
 
-In Process is not content—it’s record-keeping. It’s proof. It’s legacy.
+`}
+              <em><strong>In Process is not content—it's record-keeping. It's proof. It's legacy.</strong></em>
+              {`
+
 This is where the work lives.
 Where artists own their evolution.
 Where every sketch, verse, sound, and glitch is a timestamp in culture.
 Here, we own the timeline.
 Here, we document in real time, onchain, on our terms.`}
-          </pre>
-          <p className="font-spectral-bold pt-4 text-xl">ALWAYS IN PROCESS.</p>
+            </div>
+          </div>
+          <p className="font-spectral-bold pt-4 text-xl">
+            <em><strong>ALWAYS IN PROCESS.</strong></em>
+          </p>
           <div
             className="md:absolute md:bottom-0 md:translate-x-0 md:translate-y-3/4 md:right-0
           relative translate-x-1/2 -translate-y-1/3"


### PR DESCRIPTION
The `/manifesto` page was updated by modifying `components/ManifestoPage/ManifestoPage.tsx`.

*   The title was updated to `<strong>in process: a manifesto</strong>`.
*   The subtitle was changed to `<em><strong>THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.</strong></em>`.
*   The entire main manifesto text was replaced with the new content, applying `<strong>` for bold and `<em><strong>` for bold italic formatting as specified.
*   The `<pre>` tag containing the main text was replaced with a `<div>` element, and `whitespace-pre-line` styling was applied. This change was implemented to resolve linter errors and ensure correct rendering when mixing JSX elements within template literals.
*   The content within the main text was restructured to properly separate string literals and JSX elements, addressing the linter issues and improving code compatibility.
*   The final statement was updated to `<em><strong>ALWAYS IN PROCESS.</strong></em>`.

The `.cursorrules` scratchpad was also updated to reflect the completion of the task and detail the changes made.