### PR TITLE
Restrict input to numeric values only - price field

### DIFF
--- a/components/CreateForm/Price.tsx
+++ b/components/CreateForm/Price.tsx
@@ -17,11 +17,18 @@ export default function Price() {
       <div className="flex overflow-hidden border border-grey-secondary">
         <Input
           id="price"
-          type="text"
-          value={price}
-          onChange={(e) => setPrice(e.target.value)}
-          className="flex-grow !font-spectral !rounded-[0px] !border-none bg-white focus-visible:ring-0 focus-visible:ring-offset-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          type="number"
+          inputMode="decimal"
+          min="0"
           step="0.01"
+          value={price}
+          onChange={(e) => {
+            const val = e.target.value;
+            if (/^\d*\.?\d*$/.test(val)) {
+              setPrice(val);
+            }
+          }}
+          className="flex-grow !font-spectral !rounded-[0px] !border-none bg-white focus-visible:ring-0 focus-visible:ring-offset-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           disabled={Boolean(fileUploading || creating)}
         />
         <div className="bg-white">


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2745/restrict-input-to-numeric-values-only-price-field
The field should restrict input to numeric values only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved the Price field to use a numeric input with decimal support, enforcing non‑negative values and 0.01 increments.
  - Prevents non-numeric characters and partial invalid entries, reducing user errors during input.
  - Enhances cross-browser consistency and validation at the input level for a smoother form-filling experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->