### PR TITLE
Delete create/usdc route and sub-routes

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -92,7 +92,43 @@ The goal is to help you maintain a big picture as well as the progress of the ta
 
 # Scratchpad
 
-## Current Task: Currency Dropdown for All /create Routes (MYC-2378)
+## Current Task: Delete /create/usdc Route and Sub-routes (MYC-2380)
+
+Status: ✅ **COMPLETE** ✅
+
+**Requirement**: 
+- Delete the `/create/usdc` route and all subroutes ✅
+- Current: prototype routes in `/create/usdc` (and subroutes) still exist ✅ REMOVED
+- Required: delete the `/create/usdc` route and subroutes ✅ COMPLETED
+- Ticket: https://linear.app/mycowtf/issue/MYC-2380/createusdc-delete-route-and-sub-routes
+
+**Implementation COMPLETED**:
+[X] **Deleted entire `/create/usdc` directory**: Removed `/create/usdc/` and all subroutes (`embed/`, `link/`, `writing/`, `page.tsx`)
+[X] **Updated DesktopSelect.tsx**: Removed all USDC logic and route references
+  - Removed `isUsdc` variable and conditional logic
+  - Simplified `baseRoute` to always be `/create`
+  - Updated all page detection logic to only check main routes
+[X] **Updated MobileSelect.tsx**: Removed all USDC logic and route references
+  - Removed `isUsdc` variable and conditional logic  
+  - Simplified `baseRoute` to always be `/create`
+  - Updated `selectedValue` logic to only check main routes
+[X] **Verified complete removal**: Confirmed no USDC references remain in navigation components
+
+**Changes Made**:
+- **Deleted directories**: `/create/usdc/`, `/create/usdc/embed/`, `/create/usdc/link/`, `/create/usdc/writing/`
+- **Deleted files**: `/create/usdc/page.tsx`, `/create/usdc/embed/page.tsx`, `/create/usdc/link/page.tsx`, `/create/usdc/writing/page.tsx`
+- **DesktopSelect.tsx**: Removed USDC conditional logic, simplified to only handle main `/create` routes
+- **MobileSelect.tsx**: Removed USDC conditional logic, simplified to only handle main `/create` routes
+
+**Technical Details**:
+- All USDC routes and navigation logic have been completely removed
+- Navigation components now only handle the main `/create`, `/create/writing`, `/create/link`, `/create/embed` routes
+- No more dual ETH/USDC route support - back to single route structure
+- Verified through directory listing and grep searches - no USDC references remain
+
+**Status**: ✅ **USDC ROUTE DELETION COMPLETE**
+
+## Previous Task: Currency Dropdown for All /create Routes (MYC-2378)
 
 Status: ✅ **COMPLETE** ✅
 

--- a/app/create/usdc/embed/page.tsx
+++ b/app/create/usdc/embed/page.tsx
@@ -1,7 +1,0 @@
-"use client";
-
-import EmbedPage from "@/components/EmbedPage";
-
-const Embed = () => <EmbedPage />;
-
-export default Embed;

--- a/app/create/usdc/link/page.tsx
+++ b/app/create/usdc/link/page.tsx
@@ -1,7 +1,0 @@
-"use client";
-
-import LinkPage from "@/components/LinkPage";
-
-const Linking = () => <LinkPage />;
-
-export default Linking;

--- a/app/create/usdc/page.tsx
+++ b/app/create/usdc/page.tsx
@@ -1,6 +1,0 @@
-"use client";
-
-import CreatePage from "@/components/CreatePage";
-const Create = () => <CreatePage />;
-
-export default Create;

--- a/app/create/usdc/writing/page.tsx
+++ b/app/create/usdc/writing/page.tsx
@@ -1,7 +1,0 @@
-"use client";
-
-import WritingPage from "@/components/WritingPage";
-
-const Writing = () => <WritingPage />;
-
-export default Writing;

--- a/components/CreateModeSelect/DesktopSelect.tsx
+++ b/components/CreateModeSelect/DesktopSelect.tsx
@@ -8,12 +8,11 @@ const DesktopSelect = () => {
   const { push } = useRouter();
   const searchParams = useSearchParams();
   const urlParams = searchParams.toString();
-  const isUsdc = pathname.includes("/usdc");
-  const baseRoute = isUsdc ? "/create/usdc" : "/create";
-  const isCreatePage = pathname === "/create" || pathname === "/create/usdc";
-  const isWritingPage = pathname === "/create/writing" || pathname === "/create/usdc/writing";
-  const isLinkPage = pathname === "/create/link" || pathname === "/create/usdc/link";
-  const isEmbedPage = pathname === "/create/embed" || pathname === "/create/usdc/embed";
+  const baseRoute = "/create";
+  const isCreatePage = pathname === "/create";
+  const isWritingPage = pathname === "/create/writing";
+  const isLinkPage = pathname === "/create/link";
+  const isEmbedPage = pathname === "/create/embed";
   const urlQuery = urlParams ? `?${urlParams}` : "";
   return (
     <div className="w-full lg:max-w-[250px] xl:max-w-[300px] h-fit">

--- a/components/CreateModeSelect/MobileSelect.tsx
+++ b/components/CreateModeSelect/MobileSelect.tsx
@@ -8,13 +8,12 @@ const MobileSelect = () => {
   const [isOpenSelect, setIsOpenSelect] = useState<boolean>(false);
   const { push } = useRouter();
   const pathname = usePathname();
-  const isUsdc = pathname.includes("/usdc");
-  const baseRoute = isUsdc ? "/create/usdc" : "/create";
+  const baseRoute = "/create";
   const selectedValue = useMemo(() => {
-    if (pathname === "/create" || pathname === "/create/usdc") return "moment";
-    if (pathname === "/create/writing" || pathname === "/create/usdc/writing") return "thought";
-    if (pathname === "/create/link" || pathname === "/create/usdc/link") return "link";
-    if (pathname === "/create/embed" || pathname === "/create/usdc/embed") return "embed";
+    if (pathname === "/create") return "moment";
+    if (pathname === "/create/writing") return "thought";
+    if (pathname === "/create/link") return "link";
+    if (pathname === "/create/embed") return "embed";
   }, [pathname]);
 
   const values = useMemo(() => {


### PR DESCRIPTION
The `/create/usdc` route and its sub-routes were removed.

*   The entire `/app/create/usdc/` directory was deleted, including:
    *   `/app/create/usdc/page.tsx`
    *   `/app/create/usdc/embed/page.tsx`
    *   `/app/create/usdc/link/page.tsx`
    *   `/app/create/usdc/writing/page.tsx`

*   Navigation components were updated to remove references to the deleted routes:
    *   In `components/CreateModeSelect/DesktopSelect.tsx` and `components/CreateModeSelect/MobileSelect.tsx`, the `isUsdc` variable and all USDC-specific conditional logic were removed.
    *   The `baseRoute` was simplified to always be `/create`.
    *   Page detection logic was updated to only check the main `/create` paths (e.g., `/create`, `/create/writing`, `/create/link`, `/create/embed`).

These changes eliminate the prototype USDC routing, simplifying the application's navigation to only support the main `/create` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed all USDC-related routes and navigation logic from the creation flow, consolidating to a single route structure.
	- Simplified navigation components for a more streamlined user experience.
- **Chores**
	- Deleted unused USDC-related pages and cleaned up references across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->