### PR TITLE
Implement new advanced settings menu design on desktop

### DIFF
--- a/components/CreateForm/Advanced.tsx
+++ b/components/CreateForm/Advanced.tsx
@@ -18,12 +18,12 @@ const Advanced = () => {
     <div className="flex flex-col gap-2 pt-2 z-10">
       <Button
         type="button"
-        className="w-fit self-center border border-grey rounded-full flex gap-2 items-center"
+        className="w-full h-fit p-0 mb-3 pb-1 self-center font-archivo font-medium border-b text-md border-grey-moss-300 rounded-none flex justify-between items-center"
         onClick={() => setIsOpenAdvanced(!isOpenAdvanced)}
       >
         advanced
         <ChevronDown
-          className={`text-grey-moss-900 transition-transform duration-200 ${isOpenAdvanced ? "rotate-180" : ""}`}
+          className={`text-grey-moss-200 transition-transform duration-200 ${isOpenAdvanced ? "rotate-180" : ""}`}
         />
       </Button>
       {isOpenAdvanced && (


### PR DESCRIPTION
Updated UI of the advanced settings toggle button in `/create` page.
- Removed full border and added only bottom border
- Changed width of the button
- Updated font of the button
- Updated colors of the button border and ChevronDown icon
- Adjusted padding and margin around the elements by following the design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of the toggle button in the advanced section for a more streamlined and modern look, including changes to width, border, font, and icon color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->