### PR TITLE
Med Priority - shift the placement of the "price"

### DIFF
--- a/components/CreateForm/Advanced.tsx
+++ b/components/CreateForm/Advanced.tsx
@@ -3,6 +3,7 @@ import { DateTimePicker } from "../ui/date-time-picker";
 import { ChevronDown } from "lucide-react";
 import { useZoraCreateProvider } from "@/providers/ZoraCreateProvider";
 import { Textarea } from "../ui/textarea";
+import Price from "./Price";
 
 const Advanced = () => {
   const {
@@ -36,6 +37,9 @@ const Advanced = () => {
             minRows={3}
             className="resize-none font-spectral"
           />
+          <div className="pt-2">
+            <Price />
+          </div>
           <p className="font-medium font-archivo pt-2">time</p>
           <DateTimePicker date={startDate} setDate={onChangeStartDate} />
         </div>

--- a/components/CreateForm/Advanced.tsx
+++ b/components/CreateForm/Advanced.tsx
@@ -37,9 +37,7 @@ const Advanced = () => {
             minRows={3}
             className="resize-none font-spectral"
           />
-          <div className="pt-2">
-            <Price />
-          </div>
+          <Price />
           <p className="font-medium font-archivo pt-2">time</p>
           <DateTimePicker date={startDate} setDate={onChangeStartDate} />
         </div>

--- a/components/CreateForm/CreateForm.tsx
+++ b/components/CreateForm/CreateForm.tsx
@@ -2,7 +2,6 @@
 
 import { useZoraCreateProvider } from "@/providers/ZoraCreateProvider";
 import CreateButton from "./CreateButton";
-import Price from "./Price";
 import Prompt from "./Prompt";
 import Buttons from "../CreatedMoment/Buttons";
 import Advanced from "./Advanced";
@@ -28,7 +27,6 @@ const CreateForm = () => {
         ) : (
           <>
             <Prompt />
-            <Price />
             <Advanced />
             <Preview />
             <CreateButton />

--- a/components/CreateForm/Price.tsx
+++ b/components/CreateForm/Price.tsx
@@ -10,7 +10,7 @@ export default function Price() {
     useZoraCreateProvider();
 
   return (
-    <div className="w-full space-y-2">
+    <div className="w-full pt-2">
       <Label htmlFor="price" className="font-archivo text-md">
         price
       </Label>


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2705/med-priority-shift-the-placement-of-the-price
move the "price" under advanced section,in between description and time 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Moved the Price field from the main Create form into the Advanced section.
  - Price is now visible only when the Advanced panel is expanded, reducing clutter in the default view.
  - No changes to creation flow, data, or interactions; behavior remains the same outside of the new placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->