### PR TITLE
Create default prices (ETH = 0.000111 ETH and USD = $1 USD)

### DIFF
--- a/hooks/useMetadataValues.ts
+++ b/hooks/useMetadataValues.ts
@@ -1,5 +1,5 @@
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 const useMetadataValues = () => {
   const pathname = usePathname();
@@ -7,7 +7,7 @@ const useMetadataValues = () => {
 
   const [name, setName] = useState<string>("");
   const [priceUnit, setPriceUnit] = useState<string>(isUsdc ? "usdc" : "eth");
-  const [price, setPrice] = useState("0");
+  const [price, setPrice] = useState("");
   const [description, setDescription] = useState<string>("");
   const [isTimedSale, setIsTimedSale] = useState<boolean>(false);
   const [imageUri, setImageUri] = useState<string>("");
@@ -18,6 +18,14 @@ const useMetadataValues = () => {
   const [isOpenPreviewUpload, setIsOpenPreviewUpload] =
     useState<boolean>(false);
   const [previewSrc, setPreviewSrc] = useState<string>("");
+
+  useEffect(() => {
+    if (priceUnit === "usdc") {
+      setPrice("1");
+    } else {
+      setPrice("0.000111");
+    }
+  }, [priceUnit]);
 
   return {
     name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of the price field, ensuring it updates automatically when the price unit changes. The price now defaults to "1" for USDC and "0.000111" for other units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->