### PR TITLE
Create button - toast missing metadata

### DIFF
--- a/components/CreateForm/CreateButton.tsx
+++ b/components/CreateForm/CreateButton.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useZoraCreateProvider } from "@/providers/ZoraCreateProvider";
+import { toast } from "sonner";
 
 const CreateButton = () => {
   const {
@@ -20,11 +21,25 @@ const CreateButton = () => {
     !creating &&
       name &&
       (previewUri || writingText) &&
-      Boolean(animationUri || link || embedCode || imageUri || writingText),
+      Boolean(animationUri || link || embedCode || imageUri || writingText)
   );
+
+  const toastCreateError = () => {
+    if (!previewUri && !writingText) {
+      toast.error("Missing a preview image");
+    } else if (!animationUri && !link && !embedCode && !imageUri) {
+      toast.error("Missing media");
+    } else {
+      toast.error("Error creating");
+    }
+  };
 
   const handleCreate = async () => {
     try {
+      if (!canCreate) {
+        toastCreateError();
+        return;
+      }
       await create();
     } catch (error) {
       console.error("Error creating:", error);
@@ -34,7 +49,7 @@ const CreateButton = () => {
   return (
     <Button
       onClick={handleCreate}
-      disabled={!canCreate}
+      disabled={creating}
       className="self-center w-fit z-10 px-14 py-5 md:py-6 md:w-full md:!mt-4 !font-archivo bg-black hover:bg-grey-moss-300 text-grey-eggshell md:h-[60px] !text-xl !rounded-sm transform transition-transform duration-150 disabled:opacity-1 disabled:!cursor-not-allowed disabled:!pointer-events-auto"
     >
       {creating ? "creating..." : "create"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contextual toast notifications when creation can’t proceed (e.g., missing preview image or required media), plus a generic error message.

* **Bug Fixes**
  * Creation is now blocked when requirements aren’t met, with immediate feedback via toasts instead of silent failure.
  * Create button only disables while creation is in progress, ensuring users can click to receive feedback when inputs are incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->