### PR TITLE
connect and disconnect email in Farcaster mini app

### DIFF
--- a/components/ConnectEmail/ConnectButton.tsx
+++ b/components/ConnectEmail/ConnectButton.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+const ConnectButton = () => {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center justify-center gap-2 rounded-md bg-grey-moss-900 py-2 font-archivo text-grey-eggshell hover:bg-grey-eggshell hover:text-grey-moss-900 md:w-fit md:min-w-[150px]"
+    >
+      connect email
+    </button>
+  );
+};
+
+export default ConnectButton;

--- a/components/ConnectEmail/ConnectEmail.tsx
+++ b/components/ConnectEmail/ConnectEmail.tsx
@@ -4,30 +4,25 @@ import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useEmailVerificationProvider } from "@/providers/EmailVerificationProvider";
 import { EMAIL_VERIFICATION_STATUS } from "@/types/email";
-import EmailAddressInput from "./EmailAddressInput";
-import EmailCodeInput from "./EmailCodeInput";
+import EmailAddressInput from "../ManagePage/EmailAddressInput";
+import EmailCodeInput from "../ManagePage/EmailCodeInput";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
-import DisconnectButton from "../ExternalWalletButton/DisconnectButton";
+import DisconnectButton from "./DisconnectButton";
 import { Fragment } from "react";
+import ConnectButton from "./ConnectButton";
 
-const ConnectEmailButton = () => {
+const ConnectEmail = () => {
   const { isDialogOpen, setIsDialogOpen, status } = useEmailVerificationProvider();
-  const { hasEOA, primaryWallet } = useWalletsProvider();
+  const { primaryWallet, wallets } = useWalletsProvider();
+  const privy = wallets.find((w) => w.type === "privy");
 
   if (!primaryWallet) return <Fragment />;
-  if (hasEOA) {
-    return <DisconnectButton label="disconnect email" />;
-  }
+  if (Boolean(privy)) return <DisconnectButton />;
 
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger asChild>
-        <button
-          type="button"
-          className="flex w-full items-center justify-center gap-2 rounded-md bg-grey-moss-900 py-2 font-archivo text-grey-eggshell hover:bg-grey-eggshell hover:text-grey-moss-900 md:w-fit md:min-w-[150px]"
-        >
-          connect email
-        </button>
+        <ConnectButton />
       </DialogTrigger>
       <DialogContent className="flex max-w-xl flex-col items-center !gap-0 overflow-hidden !rounded-3xl border-none !bg-white bg-transparent px-8 py-10 shadow-lg">
         <VisuallyHidden>
@@ -45,4 +40,4 @@ const ConnectEmailButton = () => {
   );
 };
 
-export default ConnectEmailButton;
+export default ConnectEmail;

--- a/components/ConnectEmail/DisconnectButton.tsx
+++ b/components/ConnectEmail/DisconnectButton.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import DisconnectButton from "@/components/ExternalWalletButton/DisconnectButton";
+
+const EmailDisconnectButton = () => <DisconnectButton label="disconnect email" />;
+
+export default EmailDisconnectButton;

--- a/components/ConnectEmail/index.tsx
+++ b/components/ConnectEmail/index.tsx
@@ -1,0 +1,3 @@
+import ConnectEmail from "./ConnectEmail";
+
+export default ConnectEmail;

--- a/components/ExternalWalletButton/DisconnectButton.tsx
+++ b/components/ExternalWalletButton/DisconnectButton.tsx
@@ -6,7 +6,7 @@ import disconnectWallet from "@/lib/wallets/disconnectWallet";
 import { useState } from "react";
 import { Address } from "viem";
 
-const DisconnectButton = ({ label = "disconnect" }: { label?: string }) => {
+const DisconnectButton = ({ label = "disconnect wallet" }: { label?: string }) => {
   const { refetchWallets, primaryWallet } = useWalletsProvider();
   const { authorization } = useAuthorizationProvider();
   const [isLoading, setIsLoading] = useState(false);

--- a/components/ManagePage/AccountPage.tsx
+++ b/components/ManagePage/AccountPage.tsx
@@ -2,8 +2,7 @@
 
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import { useMiniAppProvider } from "@/providers/MiniAppProvider";
-import ExternalWalletButton from "../ExternalWalletButton";
-import ConnectEmailButton from "./ConnectEmailButton";
+import ExternalWalletButton from "@/components/ExternalWalletButton";
 import PhoneButton from "./PhoneButton";
 import { PhoneVerificationProvider } from "@/providers/PhoneVerificationProvider";
 import { EmailVerificationProvider } from "@/providers/EmailVerificationProvider";
@@ -11,6 +10,7 @@ import AccountPageSkeleton from "./AccountPageSkeleton";
 import SignToInProcess from "./SignToInProcess";
 import ProfileForm from "./ProfileForm";
 import useUpdateProfile from "@/hooks/useUpdateProfile";
+import ConnectEmail from "@/components/ConnectEmail";
 
 const AccountPage = () => {
   const { isMiniApp } = useMiniAppProvider();
@@ -29,7 +29,7 @@ const AccountPage = () => {
         </PhoneVerificationProvider>
         {isMiniApp ? (
           <EmailVerificationProvider>
-            <ConnectEmailButton />
+            <ConnectEmail />
           </EmailVerificationProvider>
         ) : (
           <ExternalWalletButton />

--- a/hooks/useEmailVerify.ts
+++ b/hooks/useEmailVerify.ts
@@ -4,11 +4,12 @@ import { EMAIL_VERIFICATION_STATUS } from "@/types/email";
 import sendCode from "@/lib/oauth/sendCode";
 import loginWithOtp from "@/lib/oauth/loginWithOtp";
 import { useUserProvider } from "@/providers/UserProvider";
-import updateProfile from "@/lib/artists/updateProfile";
-import { useMiniAppProvider } from "@/providers/MiniAppProvider";
+import connectEOA from "@/lib/wallets/connectEOA";
+import { buildWalletConnectMessage } from "@/lib/wallets/buildWalletConnectMessage";
+import { useWalletClient } from "wagmi";
+import { Address } from "viem";
 
 export const useEmailVerify = () => {
-  const { context } = useMiniAppProvider();
   const [email, setEmail] = useState<string>("");
   const [code, setCode] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -17,6 +18,7 @@ export const useEmailVerify = () => {
     EMAIL_VERIFICATION_STATUS.ENTER_EMAIL
   );
   const { signedAddress: farcasterAddress } = useUserProvider();
+  const { data: walletClient } = useWalletClient();
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -50,9 +52,13 @@ export const useEmailVerify = () => {
     try {
       const { token } = await loginWithOtp(email.trim(), code.trim());
       if (!farcasterAddress) throw new Error("No Farcaster wallet found");
-      await updateProfile({
+      if (!walletClient) throw new Error("No wallet client found");
+      const message = buildWalletConnectMessage(farcasterAddress as Address, "farcaster");
+      const signature = await walletClient.signMessage({ message });
+      await connectEOA({
         authHeaders: { Authorization: `Bearer ${token}` },
-        username: context?.user?.displayName || undefined,
+        message,
+        signature,
       });
       setStatus(EMAIL_VERIFICATION_STATUS.VERIFIED);
       if (closeTimerRef.current) clearTimeout(closeTimerRef.current);

--- a/hooks/useWallets.ts
+++ b/hooks/useWallets.ts
@@ -2,9 +2,11 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useUserProvider } from "@/providers/UserProvider";
 import getArtistWallets from "@/lib/wallets/getArtistWallets";
+import { useMiniAppProvider } from "@/providers/MiniAppProvider";
 
 const useWallets = () => {
   const { userId, userReady, signedAddress } = useUserProvider();
+  const { isMiniApp } = useMiniAppProvider();
 
   const {
     data: wallets = [],
@@ -23,9 +25,11 @@ const useWallets = () => {
     const eoa = wallets.find((w) => w.type === "external");
     return {
       hasEOA: Boolean(eoa),
-      primaryWallet: (eoa?.address ?? signedAddress) as typeof signedAddress,
+      primaryWallet: (isMiniApp
+        ? signedAddress
+        : (eoa?.address ?? signedAddress)) as typeof signedAddress,
     };
-  }, [wallets, signedAddress]);
+  }, [wallets, signedAddress, isMiniApp]);
 
   return {
     wallets,


### PR DESCRIPTION
- useWallets: primaryWallet falls back to signedAddress when isMiniApp
- useEmailVerify: verify OTP then sign wallet-connect message via wagmi and call connectEOA
- DisconnectButton: accept label prop; ConnectEmail/DisconnectButton reuses it with "disconnect email"
- AccountPage: replace ConnectEmailButton with new ConnectEmail component