### PR TITLE
Update Manifesto page formatting

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -91,84 +91,45 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Scratchpad
 
-## Current Task: Fix Missing Image Field in Writing Metadata (MYC-2342)
+## Current Task: Update Manifesto Page with New Content and Formatting (MYC-2343)
 
 Status: ✅ Complete ✅
 
 **Requirement**: 
-- Both `/create/usdc/writing` AND `/create/writing/` routes create moments with empty `image` field
-- All other metadata fields are populated correctly (`name`, `animation_url`, `content`)
-- Need to populate `image` field with preview image (like shown on collection pages)
-- Ticket: https://linear.app/mycowtf/issue/MYC-2342/createusdcwriting-missing-image
+- Update `/manifesto` page with new manifesto content
+- Fix bolding and capitalization according to provided format
+- Reference: Google Doc (content provided in task)
+- Only modify bolding and capitalization formatting
+- Ticket: https://linear.app/mycowtf/issue/MYC-2343/manifesto-page-updat
 
-**Problem**:
-- Current behavior: Writing routes produce empty `image` field:
-```json
-{
-  "name": "today i am writing for USDC",
-  "description": "", 
-  "external_url": "",
-  "image": "",  // ← EMPTY!
-  "animation_url": "ar://gJc_9A-1eU9RJDzM2Y36NcmbOWZhvHiYPwLS_JQIJo0",
-  "content": {
-    "mime": "text/plain",
-    "uri": "ar://gJc_9A-1eU9RJDzM2Y36NcmbOWZhvHiYPwLS_JQIJo0"
-  }
-}
-```
-- Expected: Should have populated `image` field like collection pages display
+**Implementation COMPLETED**:
+[X] **Updated title**: "in process: a manifesto" → `<strong>IN PROCESS: A MANIFESTO</strong>` (bold)
+[X] **Updated subtitle**: Added bold+italic formatting: `<em><strong>THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.</strong></em>`
+[X] **Replaced entire content**: Updated `<pre>` → `<div>` with new manifesto text and proper formatting
+[X] **Converted markdown to JSX**:
+  - `*text*` → `<strong>text</strong>` (bold)
+  - `_*text*_` → `<em><strong>text</strong></em>` (bold italic)
+[X] **Updated final tagline**: `<em><strong>ALWAYS IN PROCESS.</strong></em>` (bold italic)
 
-**Investigation & Root Cause**:
-[X] **Analyzed metadata generation**: `useCreateMetadata.tsx` → `getUri()` function
-[X] **Found issue**: `image: previewUri` but `previewUri` is empty for writing routes
-[X] **Identified solution**: Need to generate text preview image for writing content
-[X] **Found existing logic**: `lib/protocolSdk/ipfs/text-metadata.ts` has `generateTextPreview()`
+**Changes Made**:
+- **Title**: Now properly bolded with `<strong>` tags
+- **Subtitle**: Now bold+italic with `<em><strong>` tags
+- **Main Content**: Replaced with new manifesto text including:
+  - "**They lied.**" (bold)
+  - "***The algorithm starves without our stories.***" (bold italic)
+  - "***In Process is a space for process. For lineage. For the drafts that built dynasties.***" (bold italic)
+  - "***In Process is not content—it's record-keeping. It's proof. It's legacy.***" (bold italic)
+- **Final Line**: "***ALWAYS IN PROCESS.***" (bold italic)
 
-**Root Cause IDENTIFIED**:
-- **Issue**: `useCreateMetadata.tsx` → `getUri()` function (line 66)
-- **Problem**: `image: previewUri` but `previewUri` is never set for writing routes
-- **Impact**: Both ETH and USDC writing routes have empty `image` field
+**Technical Details**:
+- Changed `<pre>` to `<div>` with `whitespace-pre-line` class to maintain formatting while allowing JSX elements
+- Used template literals with embedded JSX for proper bold/italic formatting
+- Maintained all existing styling classes and layout structure
+- Preserved mobile responsiveness and design elements
 
-**Fix IMPLEMENTED**:
-[X] **Created `lib/writing/generateTextPreview.ts`**:
-- Standalone function for generating text preview images
-- Matches production OG route styling exactly
-- Extracted from useWriting hook following SRP
+**Status**: ✅ **MANIFESTO UPDATE COMPLETE**
 
-[X] **Created `lib/writing/generateAndUploadPreview.ts`**:
-- Standalone function for generating and uploading previews to Arweave
-- Imports generateTextPreview function
-- Handles error logging and empty text cases
-
-[X] **Reverted `hooks/useWriting.ts`**:
-- Removed all changes to keep it focused only on writing state management
-- No unnecessary imports or wrapper functions
-- Clean, minimal hook with single responsibility
-
-[X] **Updated `hooks/useCreateMetadata.tsx`**:
-- Added direct import: `import { generateAndUploadPreview } from "@/lib/writing/generateAndUploadPreview"`
-- Modified `getUri()` function to generate text preview for writing routes
-- Added `let image = previewUri` variable to track image URL
-- For writing routes: `image = await generateAndUploadPreview(writinig.writingText)`
-- Direct function call without unnecessary indirection
-
-**Technical Solution**:
-1. **Text Preview Generation**: Canvas-based preview (500x333px) matching production OG route styling
-   - Background: `#E0DDD8` (beige/tan, same as production)
-   - Font: Spectral (same as production OG route)
-   - Dynamic sizing: 32px for short text (≤3 lines), 16px for longer text
-   - Layout: 32px padding, centered alignment for short text, top alignment for longer text
-2. **Upload to Arweave**: Preview image uploaded and URI returned
-3. **Metadata Population**: `image` field now populated with preview URI
-4. **Route Coverage**: Both `/create/writing` and `/create/usdc/writing` routes fixed
-
-**Technical Impact**:
-- **Both Writing Routes**: Now generate proper text preview images
-- **Image Field**: Fully populated with Arweave URI of generated preview
-- **Collection Pages**: Will now display preview images correctly
-- **Backwards Compatibility**: Other routes (link, embed, file upload) unaffected
-
-**Status**: ✅ **TASK COMPLETE - READY FOR TESTING**
+Note: Some TypeScript linter warnings appear but are configuration-related, not syntax errors. The JSX is valid and functional.
 
 ## Previous Task: Add USDC Subroutes for /create/usdc (MYC-2324)
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -129,7 +129,13 @@ Status: ✅ Complete ✅
 
 **Status**: ✅ **MANIFESTO UPDATE COMPLETE**
 
-Note: Some TypeScript linter warnings appear but are configuration-related, not syntax errors. The JSX is valid and functional.
+**Build Errors FIXED**:
+[X] **Fixed ESLint errors**: Replaced unescaped apostrophes with HTML entities (`&rsquo;`)
+- "doesn't" → "doesn&rsquo;t" 
+- "it's" → "it&rsquo;s" (multiple instances)
+- Build now passes ESLint validation
+
+**Status**: ✅ **MANIFESTO UPDATE COMPLETE - BUILD PASSING**
 
 ## Previous Task: Add USDC Subroutes for /create/usdc (MYC-2324)
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -135,7 +135,15 @@ Status: ✅ Complete ✅
 - "it's" → "it&rsquo;s" (multiple instances)
 - Build now passes ESLint validation
 
-**Status**: ✅ **MANIFESTO UPDATE COMPLETE - BUILD PASSING**
+**Capitalization Issue FIXED**:
+[X] **Fixed Tailwind Config**: Corrected "Spectral-bold" → "Spectral-Bold" font family name to match globals.css
+[X] **Added explicit text case classes**:
+- Title: Added `uppercase` class to force capitalization 
+- Subtitle: Added `uppercase` class to force capitalization
+- Main content: Added `normal-case` class to preserve proper sentence case
+- Final tagline: Added `uppercase` class to force capitalization
+
+**Status**: ✅ **MANIFESTO UPDATE COMPLETE - CAPITALIZATION FIXED**
 
 ## Previous Task: Add USDC Subroutes for /create/usdc (MYC-2324)
 

--- a/components/ManifestoPage/ManifestoPage.tsx
+++ b/components/ManifestoPage/ManifestoPage.tsx
@@ -41,7 +41,7 @@ The stream is silent without our sound.
 The feed is nothing but a blinking cursor, waiting on us to move.
 Yet they hold the archive hostage.
 Rewrite history in real time.
-Bury what doesn't fit their metrics.
+Bury what doesn&rsquo;t fit their metrics.
 And call it discovery.
 We refuse.
 
@@ -49,7 +49,7 @@ We refuse.
 For the blueprints they stole, repackaged, and resold.
 For the histories that deserve permanence, not expiration dates.
 
-`}<em><strong>In Process is not content—it's record-keeping. It's proof. It's legacy.</strong></em>{`
+`}<em><strong>In Process is not content—it&rsquo;s record-keeping. It&rsquo;s proof. It&rsquo;s legacy.</strong></em>{`
 This is where the work lives.
 Where artists own their evolution.
 Where every sketch, verse, sound, and glitch is a timestamp in culture.

--- a/components/ManifestoPage/ManifestoPage.tsx
+++ b/components/ManifestoPage/ManifestoPage.tsx
@@ -21,42 +21,44 @@ const ManifestoPage = () => {
       <div className="relative w-full md:w-2/4 flex justify-center text-grey-moss-900">
         <div className="w-fit relative">
           <p className="font-archivo text-2xl md:text-5xl tracking-[-1px] relative z-[2]">
-            in process: a manifesto
+            <strong>IN PROCESS: A MANIFESTO</strong>
           </p>
           <p className="font-spectral-italic pt-6 relative z-[2]">
-            THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.
+            <em><strong>THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.</strong></em>
           </p>
-          <pre className="font-spectral text-[11px] md:text-[16px] tracking-[-1px] pt-4 relative z-[2]">
+          <div className="font-spectral text-[11px] md:text-[16px] tracking-[-1px] pt-4 relative z-[2] whitespace-pre-line">
             {`They told us the artist needed the platform.
 Like we were guests at a table built from our own bones.
 Like visibility was a favor, not a debt.
 Like without them, we would vanish—scattered notes, lost rhythms, blueprints
 erased before they were ever built.
 
-They lied.
+`}<strong>They lied.</strong>{`
 
 Platforms have always needed us.
-The algorithm starves without our stories.
+`}<em><strong>The algorithm starves without our stories.</strong></em>{`
 The stream is silent without our sound.
 The feed is nothing but a blinking cursor, waiting on us to move.
 Yet they hold the archive hostage.
 Rewrite history in real time.
-Bury what doesn’t fit their metrics.
+Bury what doesn't fit their metrics.
 And call it discovery.
 We refuse.
 
-This is a space for process. For lineage. For the drafts that built dynasties.
+`}<em><strong>In Process is a space for process. For lineage. For the drafts that built dynasties.</strong></em>{`
 For the blueprints they stole, repackaged, and resold.
 For the histories that deserve permanence, not expiration dates.
 
-In Process is not content—it’s record-keeping. It’s proof. It’s legacy.
+`}<em><strong>In Process is not content—it's record-keeping. It's proof. It's legacy.</strong></em>{`
 This is where the work lives.
 Where artists own their evolution.
 Where every sketch, verse, sound, and glitch is a timestamp in culture.
 Here, we own the timeline.
 Here, we document in real time, onchain, on our terms.`}
-          </pre>
-          <p className="font-spectral-bold pt-4 text-xl">ALWAYS IN PROCESS.</p>
+          </div>
+          <p className="font-spectral-bold pt-4 text-xl">
+            <em><strong>ALWAYS IN PROCESS.</strong></em>
+          </p>
           <div
             className="md:absolute md:bottom-0 md:translate-x-0 md:translate-y-3/4 md:right-0
           relative translate-x-1/2 -translate-y-1/3"

--- a/components/ManifestoPage/ManifestoPage.tsx
+++ b/components/ManifestoPage/ManifestoPage.tsx
@@ -20,13 +20,13 @@ const ManifestoPage = () => {
       </div>
       <div className="relative w-full md:w-2/4 flex justify-center text-grey-moss-900">
         <div className="w-fit relative">
-          <p className="font-archivo text-2xl md:text-5xl tracking-[-1px] relative z-[2]">
+          <p className="font-archivo text-2xl md:text-5xl tracking-[-1px] relative z-[2] uppercase">
             <strong>IN PROCESS: A MANIFESTO</strong>
           </p>
-          <p className="font-spectral-italic pt-6 relative z-[2]">
+          <p className="font-spectral-italic pt-6 relative z-[2] uppercase">
             <em><strong>THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.</strong></em>
           </p>
-          <div className="font-spectral text-[11px] md:text-[16px] tracking-[-1px] pt-4 relative z-[2] whitespace-pre-line">
+          <div className="font-spectral text-[11px] md:text-[16px] tracking-[-1px] pt-4 relative z-[2] whitespace-pre-line normal-case">
             {`They told us the artist needed the platform.
 Like we were guests at a table built from our own bones.
 Like visibility was a favor, not a debt.
@@ -56,7 +56,7 @@ Where every sketch, verse, sound, and glitch is a timestamp in culture.
 Here, we own the timeline.
 Here, we document in real time, onchain, on our terms.`}
           </div>
-          <p className="font-spectral-bold pt-4 text-xl">
+          <p className="font-spectral-bold pt-4 text-xl uppercase">
             <em><strong>ALWAYS IN PROCESS.</strong></em>
           </p>
           <div

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -58,7 +58,7 @@ module.exports = {
         "spectral-italic": ["Spectral-Italic", "sans-serif"],
         "spectral": ["Spectral-Regular", "sans-serif"],
         "spectral-medium": ["Spectral-Medium", "sans-serif"],
-        "spectral-bold": ["Spectral-bold", "sans-serif"],
+        "spectral-bold": ["Spectral-Bold", "sans-serif"],
         "spectral-medium-italic": ["Spectral-MediumItalic", "sans-serif"],
       },
       borderRadius: {


### PR DESCRIPTION
The Manifesto page was updated to reflect new content and formatting requirements.

*   The title "in process: a manifesto" in `components/ManifestoPage/ManifestoPage.tsx` was updated to `<strong>IN PROCESS: A MANIFESTO</strong>` to apply bolding and capitalization.
*   The subtitle "THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS." was updated to `<em><strong>THE TIMELINE WAS NEVER THEIRS. IT WAS ALWAYS OURS.</strong></em>` to include both bold and italic formatting.
*   The main content block was entirely replaced with the new manifesto text.
    *   The `<pre>` tag was changed to a `<div>` with the `whitespace-pre-line` Tailwind class. This allows JSX elements (`<strong>`, `<em>`) to be rendered within the text while preserving line breaks and whitespace.
    *   Markdown-style bold (`*text*`) and bold-italic (`_*text*_`) formatting within the text was converted to explicit JSX tags (`<strong>text</strong>` and `<em><strong>text</strong></em>`).
*   The final tagline "ALWAYS IN PROCESS." was updated to `<em><strong>ALWAYS IN PROCESS.</strong></em>` for bold and italic styling.

These changes ensure the `/manifesto` page accurately displays the new content with the specified bolding and capitalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the manifesto page with new content, including revised title, subtitle, and main text.
	- Enhanced formatting using bold and italic styles for improved readability and emphasis.
	- Improved layout to better preserve formatting and line breaks while maintaining responsive design.
- **Bug Fixes**
	- Fixed typographic issues by replacing apostrophes with HTML entities.
	- Corrected font name capitalization and enforced consistent text casing for titles and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->