### PR TITLE
manage page - media tab - all metadata fields

### DIFF
--- a/components/TokenManagePage/ImageUpload/CropImage.tsx
+++ b/components/TokenManagePage/ImageUpload/CropImage.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { useState } from "react";
+import Cropper, { Area } from "react-easy-crop";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import getCroppedImg from "@/lib/cropImage/getCroppedImage";
+import clientUploadToArweave from "@/lib/arweave/clientUploadToArweave";
+
+interface CropImageProps {
+    imageUri: string;
+    previewSrc: string;
+    closeModal: () => void;
+    handleCroppedImage: (url: string, uri: string) => void
+}
+
+const CropImage = ({ previewSrc, imageUri, closeModal, handleCroppedImage }: CropImageProps) => {
+    const [crop, setCrop] = useState({ x: 0, y: 0 });
+    const [rotation, setRotation] = useState(0);
+    const [zoom, setZoom] = useState(1);
+    const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+    const [isCropUploading, setIsCropUploading] = useState(false);
+
+    const onCropComplete = (_: Area, cropped: Area) => {
+        setCroppedAreaPixels(cropped);
+    };
+
+    const saveCroppedImage = async () => {
+        if (!croppedAreaPixels || isCropUploading || !imageUri) return;
+        try {
+            setIsCropUploading(true);
+            const imageSrc = previewSrc || imageUri;
+            const resultUrl = (await getCroppedImg(
+                imageSrc,
+                croppedAreaPixels,
+                rotation
+            )) as string;
+            const response = await fetch(resultUrl);
+            const blob = await response.blob();
+            const file = new File([blob], "preview.jpeg", {
+                type: blob.type || "image/jpeg",
+            });
+            const uri = await clientUploadToArweave(file);
+            handleCroppedImage(resultUrl, uri);
+        } catch (err) {
+            console.error(err);
+            toast.error("Failed to crop image");
+        } finally {
+            setIsCropUploading(false);
+        }
+    };
+
+    const handleCropImage = async () => {
+        await saveCroppedImage();
+        closeModal();
+        toast.success("Image cropped successfully!");
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg p-6 max-w-2xl w-full mx-4">
+                <div className="space-y-4">
+                    <h3 className="font-archivo text-lg font-medium">Crop Image</h3>
+
+                    <div className="relative h-64 w-full">
+                        <Cropper
+                            image={previewSrc || imageUri}
+                            crop={crop}
+                            rotation={rotation}
+                            zoom={zoom}
+                            aspect={4 / 3}
+                            onCropChange={setCrop}
+                            onRotationChange={setRotation}
+                            onCropComplete={onCropComplete}
+                            onZoomChange={setZoom}
+                        />
+                    </div>
+
+                    <div className="flex gap-2 justify-end">
+                        <Button
+                            variant="outline"
+                            onClick={closeModal}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            onClick={handleCropImage}
+                            disabled={isCropUploading}
+                        >
+                            {isCropUploading ? "Cropping..." : "Crop & Save"}
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default CropImage;

--- a/components/TokenManagePage/ImageUpload/ImageUpload.tsx
+++ b/components/TokenManagePage/ImageUpload/ImageUpload.tsx
@@ -1,0 +1,96 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import useFileUpload from "@/hooks/useFileUpload";
+import PreviewImage from "./PreviewImage";
+import CropImage from "./CropImage";
+
+interface ImageUploadProps {
+    initialImageUri?: string;
+    onImageChange: (imageUri: string) => void;
+    disabled?: boolean;
+}
+
+const ImageUpload = ({ initialImageUri = "", onImageChange, disabled = false }: ImageUploadProps) => {
+    const [imageUri, setImageUri] = useState(initialImageUri);
+    const [previewSrc, setPreviewSrc] = useState("");
+    const [previewUri, setPreviewUri] = useState("");
+    const [animationUri, setAnimationUri] = useState("");
+    const [, setMimeType] = useState("");
+    const [showCropModal, setShowCropModal] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (initialImageUri && initialImageUri !== imageUri) {
+            setImageUri(initialImageUri);
+        }
+    }, [initialImageUri, imageUri]);
+
+    useEffect(() => {
+        if (imageUri && imageUri !== initialImageUri) {
+            onImageChange(imageUri);
+        }
+    }, [imageUri, initialImageUri, onImageChange]);
+
+    const { fileUpload, fileUploading, error: uploadError, pctComplete, }
+        = useFileUpload({ setImageUri, setPreviewSrc, setPreviewUri, setAnimationUri, setMimeType, animationUri });
+
+    const handleCroppedImage = (url: string, uri: string) => {
+        setPreviewSrc(url);
+        setPreviewUri(uri);
+        onImageChange(uri);
+    }
+
+    const handleFileUpload = async (event: any) => {
+        await fileUpload(event);
+    };
+
+    const openCropModal = () => {
+        setShowCropModal(true);
+    };
+
+    const closeCropModal = () => {
+        setShowCropModal(false);
+    }
+
+    const currentImageUri = previewSrc || previewUri || imageUri;
+
+    return (
+        <div>
+            <label className="font-archivo text-sm text-grey-moss-600 block mb-1">
+                image
+            </label>
+            <div className="space-y-2">
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    onChange={handleFileUpload}
+                    className="hidden"
+                />
+
+                <Button
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={disabled || fileUploading}
+                    variant="outline"
+                    className="w-full"
+                >
+                    {fileUploading ? `Uploading... ${pctComplete}%` : "Upload Image"}
+                </Button>
+
+                {uploadError && (
+                    <p className="text-xs text-red-500">{uploadError}</p>
+                )}
+
+                <PreviewImage currentImageUri={currentImageUri} previewSrc={previewSrc} openCropModal={openCropModal} disabled={disabled} />
+
+                {
+                    showCropModal && <CropImage previewSrc={previewSrc} imageUri={imageUri} closeModal={closeCropModal} handleCroppedImage={handleCroppedImage} />
+                }
+
+            </div>
+        </div>
+    );
+};
+
+export default ImageUpload;

--- a/components/TokenManagePage/ImageUpload/PreviewImage.tsx
+++ b/components/TokenManagePage/ImageUpload/PreviewImage.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { Button } from "@/components/ui/button";
+
+interface PreviewImageProps {
+    currentImageUri?: string;
+    previewSrc?: string;
+    disabled: boolean;
+    openCropModal: () => void;
+}
+
+const PreviewImage = ({ currentImageUri, previewSrc, disabled, openCropModal }: PreviewImageProps) => {
+    return (
+        <div className="space-y-2">
+            <div className="relative">
+                {
+                    currentImageUri && <img
+                        src={currentImageUri}
+                        alt="Preview"
+                        className="w-full h-48 object-cover rounded-md border"
+                    />
+                }
+                {previewSrc && (
+                    <div className="w-full flex items-center justify-center absolute left-0 bottom-5 ">
+                        <Button
+                            onClick={openCropModal}
+                            disabled={disabled}
+                            variant="outline"
+                            size="sm"
+                            className="w-2/4 bg-grey-moss-300 hover:bg-grey text-grey-eggshell"
+                        >
+                            Crop Image
+                        </Button>
+                    </div>
+                )}
+            </div>
+
+        </div>
+    )
+}
+
+export default PreviewImage;

--- a/components/TokenManagePage/ImageUpload/index.tsx
+++ b/components/TokenManagePage/ImageUpload/index.tsx
@@ -1,0 +1,3 @@
+import ImageUpload from "./ImageUpload";
+
+export default ImageUpload;

--- a/components/TokenManagePage/Media.tsx
+++ b/components/TokenManagePage/Media.tsx
@@ -1,42 +1,43 @@
 "use client";
+import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { getAddress } from "viem";
-
 import { useTokenProvider } from "@/providers/TokenProvider";
-import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import MediaSkeleton from "./MediaSkeleton";
+import ImageUpload from "./ImageUpload";
+import MediaButton from "./MediaButton";
 import useMediaConfig from "@/hooks/useMediaConfig";
 import { useUserProvider } from "@/providers/UserProvider";
 import { useCollectionProvider } from "@/providers/CollectionProvider";
+import { getFetchableUrl } from "@/lib/protocolSdk/ipfs/gateway";
 
 const Media = () => {
   const { collection } = useCollectionProvider();
   const { connectedAddress } = useUserProvider();
-
   const { metadata, token, owner } = useTokenProvider();
   const { data: meta, isLoading } = metadata;
-
-  const {
-    setMetadata,
-    generateNewMetadataFromToken,
-    isLoading: isSaving,
-  } = useMediaConfig();
-
+  const { setMetadata, generateNewMetadataFromToken, isLoading: isSaving, } = useMediaConfig();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [imageUri, setImageUri] = useState("");
+  const [originalImageUri, setOriginalImageUri] = useState("");
 
   useEffect(() => {
     if (!meta) return;
     if (!title) setTitle(meta.name || "");
     if (!description) setDescription(meta.description || "");
-  }, [meta, title, description]);
+    if (meta.image && !imageUri) {
+      const fetchableUrl = getFetchableUrl(meta.image);
+      if (fetchableUrl) {
+        setOriginalImageUri(fetchableUrl);
+        setImageUri(fetchableUrl);
+      }
+    }
+  }, [meta, title, description, imageUri]);
 
-  const isOwner = Boolean(
-    connectedAddress && owner &&
-    getAddress(connectedAddress) === getAddress(owner)
-  );
+  const isOwner = Boolean(connectedAddress && owner && getAddress(connectedAddress) === getAddress(owner));
 
   const onSave = async () => {
     if (!isOwner || !token || !collection) return;
@@ -47,11 +48,19 @@ const Media = () => {
         token.tokenId,
         title,
         description,
+        imageUri || originalImageUri,
       );
       await setMetadata(newUri);
       toast.success("Metadata updated successfully!");
     } catch (e) {
       toast.error("Failed to save metadata");
+    }
+  }
+
+  const handleImageChange = (newImageUri: string) => {
+    const fetchableUrl = getFetchableUrl(newImageUri);
+    if (fetchableUrl) {
+      setImageUri(fetchableUrl);
     }
   };
 
@@ -64,21 +73,12 @@ const Media = () => {
       <div className="bg-white rounded-lg shadow-sm p-6 max-w-md mt-4">
         <div className="space-y-4">
           <div>
-            <label className="font-archivo text-sm text-grey-moss-600 block mb-1">
-              title
-            </label>
-            <Input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="enter a title"
-            />
+            <label className="font-archivo text-sm text-grey-moss-600 block mb-1"> title</label>
+            <Input type="text" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="enter a title" />
           </div>
 
           <div>
-            <label className="font-archivo text-sm text-grey-moss-600 block mb-1">
-              description
-            </label>
+            <label className="font-archivo text-sm text-grey-moss-600 block mb-1">description</label>
             <Textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -87,19 +87,8 @@ const Media = () => {
               placeholder="enter a description"
             />
           </div>
-
-          <button
-            className="bg-black text-grey-eggshell w-fit px-8 py-2 rounded-md disabled:opacity-50"
-            onClick={onSave}
-            disabled={isLoading || isSaving || !isOwner}
-          >
-            {isSaving ? "saving..." : "Save"}
-          </button>
-          {!isOwner && (
-            <p className="text-xs text-grey-moss-500">
-              Only the contract owner can save changes.
-            </p>
-          )}
+          <ImageUpload initialImageUri={originalImageUri} onImageChange={handleImageChange} disabled={!isOwner} />
+          <MediaButton onSave={onSave} disabled={isLoading || isSaving || !isOwner} isSaving={isSaving} isOwner={isOwner} />
         </div>
       </div>
     </div>

--- a/components/TokenManagePage/MediaButton.tsx
+++ b/components/TokenManagePage/MediaButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { Fragment } from "react";
+
+interface MediaButtonProps {
+    onSave: () => void;
+    disabled: boolean;
+    isSaving: boolean;
+    isOwner: boolean;
+}
+
+
+const MediaButton = ({ onSave, disabled, isOwner, isSaving }: MediaButtonProps) => {
+    return (
+        <Fragment>
+            <button
+                className="bg-black text-grey-eggshell w-fit px-8 py-2 rounded-md disabled:opacity-50"
+                onClick={onSave}
+                disabled={disabled}
+            >
+                {isSaving ? "saving..." : "Save"}
+            </button>
+            {
+                !isOwner && (
+                    <p className="text-xs text-grey-moss-500">
+                        Only the contract owner can save changes.
+                    </p>
+                )
+            }
+        </Fragment>
+    )
+}
+
+export default MediaButton;

--- a/hooks/useMediaConfig.ts
+++ b/hooks/useMediaConfig.ts
@@ -47,11 +47,17 @@ const useMediaConfig = () => {
     tokenId: string,
     title: string,
     description: string,
+    image?: string,
   ): Promise<string> => {
     const tokenInfo = await getTokenInfo(collection, tokenId, chainId);
     const current = await fetchTokenMetadata(tokenInfo.tokenUri);
 
-    const updated = { ...(current || {}), name: title, description };
+    const updated = {
+      ...(current || {}),
+      name: title,
+      description,
+      ...(image && { image })
+    };
     return uploadJson(updated);
   };
 


### PR DESCRIPTION
ticket: https://linear.app/mycowtf/issue/MYC-2908/manage-page-media-tab-all-metadata-fields

<img width="1315" height="878" alt="image" src="https://github.com/user-attachments/assets/7dd5109a-2a92-4be9-a25d-cbb6ac433d6b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add image upload UI with preview, progress indicator, and 4:3 crop modal (Crop & Save) including upload-to-remote and local preview handling.
  - Add inline media save control with saving state and owner-only messaging; non-owners see disabled controls and notice.
  - Auto-convert and manage image URIs for smooth previewing and final metadata save; expose metadata save/generation utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->