### PR TITLE
August Priority - have long descriptions show in post details

### DIFF
--- a/components/TokenPage/Description.tsx
+++ b/components/TokenPage/Description.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+interface DescriptionProps {
+  description: string;
+  truncateLength?: number;
+}
+
+const Description = ({ description, truncateLength = 150 }: DescriptionProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  
+  if (!description) return null;
+  
+  const shouldTruncate = description.length > truncateLength;
+  const displayText = shouldTruncate && !isExpanded 
+    ? description.slice(0, truncateLength) + "..." 
+    : description;
+
+  return (
+    <div className="mt-3 md:mt-4">
+      <p className="font-archivo text-sm md:text-base text-grey-moss-300 leading-relaxed whitespace-pre-wrap">
+        {displayText}
+      </p>
+      {shouldTruncate && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="mt-2 text-xs md:text-sm font-archivo text-grey-moss-900 hover:text-black transition-colors underline"
+        >
+          {isExpanded ? "Read less" : "Read more"}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Description;

--- a/components/TokenPage/MetaAndComments.tsx
+++ b/components/TokenPage/MetaAndComments.tsx
@@ -1,7 +1,8 @@
 import { useTokenProvider } from "@/providers/TokenProvider";
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 import { Skeleton } from "../ui/skeleton";
 import CommentSection from "./CommentSection";
+import Description from "./Description";
 import getPrice from "@/lib/getPrice";
 import getPriceUnit from "@/lib/getPriceUnit";
 import { CopyIcon, DownloadIcon } from "lucide-react";
@@ -23,36 +24,15 @@ const MetaAndComments = ({
   const { share } = useShareMoment();
   const { balanceOf } = useBalanceOf();
   const { download } = useDownload();
-  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
   if (!meta) return <Fragment />;
-  
-  // Check if description is long enough to warrant truncation
-  const shouldTruncateDescription = meta.description && meta.description.length > 150;
-  const displayDescription = shouldTruncateDescription && !isDescriptionExpanded 
-    ? meta.description.slice(0, 150) + "..." 
-    : meta.description;
 
   return (
     <div className="w-full md:max-w-[400px] h-fit">
       <h3 className="text-4xl md:text-5xl font-spectral pt-2 md:pt-4">
         {meta.name}
       </h3>
-      {meta.description && (
-        <div className="mt-3 md:mt-4">
-          <p className="font-archivo text-sm md:text-base text-grey-moss-300 leading-relaxed whitespace-pre-wrap">
-            {displayDescription}
-          </p>
-          {shouldTruncateDescription && (
-            <button
-              onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
-              className="mt-2 text-xs md:text-sm font-archivo text-grey-moss-900 hover:text-black transition-colors underline"
-            >
-              {isDescriptionExpanded ? "Read less" : "Read more"}
-            </button>
-          )}
-        </div>
-      )}
+      <Description description={meta.description || ""} />
       {!priceHidden && isSetSale && (
         <>
           <div className="space-y-1 md:space-y-2 mt-2 md:mt-4">

--- a/components/TokenPage/MetaAndComments.tsx
+++ b/components/TokenPage/MetaAndComments.tsx
@@ -1,5 +1,5 @@
 import { useTokenProvider } from "@/providers/TokenProvider";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import { Skeleton } from "../ui/skeleton";
 import CommentSection from "./CommentSection";
 import getPrice from "@/lib/getPrice";
@@ -23,13 +23,36 @@ const MetaAndComments = ({
   const { share } = useShareMoment();
   const { balanceOf } = useBalanceOf();
   const { download } = useDownload();
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
   if (!meta) return <Fragment />;
+  
+  // Check if description is long enough to warrant truncation
+  const shouldTruncateDescription = meta.description && meta.description.length > 150;
+  const displayDescription = shouldTruncateDescription && !isDescriptionExpanded 
+    ? meta.description.slice(0, 150) + "..." 
+    : meta.description;
+
   return (
     <div className="w-full md:max-w-[400px] h-fit">
       <h3 className="text-4xl md:text-5xl font-spectral pt-2 md:pt-4">
         {meta.name}
       </h3>
+      {meta.description && (
+        <div className="mt-3 md:mt-4">
+          <p className="font-archivo text-sm md:text-base text-grey-moss-300 leading-relaxed whitespace-pre-wrap">
+            {displayDescription}
+          </p>
+          {shouldTruncateDescription && (
+            <button
+              onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
+              className="mt-2 text-xs md:text-sm font-archivo text-grey-moss-900 hover:text-black transition-colors underline"
+            >
+              {isDescriptionExpanded ? "Read less" : "Read more"}
+            </button>
+          )}
+        </div>
+      )}
       {!priceHidden && isSetSale && (
         <>
           <div className="space-y-1 md:space-y-2 mt-2 md:mt-4">


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2509/august-priority-have-long-descriptions-show-in-post-details
 show up in the post detail view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a description section to token pages, displaying metadata descriptions when available.
  * Long descriptions are truncated by default with an ellipsis and a “Read more” toggle to expand/collapse content.
  * Default truncation length is 150 characters, ensuring cleaner layouts for lengthy text.
  * If no description is provided, the section is omitted to avoid empty space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->