### PR TITLE
lI.High Priority - Post sizes for written pieces getting cut off

### DIFF
--- a/components/MetadataCreation/TextCreation.tsx
+++ b/components/MetadataCreation/TextCreation.tsx
@@ -1,11 +1,8 @@
-import { useZoraCreateProvider } from "@/providers/ZoraCreateProvider";
 import TextInput from "./TextInput";
 
 const TextCreation = () => {
-  const { createdContract } = useZoraCreateProvider();
-
   return (
-    <div className={`size-full ${createdContract && "pointer-events-none"}`}>
+    <div className="size-full">
       <TextInput />
     </div>
   );

--- a/components/MetadataCreation/TextInput.tsx
+++ b/components/MetadataCreation/TextInput.tsx
@@ -1,5 +1,5 @@
 import { useZoraCreateProvider } from "@/providers/ZoraCreateProvider";
-import { ChangeEvent, useState, useEffect } from "react";
+import { ChangeEvent, UIEvent, useState, useEffect } from "react";
 
 type ScrollPosition = "top" | "mid" | "bottom" | null;
 
@@ -8,9 +8,8 @@ const TextInput = () => {
     useZoraCreateProvider();
   const [scrollPosition, setScrollPosition] = useState<ScrollPosition>(null);
 
-  const handleScroll = (e: React.UIEvent<HTMLTextAreaElement | HTMLDivElement>) => {
-    const { scrollTop, scrollHeight, clientHeight } =
-      e.target as HTMLTextAreaElement | HTMLDivElement;
+  const handleScroll = (e: UIEvent<HTMLTextAreaElement | HTMLDivElement>) => {
+    const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
     const position: ScrollPosition =
       scrollTop === 0
         ? "top"
@@ -30,12 +29,21 @@ const TextInput = () => {
     return (
       <div className="size-full !font-spectral shadow-[5px_6px_2px_2px_#0000000f] border border-grey-moss-300 bg-white disabled:cursor-not-allowed relative">
         <div
-          className="relative z-[2] size-full p-2 md:p-4 pt-24 bg-grey-eggshell overflow-y-auto whitespace-pre-wrap"
+          className="relative z-[2] size-full p-2 md:p-4 pt-24 pb-24 bg-grey-eggshell overflow-y-auto whitespace-pre-wrap break-words"
           onScroll={handleScroll}
         >
           {writingText}
         </div>
-        <div className="pointer-events-none absolute z-[3] left-0 top-0 bg-gradientTopBottom w-full h-24" />
+        {scrollPosition && (
+          <>
+            {scrollPosition !== "top" && (
+              <div className="pointer-events-none absolute z-[3] left-0 top-0 bg-gradientTopBottom w-full h-24" />
+            )}
+            {scrollPosition !== "bottom" && (
+              <div className="pointer-events-none absolute z-[3] left-0 bottom-0 bg-gradientBottomTop w-full h-24" />
+            )}
+          </>
+        )}
       </div>
     );
   }

--- a/components/MetadataCreation/TextInput.tsx
+++ b/components/MetadataCreation/TextInput.tsx
@@ -1,24 +1,44 @@
 import { useZoraCreateProvider } from "@/providers/ZoraCreateProvider";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useState, useEffect } from "react";
 
 type ScrollPosition = "top" | "mid" | "bottom" | null;
 
 const TextInput = () => {
-  const { fileUploading, write, writingText, creating } =
+  const { fileUploading, write, writingText, creating, createdContract } =
     useZoraCreateProvider();
   const [scrollPosition, setScrollPosition] = useState<ScrollPosition>(null);
 
-  const handleScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
+  const handleScroll = (e: React.UIEvent<HTMLTextAreaElement | HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } =
-      e.target as HTMLTextAreaElement;
+      e.target as HTMLTextAreaElement | HTMLDivElement;
     const position: ScrollPosition =
       scrollTop === 0
         ? "top"
         : scrollHeight - scrollTop - clientHeight <= 5
-          ? "bottom"
-          : "mid";
+        ? "bottom"
+        : "mid";
     setScrollPosition(position);
   };
+
+  useEffect(() => {
+    if (createdContract) {
+      setScrollPosition("top");
+    }
+  }, [createdContract]);
+
+  if (createdContract) {
+    return (
+      <div className="size-full !font-spectral shadow-[5px_6px_2px_2px_#0000000f] border border-grey-moss-300 bg-white disabled:cursor-not-allowed relative">
+        <div
+          className="relative z-[2] size-full p-2 md:p-4 pt-24 bg-grey-eggshell overflow-y-auto whitespace-pre-wrap"
+          onScroll={handleScroll}
+        >
+          {writingText}
+        </div>
+        <div className="pointer-events-none absolute z-[3] left-0 top-0 bg-gradientTopBottom w-full h-24" />
+      </div>
+    );
+  }
 
   return (
     <div className="overflow-hidden size-full !font-spectral shadow-[5px_6px_2px_2px_#0000000f] border border-grey-moss-300 bg-white disabled:cursor-not-allowed relative">


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2734/lihigh-priority-post-sizes-for-written-pieces-getting-cut-off

Issue:
When creating a new thought in /create/writing, the creator cannot see the full post they just wrote. The text gets cut off with no way to scroll or expand it, making it difficult to review the full content.

Expected Behavior:
Users should be able to scroll within the post area to view the entire written piece after creating it.

Suggested Fix:
Enable scrolling (or an expandable view) for created posts so the creator can always read the full text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - After creation, the editor now always switches to a full-size, scrollable writing preview of the generated description.
  - Preview displays description directly when external content isn’t available.

- Bug Fixes
  - Improved scroll detection for smoother top/middle/bottom tracking during editing.
  - Scroll position reliably resets to the top when entering the post-creation preview and loading no longer stalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->