### PR TITLE
fix: auto-select first collection when none is chosen

### DIFF
--- a/hooks/useCollections.ts
+++ b/hooks/useCollections.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useSearchParams } from "next/navigation";
 import { fetchCollections } from "@/lib/collections/fetchCollections";
@@ -24,8 +24,17 @@ export function useCollections() {
     staleTime: 60_000,
   });
 
+  const collections = query.data?.collections ?? [];
+
+  useEffect(() => {
+    if (selectedCollection) return;
+    const loadedCollections = query.data?.collections;
+    if (!loadedCollections?.length) return;
+    setSelectedCollection(loadedCollections[0].address);
+  }, [selectedCollection, query.data?.collections]);
+
   return {
-    collections: query.data?.collections ?? [],
+    collections,
     isLoading: query.isLoading || query.isPending,
     error: query.error instanceof Error ? query.error : null,
     selectedCollection,


### PR DESCRIPTION
## Summary
- Automatically select the first loaded collection in `useCollections` when no collection is already chosen
- Preserves existing behavior when a collection address is provided via URL params or route params

## Test plan
- [ ] Open the create page with a wallet that has collections and confirm the dropdown shows the first collection selected by default
- [ ] Confirm "Please select a collection" no longer appears after collections finish loading
- [ ] Open a page with `?collectionAddress=...` and confirm that collection remains selected
- [ ] Verify moment creation uses the auto-selected collection without manual selection


Made with [Cursor](https://cursor.com)