### PR TITLE
High Priority - Image cut off on mints

### DIFF
--- a/components/Renderers/ContentRenderer.tsx
+++ b/components/Renderers/ContentRenderer.tsx
@@ -43,7 +43,11 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
       <div className="size-full flex justify-center">
         <iframe
           src={getFetchableUrl(metadata.animation_url) || ""}
-          className="w-full"
+          className="w-full h-full"
+          title={metadata?.name || "Embedded content"}
+          sandbox="allow-scripts allow-same-origin"
+          referrerPolicy="no-referrer"
+          loading="lazy"
         />
       </div>
     );
@@ -51,7 +55,7 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
   if (mimeType.includes("text/plain"))
     return (
       <Writing
-        fileUrl={getFetchableUrl(metadata.content.uri) || ""}
+        fileUrl={getFetchableUrl(metadata?.content?.uri) || ""}
         description={metadata.description}
       />
     );

--- a/components/Renderers/ContentRenderer.tsx
+++ b/components/Renderers/ContentRenderer.tsx
@@ -52,7 +52,7 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
       />
     );
   return (
-    <div className="grow relative">
+    <div className="relative w-full h-full">
       {/* eslint-disable-next-line */}
       <img
         src={
@@ -61,11 +61,12 @@ const ContentRenderer = ({ metadata }: ContentRendererProps) => {
           "/images/placeholder.png"
         }
         alt="Token Image."
+        className="absolute inset-0 w-full h-full"
         style={{
           imageRendering: isMobile ? "auto" : "pixelated",
+          objectFit: "contain",
+          objectPosition: "center",
         }}
-        width="100%"
-        height="100%"
       />
     </div>
   );


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2667/high-priority-image-cut-off-on-mints

I want to be able to see the full image when I mint things - it cuts them off at the bottom


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native in-app rendering for audio and video players, and embedded HTML pages and plain-text so more file types display directly.

- **Style**
  - Improved image presentation: images center, scale, and fill available space more consistently across viewports.

- **Refactor**
  - Switched image sizing to CSS-driven layout for more predictable rendering.
  - Embedded HTML now uses safer, performance-minded loading (sandboxing and lazy load).
  - No changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->