### PR TITLE
set content.uri to animation_url for audio moments

### DIFF
--- a/hooks/useMetadataUpload.ts
+++ b/hooks/useMetadataUpload.ts
@@ -90,8 +90,9 @@ const useMetadataUpload = () => {
 
       const isPdf = mimeType.includes("pdf");
       const isImage = mimeType.includes("image");
+      const isAudio = mimeType.includes("audio");
       const isModel = isModelGltfLike(mimeType, animationFile?.name ?? null);
-      if ((isPdf || isImage) && animation_url) {
+      if ((isPdf || isImage || isAudio) && animation_url) {
         contentUri = animation_url;
       }
       if (isModel && animation_url) {


### PR DESCRIPTION
## Summary
- Audio files now populate `content.uri` with the same Arweave URI as `animation_url`, consistent with how PDF and image files behave

## Test plan
- [ ] Upload an audio moment and verify `content.uri` matches `animation_url` in the generated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio files are now properly handled when uploading metadata, ensuring consistent processing alongside PDF and image files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->