### PR TITLE
fix(Med Priority) : remove total earning from drop down move to manage page

### DIFF
--- a/components/LoginButton/DropdownMenu.tsx
+++ b/components/LoginButton/DropdownMenu.tsx
@@ -2,10 +2,8 @@ import useSignedAddress from "@/hooks/useSignedAddress";
 import { useFrameProvider } from "@/providers/FrameProvider";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import CreateToEarnButton from "./CreateToEarnButton";
 import Divider from "./Divider";
 import { useLayoutProvider } from "@/providers/LayoutProvider";
-import TotalEarnings from "./TotalEarnings";
 import { usePrivy } from "@privy-io/react-auth";
 
 export function DropdownMenu() {
@@ -17,36 +15,6 @@ export function DropdownMenu() {
 
   return (
     <div className="absolute top-full left-0 right-0 h-screen md:h-fit bg-grey-moss-900 shadow-lg font-archivo z-[999999999] rounded-b-sm border-t-0">
-      <Divider />
-      <div className="px-6 md:px-4 py-4 md:py-2">
-        <div className="flex gap-2 items-start md:justify-between md:items-center">
-          <Image
-            src="/images/dropdown-ellipse.svg"
-            alt="Dropdown indicator"
-            width={32}
-            height={32}
-            className="block md:hidden"
-          />
-          <div className="text-white w-full">
-            <p className="font-archivo text-2xl md:text-base">total earnings</p>
-            <div className="block md:hidden flex items-center justify-between w-full">
-              <TotalEarnings className="block md:hidden" />
-              <CreateToEarnButton className="block md:hidden" />
-            </div>
-          </div>
-          <Image
-            src="/images/dropdown-ellipse.svg"
-            alt="Dropdown indicator"
-            width={24}
-            height={24}
-            className="hidden md:block"
-          />
-        </div>
-        <div className="flex justify-between pt-2">
-          <TotalEarnings className="hidden md:block" />
-          <CreateToEarnButton className="hidden md:block" />
-        </div>
-      </div>
       <Divider />
       <button
         onClick={() => {

--- a/components/LoginButton/TotalEarnings.tsx
+++ b/components/LoginButton/TotalEarnings.tsx
@@ -7,9 +7,7 @@ const TotalEarnings = ({ className }: { className: string }) => {
   const { isLoading } = useUserCollectionsProvider();
 
   return (
-    <div
-      className={`text-white md:text-base font-spectral text-xl ${className}`}
-    >
+    <div className={`font-spectral ${className}`}>
       {isLoading ? (
         <Skeleton className="bg-grey-moss-300 w-10 md:w-8 h-4 mt-1" />
       ) : (

--- a/components/ManagePage/ManagePage.tsx
+++ b/components/ManagePage/ManagePage.tsx
@@ -7,6 +7,7 @@ import SignToInProcess from "./SignToInProcess";
 import { usePrivy } from "@privy-io/react-auth";
 import { Fragment, useEffect, useState } from "react";
 import Collections from "./Collections";
+import TotalEarnings from "../LoginButton/TotalEarnings";
 
 const ManagePage = () => {
   const { context } = useFrameProvider();
@@ -27,6 +28,16 @@ const ManagePage = () => {
   if (!signedWallet) return <SignToInProcess />;
   return (
     <div className="w-screen flex flex-col grow pt-10 md:pt-16">
+      <div className="px-6 md:px-8 pb-6">
+        <div className="flex items-center gap-4">
+          <h2 className=" text-2xl md:text-3xl font-archivo">total earnings</h2>
+          <TotalEarnings className="text-2xl md:text-3xl font-spectral text-grey-moss-900" />
+        </div>
+        <p className="text-grey-moss-300 text-sm mt-2">
+          Note: Earnings calculation is being improved and may not reflect
+          accurate totals
+        </p>
+      </div>
       <Collections />
     </div>
   );


### PR DESCRIPTION
Ticket : [](https://linear.app/mycowtf/issue/MYC-2772/med-priority-remove-total-earning-from-drop-down-move-to-manage-page)

 1. remove total earnings from dropdown.
 2. add total earnings component to Manage page . removed hardcoded text classes for <TotalEarnings/> component and consume it  from props.