### PR TITLE
August - homepage moment timeline flow

### DIFF
--- a/components/ArtSlider/SliderFeed.tsx
+++ b/components/ArtSlider/SliderFeed.tsx
@@ -1,20 +1,14 @@
-import { useMetadata } from "@/hooks/useMetadata";
 import { Token } from "@/types/token";
 import Loading from "../Loading";
-import { useRouter } from "next/navigation";
 import CarouselItem from "./CarouselItem";
+import { useClickTimelineFeed } from "@/hooks/useClickTimelineFeed";
 
 interface SliderFeedProps {
   feed: Token;
 }
 
 const SliderFeed = ({ feed }: SliderFeedProps) => {
-  const { data, isLoading } = useMetadata(feed.uri);
-  const { push } = useRouter();
-
-  const handleClick = () => {
-    push(`/${feed.creator}`);
-  };
+  const { data, isLoading, handleClick } = useClickTimelineFeed(feed);
 
   return (
     <button

--- a/components/SprialFeeds/Feed.tsx
+++ b/components/SprialFeeds/Feed.tsx
@@ -5,6 +5,7 @@ import { Token } from "@/types/token";
 import { useRouter } from "next/navigation";
 import { useMetadata } from "@/hooks/useMetadata";
 import truncateAddress from "@/lib/truncateAddress";
+import { getShortNetworkName } from "@/lib/zora/zoraToViem";
 
 interface FeedProps {
   feed: Token;
@@ -24,13 +25,28 @@ const Feed = ({
   const { push } = useRouter();
   const { data } = useMetadata(feed.uri);
 
+  const handleClick = () => {
+    if (data?.external_url) {
+      const newWindow = window.open(data.external_url, "_blank");
+      if (newWindow) {
+        newWindow.opener = null;
+      }
+      return;
+    }
+    const shortNetworkName = getShortNetworkName(
+      feed.chain.replaceAll("_", " ")
+    );
+    const tokenId = feed.tokenId == "0" ? 1 : feed.tokenId;
+    push(`/collect/${shortNetworkName}:${feed.collection}/${tokenId}`);
+  };
+
   return (
     <React.Fragment>
       {index > 0 && generateSpacer(spacerWidth)}
       <tspan
         onMouseMove={(e) => handleMouseMove(e, feed)}
         onMouseLeave={handleMouseLeave}
-        onClick={() => push(`/${feed.creator}`)}
+        onClick={handleClick}
         dominant-baseline="middle"
       >
         <tspan fill="#1B1504" fontSize={isMobile ? 3 : 6} textAnchor="middle">

--- a/components/SprialFeeds/Feed.tsx
+++ b/components/SprialFeeds/Feed.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import useIsMobile from "@/hooks/useIsMobile";
 import { formatFeedText, generateSpacer } from "@/lib/spiralUtils";
 import { Token } from "@/types/token";
-import { useRouter } from "next/navigation";
-import { useMetadata } from "@/hooks/useMetadata";
 import truncateAddress from "@/lib/truncateAddress";
-import { getShortNetworkName } from "@/lib/zora/zoraToViem";
+import { useClickTimelineFeed } from "@/hooks/useClickTimelineFeed";
 
 interface FeedProps {
   feed: Token;
@@ -22,23 +20,7 @@ const Feed = ({
   handleMouseMove,
 }: FeedProps) => {
   const isMobile = useIsMobile();
-  const { push } = useRouter();
-  const { data } = useMetadata(feed.uri);
-
-  const handleClick = () => {
-    if (data?.external_url) {
-      const newWindow = window.open(data.external_url, "_blank");
-      if (newWindow) {
-        newWindow.opener = null;
-      }
-      return;
-    }
-    const shortNetworkName = getShortNetworkName(
-      feed.chain.replaceAll("_", " ")
-    );
-    const tokenId = feed.tokenId == "0" ? 1 : feed.tokenId;
-    push(`/collect/${shortNetworkName}:${feed.collection}/${tokenId}`);
-  };
+  const { data, handleClick } = useClickTimelineFeed(feed);
 
   return (
     <React.Fragment>

--- a/components/Timeline/Table/TimelineTableRow.tsx
+++ b/components/Timeline/Table/TimelineTableRow.tsx
@@ -1,21 +1,10 @@
-import { useMetadata } from "@/hooks/useMetadata";
-import { useRouter } from "next/navigation";
 import truncateAddress from "@/lib/truncateAddress";
 import { TimelineMoment } from "@/hooks/useTimelineApi";
 import truncated from "@/lib/truncated";
-import { getShortNetworkNameFromChainId } from "@/lib/zora/zoraToViem";
+import { useClickMoment } from "@/hooks/useClickMoment";
 
 const TimelineTableRow = ({ moment }: { moment: TimelineMoment }) => {
-  const { data } = useMetadata(moment.uri);
-  const { push } = useRouter();
-
-  const handleClick = () => {
-    const shortNetworkName = getShortNetworkNameFromChainId(moment.chainId);
-    if (shortNetworkName) {
-      const tokenId = moment.tokenId === "0" ? "1" : moment.tokenId;
-      push(`/collect/${shortNetworkName}:${moment.address}/${tokenId}`);
-    }
-  };
+  const { data, handleClick } = useClickMoment(moment);
 
   return (
     <button

--- a/components/Timeline/Table/TimelineTableRow.tsx
+++ b/components/Timeline/Table/TimelineTableRow.tsx
@@ -3,16 +3,25 @@ import { useRouter } from "next/navigation";
 import truncateAddress from "@/lib/truncateAddress";
 import { TimelineMoment } from "@/hooks/useTimelineApi";
 import truncated from "@/lib/truncated";
+import { getShortNetworkNameFromChainId } from "@/lib/zora/zoraToViem";
 
 const TimelineTableRow = ({ moment }: { moment: TimelineMoment }) => {
   const { data } = useMetadata(moment.uri);
   const { push } = useRouter();
 
+  const handleClick = () => {
+    const shortNetworkName = getShortNetworkNameFromChainId(moment.chainId);
+    if (shortNetworkName) {
+      const tokenId = moment.tokenId === "0" ? "1" : moment.tokenId;
+      push(`/collect/${shortNetworkName}:${moment.address}/${tokenId}`);
+    }
+  };
+
   return (
     <button
       type="button"
       className="w-full flex items-start justify-between p-4"
-      onClick={() => push(`/${moment.admin}`)}
+      onClick={handleClick}
     >
       <div>
         <p className="font-spectral-italic text-base text-left">

--- a/components/Timeline/Table/TimelineTableRowDesktop.tsx
+++ b/components/Timeline/Table/TimelineTableRowDesktop.tsx
@@ -2,6 +2,7 @@ import { useMetadata } from "@/hooks/useMetadata";
 import { useRouter } from "next/navigation";
 import { TableRow, TableCell } from "@/components/ui/table";
 import truncateAddress from "@/lib/truncateAddress";
+import { getShortNetworkNameFromChainId } from "@/lib/zora/zoraToViem";
 
 const fontFamilies = ["font-archivo", "font-spectral-italic", "font-archivo"];
 const fontSizes = [
@@ -14,10 +15,18 @@ const TimelineTableRowDesktop = ({ moment }: { moment: any }) => {
   const { data } = useMetadata(moment.uri);
   const { push } = useRouter();
 
+  const handleClick = () => {
+    const shortNetworkName = getShortNetworkNameFromChainId(moment.chainId);
+    if (shortNetworkName) {
+      const tokenId = moment.tokenId === "0" ? "1" : moment.tokenId;
+      push(`/collect/${shortNetworkName}:${moment.address}/${tokenId}`);
+    }
+  };
+
   return (
     <TableRow
       className="!border-b !border-transparent hover:!bg-transparent hover:!text-grey-moss-300 hover:!border-b-grey-moss-300"
-      onClick={() => push(`/${moment.admin}`)}
+      onClick={handleClick}
     >
       <TableCell
         className={`md:py-3 border-none cursor-pointer ${fontFamilies[0]} ${fontSizes[0]}`}

--- a/components/Timeline/Table/TimelineTableRowDesktop.tsx
+++ b/components/Timeline/Table/TimelineTableRowDesktop.tsx
@@ -1,8 +1,6 @@
-import { useMetadata } from "@/hooks/useMetadata";
-import { useRouter } from "next/navigation";
 import { TableRow, TableCell } from "@/components/ui/table";
 import truncateAddress from "@/lib/truncateAddress";
-import { getShortNetworkNameFromChainId } from "@/lib/zora/zoraToViem";
+import { useClickMoment } from "@/hooks/useClickMoment";
 
 const fontFamilies = ["font-archivo", "font-spectral-italic", "font-archivo"];
 const fontSizes = [
@@ -12,16 +10,7 @@ const fontSizes = [
 ];
 
 const TimelineTableRowDesktop = ({ moment }: { moment: any }) => {
-  const { data } = useMetadata(moment.uri);
-  const { push } = useRouter();
-
-  const handleClick = () => {
-    const shortNetworkName = getShortNetworkNameFromChainId(moment.chainId);
-    if (shortNetworkName) {
-      const tokenId = moment.tokenId === "0" ? "1" : moment.tokenId;
-      push(`/collect/${shortNetworkName}:${moment.address}/${tokenId}`);
-    }
-  };
+  const { data, handleClick } = useClickMoment(moment);
 
   return (
     <TableRow

--- a/hooks/useClickMoment.ts
+++ b/hooks/useClickMoment.ts
@@ -9,11 +9,16 @@ export const useClickMoment = (moment: TimelineMoment) => {
 
   const handleClick = () => {
     if (data?.external_url) {
-      const newWindow = window.open(data.external_url, "_blank");
-      if (newWindow) {
-        newWindow.opener = null;
+      try {
+        const url = new URL(data.external_url);
+        if (url.protocol === "http:" || url.protocol === "https:") {
+          window.open(url.toString(), "_blank", "noopener,noreferrer");
+          return;
+        }
+      } catch {
+        // Invalid or unsupported URL; fall through to internal navigation
       }
-      return;
+    }
     }
     
     const shortNetworkName = getShortNetworkNameFromChainId(moment.chainId);

--- a/hooks/useClickMoment.ts
+++ b/hooks/useClickMoment.ts
@@ -19,7 +19,6 @@ export const useClickMoment = (moment: TimelineMoment) => {
         // Invalid or unsupported URL; fall through to internal navigation
       }
     }
-    }
     
     const shortNetworkName = getShortNetworkNameFromChainId(moment.chainId);
     if (shortNetworkName) {

--- a/hooks/useClickMoment.ts
+++ b/hooks/useClickMoment.ts
@@ -1,0 +1,32 @@
+import { useRouter } from "next/navigation";
+import { useMetadata } from "./useMetadata";
+import { TimelineMoment } from "./useTimelineApi";
+import { getShortNetworkNameFromChainId } from "@/lib/zora/zoraToViem";
+
+export const useClickMoment = (moment: TimelineMoment) => {
+  const { push } = useRouter();
+  const { isLoading, data } = useMetadata(moment.uri);
+
+  const handleClick = () => {
+    if (data?.external_url) {
+      const newWindow = window.open(data.external_url, "_blank");
+      if (newWindow) {
+        newWindow.opener = null;
+      }
+      return;
+    }
+    
+    const shortNetworkName = getShortNetworkNameFromChainId(moment.chainId);
+    if (shortNetworkName) {
+      const tokenId = moment.tokenId === "0" ? "1" : moment.tokenId;
+      push(`/collect/${shortNetworkName}:${moment.address}/${tokenId}`);
+    }
+  };
+
+  return {
+    isLoading,
+    data,
+    handleClick,
+    formattedDate: new Date(moment.createdAt).toLocaleString(),
+  };
+};

--- a/hooks/useClickTimelineFeed.ts
+++ b/hooks/useClickTimelineFeed.ts
@@ -1,20 +1,14 @@
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useMetadata } from "./useMetadata";
 import { Token } from "@/types/token";
 import { getShortNetworkName } from "@/lib/zora/zoraToViem";
 
 export const useClickTimelineFeed = (feed: Token) => {
   const { push } = useRouter();
-  const pathname = usePathname();
-  const isHomePage = pathname === "/" || pathname === "/timeline";
 
   const { isLoading, data } = useMetadata(feed.uri);
 
   const handleClick = () => {
-    if (isHomePage) {
-      push(`/${feed.creator}`);
-      return;
-    }
     if (data?.external_url) {
       const newWindow = window.open(data.external_url, "_blank");
       if (newWindow) {

--- a/lib/zora/zoraToViem.ts
+++ b/lib/zora/zoraToViem.ts
@@ -1,3 +1,5 @@
+import { networkConfigByChain } from "../protocolSdk/apis/chain-constants";
+
 export const ZORA_TO_VIEM = {
   arb: "arbitrum",
   base: "base",
@@ -54,24 +56,6 @@ export const getShortNetworkName = (
 export const getShortNetworkNameFromChainId = (
   chainId: number,
 ): ZoraChains | undefined => {
-  switch (chainId) {
-    case 1:
-      return "eth";
-    case 8453:
-      return "base";
-    case 84532:
-      return "bsep";
-    case 10:
-      return "oeth";
-    case 42161:
-      return "arb";
-    case 7777777:
-      return "zora";
-    case 81457:
-      return "blast";
-    case 424:
-      return "pgn";
-    default:
-      return undefined;
-  }
+  const networkConfig = networkConfigByChain[chainId];
+  return networkConfig?.zoraCollectPathChainName as ZoraChains;
 };

--- a/lib/zora/zoraToViem.ts
+++ b/lib/zora/zoraToViem.ts
@@ -45,3 +45,33 @@ export const getShortNetworkName = (
   // Default lookup
   return VIEM_TO_ZORA[normalizedName as keyof typeof VIEM_TO_ZORA];
 };
+
+/**
+ * Get the short network name from chainId
+ * @param chainId - The chain ID (e.g. 8453, 84532)
+ * @returns The short network name (e.g. "base", "bsep") or undefined if not found
+ */
+export const getShortNetworkNameFromChainId = (
+  chainId: number,
+): ZoraChains | undefined => {
+  switch (chainId) {
+    case 1:
+      return "eth";
+    case 8453:
+      return "base";
+    case 84532:
+      return "bsep";
+    case 10:
+      return "oeth";
+    case 42161:
+      return "arb";
+    case 7777777:
+      return "zora";
+    case 81457:
+      return "blast";
+    case 424:
+      return "pgn";
+    default:
+      return undefined;
+  }
+};


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2737/august-homepage-moment-timeline-flow
When I'm on the homepage and I click on a moment on the timeline, it takes me to the person's full timeline. Instead, I'd like to see it take me directly to that moment that I clicked on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified click behavior for feed items and timeline rows: opens external links in a new tab or routes to the collect page.
  - Components now use centralized click hooks and provide formatted dates for moments.

- Bug Fixes
  - Corrected token handling when ID is 0.
  - More reliable cross-network navigation with safe fallbacks to creator profiles.
  - Improved security for external links (no opener/noreferrer).

- Refactor
  - Consolidated click/navigation logic across timeline and feed components; removed path-dependent branching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->