### PR TITLE
save button - onClick - sign to update metadata.

### DIFF
--- a/components/TokenManagePage/Media.tsx
+++ b/components/TokenManagePage/Media.tsx
@@ -1,17 +1,18 @@
 "use client";
+import { useEffect, useState } from "react";
 
 import { useTokenProvider } from "@/providers/TokenProvider";
-import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import MediaSkeleton from "./MediaSkeleton";
+import OwnerWarning from "./OwnerWarning";
+import SaveMediaButton from "./SaveMediaButton";
 
 const Media = () => {
   const { metadata } = useTokenProvider();
   const { data: meta, isLoading } = metadata;
-
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
+  const [title, setTitle] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
 
   useEffect(() => {
     if (!meta) return;
@@ -51,6 +52,9 @@ const Media = () => {
               placeholder="enter a description"
             />
           </div>
+
+          <SaveMediaButton title={title} description={description} />
+          <OwnerWarning />
         </div>
       </div>
     </div>

--- a/components/TokenManagePage/OwnerWarning.tsx
+++ b/components/TokenManagePage/OwnerWarning.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useTokenProvider } from "@/providers/TokenProvider";
+
+const OwnerWarning = () => {
+    const { isOwner } = useTokenProvider();
+
+    if (isOwner) return null;
+
+    return (
+        <p className="text-xs text-grey-moss-500">
+            Only the contract owner can save changes.
+        </p>
+    )
+}
+
+export default OwnerWarning;

--- a/components/TokenManagePage/SaveMediaButton.tsx
+++ b/components/TokenManagePage/SaveMediaButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useTokenProvider } from "@/providers/TokenProvider";
+import useUpdateTokenURI from "@/hooks/useUpdateTokenURI";
+
+interface SaveMediaButtonProps {
+    title: string;
+    description: string;
+}
+
+const SaveMediaButton = ({ title, description }: SaveMediaButtonProps) => {
+    const { isOwner } = useTokenProvider();
+
+    const { updateTokenURI, isLoading: isSaving } = useUpdateTokenURI();
+
+    const saveHandler = () => {
+        updateTokenURI(title, description);
+    }
+
+    return (
+        <button
+            className="bg-black text-grey-eggshell w-fit px-8 py-2 rounded-md disabled:opacity-50"
+            onClick={saveHandler}
+            disabled={isSaving || !isOwner}
+        >
+            {isSaving ? "saving..." : "Save"}
+        </button>
+    )
+}
+
+export default SaveMediaButton;

--- a/hooks/useTokenInfo.ts
+++ b/hooks/useTokenInfo.ts
@@ -1,7 +1,8 @@
-import { Address } from "viem";
-import { useCallback, useState } from "react";
+import { Address, getAddress } from "viem";
+import { useCallback, useMemo, useState } from "react";
 import getTokenInfo from "@/lib/viem/getTokenInfo";
 import { useEffect } from "react";
+import { useUserProvider } from "@/providers/UserProvider";
 
 export type SaleConfig = {
   saleStart: bigint;
@@ -22,6 +23,14 @@ const useTokenInfo = (
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isSetSale, setIsSetSale] = useState<boolean>(false);
   const [owner, setOwner] = useState<Address | null>(null);
+  const { connectedAddress } = useUserProvider();
+
+  const isOwner = useMemo(() => {
+    return Boolean(
+      connectedAddress && owner &&
+      getAddress(connectedAddress) === getAddress(owner)
+    )
+  }, [connectedAddress, owner])
 
   const fetchTokenInfo = useCallback(async () => {
     const tokenInfo = await getTokenInfo(tokenContract, tokenId, chainId);
@@ -43,6 +52,7 @@ const useTokenInfo = (
     isSetSale,
     fetchTokenInfo,
     owner,
+    isOwner
   };
 };
 

--- a/hooks/useUpdateTokenURI.ts
+++ b/hooks/useUpdateTokenURI.ts
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useTokenProvider } from "@/providers/TokenProvider";
+import { Address } from "viem";
+import useSignTransaction from "./useSignTransaction";
+import { getPublicClient } from "@/lib/viem/publicClient";
+import { CHAIN, CHAIN_ID } from "@/lib/consts";
+import { zoraCreator1155ImplABI } from "@zoralabs/protocol-deployments";
+import { useUserProvider } from "@/providers/UserProvider";
+import { uploadJson } from "@/lib/arweave/uploadJson";
+import { fetchTokenMetadata } from "@/lib/protocolSdk/ipfs/token-metadata";
+import getTokenInfo from "@/lib/viem/getTokenInfo";
+
+const useUpdateTokenURI = () => {
+  const { token, fetchTokenInfo } = useTokenProvider();
+  const { signTransaction } = useSignTransaction();
+  const { connectedAddress } = useUserProvider();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const updateTokenURI = async (title: string, description: string) => {
+    const tokenInfo = await getTokenInfo(token.tokenContractAddress, token.tokenId, CHAIN_ID);
+    const current = await fetchTokenMetadata(tokenInfo.tokenUri);
+
+    const updated = { ...(current || {}), name: title, description };
+    if (!updated.name) throw new Error("Missing token name");
+    if (!updated.description) throw new Error("Missing token description");
+
+    const newUri = await uploadJson(updated);
+
+    if (!connectedAddress) throw new Error("Wallet not connected");
+    if (!token?.tokenContractAddress || !token?.tokenId) {
+      throw new Error("Missing token context");
+    }
+    setIsLoading(true);
+    try {
+      const publicClient = getPublicClient(CHAIN_ID);
+      const hash = await signTransaction({
+        address: token.tokenContractAddress,
+        abi: zoraCreator1155ImplABI,
+        functionName: "updateTokenURI",
+        args: [BigInt(token.tokenId), newUri],
+        account: connectedAddress as Address,
+        chain: CHAIN,
+      });
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      fetchTokenInfo();
+      return receipt;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    updateTokenURI,
+    isLoading,
+  };
+};
+
+export default useUpdateTokenURI;


### PR DESCRIPTION
ticket - https://linear.app/mycowtf/issue/MYC-2696/save-button-onclick-sign-to-update-metadata


- add save button and sign tx to update token uri
- Only contract owner can update metadata.
- Test Transaction
Call function: updateTokenURI(uint256 _tokenId,string _uri)
Tx Link:
`https://sepolia.basescan.org/tx/0xd645b770439e10b054a5265db609efd75f4a6aa7cdaa13a2ed87916ff20d1e96`


<img width="1558" height="619" alt="image" src="https://github.com/user-attachments/assets/3809a3ac-9973-4389-b247-c4da92071671" />

<img width="1542" height="586" alt="image" src="https://github.com/user-attachments/assets/d58f42b8-50d3-484e-8224-edf7266dcc77" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit and save token media title and description from the UI.
  * Save button updates on-chain metadata and shows "saving..." while in progress.
  * Saving restricted to contract owners; button disabled for non-owners.
  * Display ownership warning for non-owners.
  * Auto-fill title and description from existing metadata when available.
  * Show loading skeleton until token metadata is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->