### PR TITLE
Airdrop - add handlePaste for bulk entries from Google Sheets

### DIFF
--- a/components/TokenManagePage/Airdrop.tsx
+++ b/components/TokenManagePage/Airdrop.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useAirdropProvider } from "@/providers/AirdropProvider";
-import { useState } from "react";
 import AirdropButton from "./AirdropButton";
 import { X } from "lucide-react";
 import { AirdropItem } from "@/hooks/useAirdrop";

--- a/components/TokenManagePage/Airdrop.tsx
+++ b/components/TokenManagePage/Airdrop.tsx
@@ -1,61 +1,17 @@
 "use client";
 
 import { useAirdropProvider } from "@/providers/AirdropProvider";
-import { KeyboardEvent, ClipboardEvent, useState } from "react";
+import { useState } from "react";
 import AirdropButton from "./AirdropButton";
 import { X } from "lucide-react";
 import { AirdropItem } from "@/hooks/useAirdrop";
 import truncateAddress from "@/lib/truncateAddress";
+import useAirdropInput from "@/hooks/useAirdropInput";
 
 const Airdrop = () => {
-  const { airdopToItems, onChangeAddress, removeAddress } =
-    useAirdropProvider();
-  const [value, setValue] = useState("");
-
-  // When the user presses Enter we want to submit whatever is currently in the
-  // input. The user might have typed or pasted multiple lines, so we split the
-  // value on new-lines, trim each entry and ignore blank rows.
-  const handleInput = async (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      const items = value
-        .split(/\r?\n/) // handle both Windows and Unix newlines
-        .map((item) => item.trim())
-        .filter(Boolean);
-
-      for (const item of items) {
-        await onChangeAddress(item);
-      }
-      setValue("");
-    }
-  };
-
-  // Support pasting a column of cells (e.g. from Google Sheets / Docs). We
-  // intercept the paste event, extract the text, split on new-lines, and add
-  // each non-empty row as a separate address to validate. We prevent the
-  // default paste behaviour so that the raw multi-line text is not inserted
-  // into the input field.
-  const handlePaste = async (e: ClipboardEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    const text = e.clipboardData.getData("text");
-
-    const items = text
-      .split(/\r?\n/)
-      .map((item) => item.trim())
-      .filter(Boolean);
-
-    for (const item of items) {
-      await onChangeAddress(item);
-    }
-
-    // Clear the input after processing the pasted data so the user can type
-    // again immediately.
-    setValue("");
-  };
-
-  const handleBlur = async () => {
-    await onChangeAddress(value);
-    setValue("");
-  };
+  const { airdopToItems, removeAddress } = useAirdropProvider();
+  const { handleInput, handlePaste, handleBlur, value, setValue } =
+    useAirdropInput();
 
   return (
     <div className="px-4 md:px-10 w-full">

--- a/hooks/useAirdropInput.ts
+++ b/hooks/useAirdropInput.ts
@@ -1,0 +1,61 @@
+import { ClipboardEvent, KeyboardEvent, useState } from "react";
+import { useAirdropProvider } from "@/providers/AirdropProvider";
+
+const useAirdropInput = () => {
+  const [value, setValue] = useState("");
+  const { onChangeAddress } = useAirdropProvider();
+  // When the user presses Enter we want to submit whatever is currently in the
+  // input. The user might have typed or pasted multiple lines, so we split the
+  // value on new-lines, trim each entry and ignore blank rows.
+  const handleInput = async (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      const items = value
+        .split(/\r?\n/) // handle both Windows and Unix newlines
+        .map((item) => item.trim())
+        .filter(Boolean);
+
+      for (const item of items) {
+        await onChangeAddress(item);
+      }
+      setValue("");
+    }
+  };
+
+  // Support pasting a column of cells (e.g. from Google Sheets / Docs). We
+  // intercept the paste event, extract the text, split on new-lines, and add
+  // each non-empty row as a separate address to validate. We prevent the
+  // default paste behaviour so that the raw multi-line text is not inserted
+  // into the input field.
+  const handlePaste = async (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const text = e.clipboardData.getData("text");
+
+    const items = text
+      .split(/\r?\n/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    for (const item of items) {
+      await onChangeAddress(item);
+    }
+
+    // Clear the input after processing the pasted data so the user can type
+    // again immediately.
+    setValue("");
+  };
+
+  const handleBlur = async () => {
+    await onChangeAddress(value);
+    setValue("");
+  };
+
+  return {
+    handleInput,
+    handlePaste,
+    handleBlur,
+    value,
+    setValue,
+  };
+};
+
+export default useAirdropInput;

--- a/hooks/useAirdropInput.ts
+++ b/hooks/useAirdropInput.ts
@@ -38,9 +38,6 @@ const useAirdropInput = () => {
     for (const item of items) {
       await onChangeAddress(item);
     }
-
-    // Clear the input after processing the pasted data so the user can type
-    // again immediately.
     setValue("");
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for multi-line input and pasted data in the Airdrop address field, allowing each line to be processed individually.

* **Bug Fixes**
  * Enhanced input handling to ensure pasted or entered addresses are correctly recognized and added, even when input contains multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->