### PR TITLE
do not display set preview button until image is being displayed

### DIFF
--- a/components/CreateForm/Preview.tsx
+++ b/components/CreateForm/Preview.tsx
@@ -35,7 +35,7 @@ const Preview = () => {
           <WritingPreview />
         </PreviewContainer>
       )}
-      <PreviewModal />
+      {previewUri && <PreviewModal />}
     </div>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of the preview modal so it only appears when a preview is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->