### PR TITLE
UI : improve TimlineHero section ui for tablet screens

### DIFF
--- a/components/Timeline/TimelineHero.tsx
+++ b/components/Timeline/TimelineHero.tsx
@@ -8,21 +8,21 @@ interface TimelineHeroProps {
 
 const TimelineHero = ({ totalCount }: TimelineHeroProps) => {
   return (
-    <div className="pt-12 pb-4 md:flex md:justify-between md:items-start">
+    <div className="pt-12 pb-6 md:pt-16 md:pb-8 lg:pt-20 lg:pb-12 md:flex md:justify-between md:items-start md:gap-8 lg:gap-12">
       {/* Description Text - Centered on mobile, left on desktop */}
-      <div className="text-center md:text-left">
-        <h1 className="font-archivo text-2xl md:text-5xl tracking-[-1px] text-black">
+      <div className="text-center md:text-left md:flex-1 md:max-w-2xl">
+        <h1 className="font-archivo text-2xl md:text-4xl lg:text-5xl tracking-[-1px] text-black leading-tight">
           an onchain collective timeline
         </h1>
-        <p className="font-spectral-italic text-2xl md:text-5xl tracking-[-1px] text-black mt-1">
+        <p className="font-spectral-italic text-2xl md:text-4xl lg:text-5xl tracking-[-1px] text-black mt-1 md:mt-2 leading-tight">
           for artists
         </p>
       </div>
-      
+
       {/* Desktop: Moments Count + Create Button (Right side) */}
-      <div className="hidden md:flex flex-col items-end">
+      <div className="hidden md:flex flex-col items-end md:flex-shrink-0 md:min-w-fit">
         <MomentCount count={totalCount} />
-        <div className="mt-2">
+        <div className="mt-2 md:mt-3">
           <CreateButton />
         </div>
       </div>


### PR DESCRIPTION
ticket : https://linear.app/mycowtf/issue/MYC-2945/timeline-hero-section-improve-spacing-in-tablet-screen
improve timeline hero section ui for tablet screen by improve spacing 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined Timeline hero spacing across breakpoints with increased vertical padding and new horizontal gaps.
  - Adjusted responsive typography for headings and paragraphs with improved line-height and margins.
  - Left text block now scales responsively with a sensible maximum width.
  - Right column preserves its width on medium and larger screens with slight internal spacing tweaks.
  - Visual/UI updates only; no changes to behavior or public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->