### PR TITLE
adjust timeline hover preview

### DIFF
--- a/components/HorizontalFeed/FeedHover.tsx
+++ b/components/HorizontalFeed/FeedHover.tsx
@@ -16,7 +16,7 @@ const FeedHover: FC<FeedHoverProps> = ({ isLoading, data }) => {
     >
       <div className="absolute inset-0 -m-8 z-0" />
       
-      <div className="relative z-10 border border-grey-moss-900 shadow-lg transition-opacity duration-200 ease-out">
+      <div className="relative z-10 shadow-lg transition-opacity duration-200 ease-out">
         <div className="w-[200px] md:w-[300px] aspect-[360/248] overflow-hidden relative bg-grey-moss-100 !font-spectral">
           {isLoading ? (
             <Skeleton className="size-full" />

--- a/components/Renderers/ContentRenderer.tsx
+++ b/components/Renderers/ContentRenderer.tsx
@@ -51,8 +51,9 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
         description={metadata.description}
       />
     );
+
   return (
-    <div className="grow relative">
+    <div className="w-full h-full">
       {/* eslint-disable-next-line */}
       <img
         src={
@@ -61,11 +62,10 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
           "/images/placeholder.png"
         }
         alt="Token Image."
+        className="w-full h-full object-cover block"
         style={{
           imageRendering: isMobile ? "auto" : "pixelated",
         }}
-        width="100%"
-        height="100%"
       />
     </div>
   );

--- a/components/Renderers/ContentRenderer.tsx
+++ b/components/Renderers/ContentRenderer.tsx
@@ -53,16 +53,18 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
     );
 
   return (
-    <div className="w-full h-full">
-      {/* eslint-disable-next-line */}
+    <div className="size-full">
       <img
         src={
           (isCollect && getFetchableUrl(metadata.animation_url)) ||
           getFetchableUrl(metadata.image) ||
           "/images/placeholder.png"
         }
-        alt="Token Image."
-        className="w-full h-full object-cover block"
+        alt={metadata?.name || metadata?.description || "Token image"}
+        className="size-full object-cover block"
+        loading="lazy"
+        decoding="async"
+        draggable={false}
         style={{
           imageRendering: isMobile ? "auto" : "pixelated",
         }}


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2559/adjust-timeline-hover-preview

actual (current behavior): image is not filling edges of container (notice the space at the bottom)

required (expected behavior): 
image fills space
remove border

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Improved image presentation in fallback content: images now fill available space with better cropping, include improved accessibility text, lazy loading/async decoding for faster perceived load, and device-aware rendering for sharper appearance.
  - Removed visible border from hover previews for a cleaner look while retaining shadows and transitions.
  - No changes to public interfaces or user workflows; updates are purely visual.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->