### PR TITLE
use original video url as-is

### DIFF
--- a/lib/media/getStreamingUrl.ts
+++ b/lib/media/getStreamingUrl.ts
@@ -2,6 +2,7 @@ import { IN_PROCESS_API } from "@/lib/consts";
 
 const getStreamingUrl = (url: string) => {
   if (url.startsWith("blob:")) return url;
+  if (/^https?:\/\//i.test(url)) return url;
   return `${IN_PROCESS_API}/media/stream?url=${encodeURIComponent(url)}`;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External HTTP(S) URLs are now handled more efficiently by being returned directly instead of being rewritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->