### PR TITLE
feat: bulk upload create flow

### DIFF
--- a/app/create/success/page.tsx
+++ b/app/create/success/page.tsx
@@ -1,7 +1,18 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import CreateSuccess from "@/components/CreateSuccess";
+import BatchSuccess from "@/components/CreateSuccess/BatchSuccess";
 
-const Success = () => <CreateSuccess />;
+const Success = () => {
+  const searchParams = useSearchParams();
+  const isBatch = searchParams.has("tokenIds");
+
+  if (isBatch) {
+    return <BatchSuccess />;
+  }
+
+  return <CreateSuccess />;
+};
 
 export default Success;

--- a/components/BulkUpload/BulkCenterGrid.tsx
+++ b/components/BulkUpload/BulkCenterGrid.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import useBulkCenterGrid from "@/hooks/useBulkCenterGrid";
+import BulkFileCard from "./BulkFileCard";
+
+const BulkCenterGrid = () => {
+  const { bulkItems, removeFile, setItemName, isCreating, inputRef, onChange } =
+    useBulkCenterGrid();
+
+  return (
+    <div className="md:min-h-auto relative min-h-[400px] w-full overflow-y-auto bg-[url('/grid.svg')] bg-contain p-3 md:aspect-[571/692]">
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        accept="image/*,video/*,.pdf,audio/*,.glb,.gltf"
+        className="hidden"
+        onChange={onChange}
+      />
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {bulkItems.map((item) => (
+          <BulkFileCard
+            key={item.id}
+            item={item}
+            onRemove={removeFile}
+            onNameChange={setItemName}
+            isCreating={isCreating}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default BulkCenterGrid;

--- a/components/BulkUpload/BulkCreateButton.tsx
+++ b/components/BulkUpload/BulkCreateButton.tsx
@@ -12,7 +12,7 @@ const BulkCreateButton = () => {
   const label = isCreating
     ? uploadingCount > 0
       ? `uploading ${doneCount + 1} of ${count}...`
-      : "minting onchain..."
+      : "creating..."
     : `create ${count} moment${count !== 1 ? "s" : ""}`;
 
   return (

--- a/components/BulkUpload/BulkCreateButton.tsx
+++ b/components/BulkUpload/BulkCreateButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+
+const BulkCreateButton = () => {
+  const { bulkItems, createBatch, isCreating } = useBulkCreateProvider();
+  const count = bulkItems.length;
+  const allNamed = bulkItems.every((i) => i.name.trim());
+  const uploadingCount = bulkItems.filter((i) => i.status === "uploading").length;
+  const doneCount = bulkItems.filter((i) => i.status === "done").length;
+
+  const label = isCreating
+    ? uploadingCount > 0
+      ? `uploading ${doneCount + 1} of ${count}...`
+      : "minting onchain..."
+    : `create ${count} moment${count !== 1 ? "s" : ""}`;
+
+  return (
+    <button
+      type="button"
+      onClick={createBatch}
+      disabled={isCreating || !allNamed || count === 0}
+      className="w-full rounded-sm bg-grey-moss-900 py-3 font-archivo text-lg text-grey-eggshell transition-colors hover:bg-grey-moss-700 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {label}
+    </button>
+  );
+};
+
+export default BulkCreateButton;

--- a/components/BulkUpload/BulkDropZone.tsx
+++ b/components/BulkUpload/BulkDropZone.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import useBulkDropZone from "@/hooks/useBulkDropZone";
+
+interface BulkDropZoneProps {
+  onSingleFile: (file: File) => void;
+}
+
+const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
+  const { isDragging, inputRef, onDrop, onDragOver, onDragLeave, onChange, openFileDialog } =
+    useBulkDropZone(onSingleFile);
+
+  return (
+    <div
+      onDrop={onDrop}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onClick={openFileDialog}
+      className={`group relative flex h-full min-h-[320px] w-full cursor-pointer flex-col items-center justify-center gap-5 rounded-2xl border-2 border-dashed transition-all duration-200 ${
+        isDragging
+          ? "scale-[1.01] border-grey-moss-700 bg-grey-moss-200"
+          : "border-grey-moss-400 bg-grey-moss-100 hover:border-grey-moss-600 hover:bg-grey-moss-150"
+      }`}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        accept="image/*,video/*,.pdf,audio/*,.glb,.gltf"
+        className="hidden"
+        onChange={onChange}
+      />
+
+      <div
+        className={`flex size-16 items-center justify-center rounded-full border-2 transition-all duration-200 ${
+          isDragging ? "border-grey-moss-700 bg-grey-moss-300" : "border-grey-moss-400 bg-white"
+        }`}
+      >
+        <svg
+          width="28"
+          height="28"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={`transition-colors ${isDragging ? "text-grey-moss-900" : "text-grey-moss-500"}`}
+        >
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="17 8 12 3 7 8" />
+          <line x1="12" y1="3" x2="12" y2="15" />
+        </svg>
+      </div>
+
+      <div className="flex flex-col items-center gap-2 px-6 text-center">
+        <p className="font-archivo-medium text-lg text-grey-moss-800">drop files here</p>
+        <p className="font-archivo text-sm text-grey-moss-500">or click to browse</p>
+        <p className="mt-1 font-archivo text-xs text-grey-moss-400">
+          images · video · PDF · audio · 3D
+        </p>
+        <p className="font-archivo text-xs text-grey-moss-400">
+          drop <span className="font-archivo-medium text-grey-moss-600">multiple files</span> to
+          bulk mint
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default BulkDropZone;

--- a/components/BulkUpload/BulkFileCard.tsx
+++ b/components/BulkUpload/BulkFileCard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Image from "next/image";
+import { BulkItem } from "@/types/bulk";
+
+interface BulkFileCardProps {
+  item: BulkItem;
+  onRemove: (id: string) => void;
+  onNameChange: (id: string, name: string) => void;
+  isCreating: boolean;
+}
+
+const statusColor: Record<BulkItem["status"], string> = {
+  idle: "border-grey-moss-300",
+  uploading: "border-blue-400",
+  done: "border-green-400",
+  error: "border-red-400",
+};
+
+const BulkFileCard = ({ item, onRemove, onNameChange, isCreating }: BulkFileCardProps) => {
+  return (
+    <div
+      className={`relative flex flex-col overflow-hidden rounded-lg border-2 bg-grey-moss-100 transition-colors ${statusColor[item.status]}`}
+    >
+      {!isCreating && (
+        <button
+          type="button"
+          onClick={() => onRemove(item.id)}
+          className="absolute right-1.5 top-1.5 z-10 flex size-5 items-center justify-center rounded-full bg-grey-moss-900 text-white hover:bg-red-500"
+          aria-label="Remove"
+        >
+          ×
+        </button>
+      )}
+
+      <div className="relative aspect-square w-full overflow-hidden bg-grey-moss-200">
+        {item.previewUrl ? (
+          <Image src={item.previewUrl} alt={item.name} fill className="object-cover" unoptimized />
+        ) : (
+          <div className="flex size-full items-center justify-center text-2xl text-grey-moss-400">
+            {item.mimeType.includes("pdf") ? "PDF" : item.mimeType.includes("audio") ? "♪" : "?"}
+          </div>
+        )}
+
+        {item.status === "uploading" && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/50">
+            <div className="mb-1.5 h-1.5 w-3/4 overflow-hidden rounded-full bg-grey-moss-300">
+              <div
+                className="h-full bg-white transition-all duration-300"
+                style={{ width: `${item.progress}%` }}
+              />
+            </div>
+            <span className="font-archivo text-xs text-white">{item.progress}%</span>
+          </div>
+        )}
+
+        {item.status === "done" && (
+          <div className="absolute inset-0 flex items-center justify-center bg-green-500/20">
+            <span className="text-2xl">✓</span>
+          </div>
+        )}
+
+        {item.status === "error" && (
+          <div className="absolute inset-0 flex items-center justify-center bg-red-500/20">
+            <span className="font-archivo text-xs text-red-600">{item.error || "Error"}</span>
+          </div>
+        )}
+      </div>
+
+      <input
+        type="text"
+        value={item.name}
+        onChange={(e) => onNameChange(item.id, e.target.value)}
+        disabled={isCreating}
+        placeholder="name"
+        className="w-full border-t border-grey-moss-300 bg-transparent px-2 py-1.5 font-archivo text-xs text-grey-moss-900 placeholder-grey-moss-400 outline-none focus:bg-white disabled:opacity-60"
+      />
+    </div>
+  );
+};
+
+export default BulkFileCard;

--- a/components/BulkUpload/BulkFileCard.tsx
+++ b/components/BulkUpload/BulkFileCard.tsx
@@ -2,6 +2,8 @@
 
 import Image from "next/image";
 import { BulkItem } from "@/types/bulk";
+import { getStatusClass } from "@/lib/bulkUpload/getStatusClass";
+import { getMimeTypeIcon } from "@/lib/bulkUpload/getMimeTypeIcon";
 
 interface BulkFileCardProps {
   item: BulkItem;
@@ -10,17 +12,10 @@ interface BulkFileCardProps {
   isCreating: boolean;
 }
 
-const statusColor: Record<BulkItem["status"], string> = {
-  idle: "border-grey-moss-300",
-  uploading: "border-blue-400",
-  done: "border-green-400",
-  error: "border-red-400",
-};
-
 const BulkFileCard = ({ item, onRemove, onNameChange, isCreating }: BulkFileCardProps) => {
   return (
     <div
-      className={`relative flex flex-col overflow-hidden rounded-lg border-2 bg-grey-moss-100 transition-colors ${statusColor[item.status]}`}
+      className={`relative flex flex-col overflow-hidden rounded-lg border-2 bg-grey-moss-100 transition-colors ${getStatusClass(item.status)}`}
     >
       {!isCreating && (
         <button
@@ -38,7 +33,7 @@ const BulkFileCard = ({ item, onRemove, onNameChange, isCreating }: BulkFileCard
           <Image src={item.previewUrl} alt={item.name} fill className="object-cover" unoptimized />
         ) : (
           <div className="flex size-full items-center justify-center text-2xl text-grey-moss-400">
-            {item.mimeType.includes("pdf") ? "PDF" : item.mimeType.includes("audio") ? "♪" : "?"}
+            {getMimeTypeIcon(item.mimeType)}
           </div>
         )}
 

--- a/components/BulkUpload/BulkSideForm.tsx
+++ b/components/BulkUpload/BulkSideForm.tsx
@@ -25,9 +25,9 @@ const BulkSideForm = () => {
           {bulkItems.length} file{bulkItems.length !== 1 ? "s" : ""} selected
         </p>
 
-        <Collections onCreateNew={openModal} />
+        <Collections onCreateNew={openModal} disabled={isCreating} />
 
-        <Price />
+        <Price disabled={isCreating} />
 
         <input
           ref={inputRef}

--- a/components/BulkUpload/BulkSideForm.tsx
+++ b/components/BulkUpload/BulkSideForm.tsx
@@ -25,9 +25,9 @@ const BulkSideForm = () => {
           {bulkItems.length} file{bulkItems.length !== 1 ? "s" : ""} selected
         </p>
 
-        <Collections onCreateNew={openModal} disabled={isCreating} />
+        <Collections onCreateNew={openModal} />
 
-        <Price disabled={isCreating} />
+        <Price />
 
         <input
           ref={inputRef}

--- a/components/BulkUpload/BulkSideForm.tsx
+++ b/components/BulkUpload/BulkSideForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useRef } from "react";
+import Collections from "@/components/Collections";
+import Price from "@/components/CreateForm/Price";
+import { useCreateCollectionModalTriggerProvider } from "@/providers/CollectionCreateProvider/CreateCollectionModalTriggerProvider";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+import BulkCreateButton from "./BulkCreateButton";
+
+const BulkSideForm = () => {
+  const { openModal } = useCreateCollectionModalTriggerProvider();
+  const { bulkItems, addFiles, clearAll, isCreating } = useBulkCreateProvider();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleAddMore = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length > 0) await addFiles(files);
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  return (
+    <div className="col-span-1 w-full md:pl-12">
+      <div className="flex h-fit flex-col space-y-3 pb-4">
+        <p className="font-archivo text-sm text-grey-moss-500">
+          {bulkItems.length} file{bulkItems.length !== 1 ? "s" : ""} selected
+        </p>
+
+        <Collections onCreateNew={openModal} />
+
+        <Price />
+
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept="image/*,video/*,.pdf,audio/*,.glb,.gltf"
+          className="hidden"
+          onChange={handleAddMore}
+        />
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            disabled={isCreating}
+            className="flex-1 rounded-sm border border-grey-moss-400 py-2 font-archivo text-sm text-grey-moss-700 hover:bg-grey-moss-200 disabled:opacity-50"
+          >
+            + add more
+          </button>
+          <button
+            type="button"
+            onClick={clearAll}
+            disabled={isCreating}
+            className="flex-1 rounded-sm border border-grey-moss-400 py-2 font-archivo text-sm text-grey-moss-700 hover:bg-grey-moss-200 disabled:opacity-50"
+          >
+            clear all
+          </button>
+        </div>
+
+        <BulkCreateButton />
+      </div>
+    </div>
+  );
+};
+
+export default BulkSideForm;

--- a/components/BulkUpload/index.tsx
+++ b/components/BulkUpload/index.tsx
@@ -1,0 +1,5 @@
+import BulkDropZone from "./BulkDropZone";
+import BulkCenterGrid from "./BulkCenterGrid";
+import BulkSideForm from "./BulkSideForm";
+
+export { BulkDropZone, BulkCenterGrid, BulkSideForm };

--- a/components/Collections/Collections.tsx
+++ b/components/Collections/Collections.tsx
@@ -7,14 +7,15 @@ import CollectionsDropdown from "./CollectionsDropdown";
 interface CollectionsProps {
   onCreateNew?: () => void;
   onSelect?: (collection: CollectionItem) => void;
+  disabled?: boolean;
 }
 
-const Collections = ({ onCreateNew, onSelect }: CollectionsProps) => (
+const Collections = ({ onCreateNew, onSelect, disabled }: CollectionsProps) => (
   <div className="flex w-full flex-col items-start gap-2">
     <Label htmlFor="collection" className="text-md font-archivo">
       collection
     </Label>
-    <CollectionsDropdown onCreateNew={onCreateNew} onSelect={onSelect} />
+    <CollectionsDropdown onCreateNew={onCreateNew} onSelect={onSelect} disabled={disabled} />
   </div>
 );
 

--- a/components/Collections/CollectionsDropdown.tsx
+++ b/components/Collections/CollectionsDropdown.tsx
@@ -20,9 +20,10 @@ import { useCollectionsDropdown } from "@/hooks/useCollectionsDropdown";
 interface CollectionsDropdownProps {
   onSelect?: (collection: CollectionItem) => void;
   onCreateNew?: () => void;
+  disabled?: boolean;
 }
 
-const CollectionsDropdown = ({ onSelect, onCreateNew }: CollectionsDropdownProps) => {
+const CollectionsDropdown = ({ onSelect, onCreateNew, disabled }: CollectionsDropdownProps) => {
   const {
     open,
     handleOpenChange,
@@ -43,7 +44,8 @@ const CollectionsDropdown = ({ onSelect, onCreateNew }: CollectionsDropdownProps
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="h-9 w-full justify-between rounded-[0px] border border-grey bg-white !font-spectral !ring-0 !ring-offset-0"
+          disabled={disabled}
+          className="h-9 w-full justify-between rounded-[0px] border border-grey bg-white !font-spectral !ring-0 !ring-offset-0 disabled:opacity-50"
         >
           <div className="flex items-center gap-2">
             {isLoading || !currentCollection ? (

--- a/components/CreateForm/CurrencySelect.tsx
+++ b/components/CreateForm/CurrencySelect.tsx
@@ -3,14 +3,14 @@
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 
-export default function CurrencySelect() {
+export default function CurrencySelect({ disabled }: { disabled?: boolean }) {
   const { form } = useMetadataFormProvider();
   const { creating } = useMomentCreateProvider();
 
   return (
     <select
       {...form.register("priceUnit")}
-      disabled={Boolean(creating)}
+      disabled={Boolean(creating) || disabled}
       className="h-auto min-w-[70px] cursor-pointer appearance-none !rounded-[0px] !border-none bg-white px-3 py-0 text-center font-spectral focus-visible:ring-0 focus-visible:ring-offset-0"
     >
       <option value="eth">ETH</option>

--- a/components/CreateForm/CurrencySelect.tsx
+++ b/components/CreateForm/CurrencySelect.tsx
@@ -2,15 +2,17 @@
 
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
 
-export default function CurrencySelect({ disabled }: { disabled?: boolean }) {
+export default function CurrencySelect() {
   const { form } = useMetadataFormProvider();
   const { creating } = useMomentCreateProvider();
+  const { isCreating } = useBulkCreateProvider();
 
   return (
     <select
       {...form.register("priceUnit")}
-      disabled={Boolean(creating) || disabled}
+      disabled={Boolean(creating) || isCreating}
       className="h-auto min-w-[70px] cursor-pointer appearance-none !rounded-[0px] !border-none bg-white px-3 py-0 text-center font-spectral focus-visible:ring-0 focus-visible:ring-offset-0"
     >
       <option value="eth">ETH</option>

--- a/components/CreateForm/Price.tsx
+++ b/components/CreateForm/Price.tsx
@@ -6,9 +6,10 @@ import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import CurrencySelect from "./CurrencySelect";
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
 
-export default function Price() {
+export default function Price({ disabled }: { disabled?: boolean }) {
   const { form } = useMetadataFormProvider();
   const { creating } = useMomentCreateProvider();
+  const isDisabled = Boolean(creating) || disabled;
 
   return (
     <div className="w-full pt-2">
@@ -34,12 +35,12 @@ export default function Price() {
             e.currentTarget.blur();
           }}
           className="flex-grow !rounded-[0px] !border-none bg-white !font-spectral [appearance:textfield] focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-          disabled={Boolean(creating)}
+          disabled={isDisabled}
         />
         <div className="bg-white">
           <div className="my-2 h-6 w-[1px] bg-grey-secondary" />
         </div>
-        <CurrencySelect />
+        <CurrencySelect disabled={disabled} />
       </div>
       {form.formState.errors.price && (
         <p className="mt-1 font-spectral text-xs text-red-500">

--- a/components/CreateForm/Price.tsx
+++ b/components/CreateForm/Price.tsx
@@ -5,11 +5,13 @@ import { Label } from "@/components/ui/label";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import CurrencySelect from "./CurrencySelect";
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
 
-export default function Price({ disabled }: { disabled?: boolean }) {
+export default function Price() {
   const { form } = useMetadataFormProvider();
   const { creating } = useMomentCreateProvider();
-  const isDisabled = Boolean(creating) || disabled;
+  const { isCreating } = useBulkCreateProvider();
+  const isDisabled = Boolean(creating) || isCreating;
 
   return (
     <div className="w-full pt-2">
@@ -40,7 +42,7 @@ export default function Price({ disabled }: { disabled?: boolean }) {
         <div className="bg-white">
           <div className="my-2 h-6 w-[1px] bg-grey-secondary" />
         </div>
-        <CurrencySelect disabled={disabled} />
+        <CurrencySelect />
       </div>
       {form.formState.errors.price && (
         <p className="mt-1 font-spectral text-xs text-red-500">

--- a/components/CreateSuccess/BatchSuccess.tsx
+++ b/components/CreateSuccess/BatchSuccess.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import useBatchSuccess from "@/hooks/useBatchSuccess";
+import BatchSuccessCard from "./BatchSuccessCard";
+
+const BatchSuccess = () => {
+  const {
+    result,
+    contractAddress,
+    tokenIds,
+    items,
+    handleCreateMore,
+    handleViewCollection,
+    handleCopyAll,
+  } = useBatchSuccess();
+
+  if (!result) return null;
+
+  return (
+    <div className="col-span-3 flex w-full flex-col gap-6 pb-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="font-archivo-medium text-2xl md:text-4xl">
+            {tokenIds.length} moment{tokenIds.length !== 1 ? "s" : ""} created
+          </p>
+          <p className="font-archivo text-sm text-grey-moss-500">{new Date().toLocaleString()}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleCopyAll}
+            className="rounded-sm border border-grey-moss-400 px-4 py-2 font-archivo text-sm text-grey-moss-700 hover:bg-grey-moss-200"
+          >
+            copy all links
+          </button>
+          <button
+            type="button"
+            onClick={handleViewCollection}
+            className="rounded-sm border border-grey-moss-900 bg-grey-moss-100 px-4 py-2 font-archivo text-sm text-grey-moss-900 hover:bg-grey-moss-200"
+          >
+            view collection
+          </button>
+          <button
+            type="button"
+            onClick={handleCreateMore}
+            className="rounded-sm bg-grey-moss-900 px-4 py-2 font-archivo text-sm text-grey-eggshell hover:bg-grey-moss-700"
+          >
+            create more
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        {items.map((item, idx) => (
+          <BatchSuccessCard
+            key={item.tokenId || idx}
+            name={item.name}
+            previewUrl={item.previewUrl}
+            tokenId={item.tokenId}
+            contractAddress={contractAddress}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default BatchSuccess;

--- a/components/CreateSuccess/BatchSuccess.tsx
+++ b/components/CreateSuccess/BatchSuccess.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import useBatchSuccess from "@/hooks/useBatchSuccess";
 import BatchSuccessCard from "./BatchSuccessCard";
 
@@ -9,59 +10,79 @@ const BatchSuccess = () => {
     contractAddress,
     tokenIds,
     items,
+    collectionName,
+    collectionDescription,
     handleCreateMore,
-    handleViewCollection,
-    handleCopyAll,
+    handleShare,
   } = useBatchSuccess();
 
   if (!result) return null;
 
   return (
-    <div className="col-span-3 flex w-full flex-col gap-6 pb-8">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <p className="font-archivo-medium text-2xl md:text-4xl">
-            {tokenIds.length} moment{tokenIds.length !== 1 ? "s" : ""} created
-          </p>
-          <p className="font-archivo text-sm text-grey-moss-500">{new Date().toLocaleString()}</p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={handleCopyAll}
-            className="rounded-sm border border-grey-moss-400 px-4 py-2 font-archivo text-sm text-grey-moss-700 hover:bg-grey-moss-200"
-          >
-            copy all links
-          </button>
-          <button
-            type="button"
-            onClick={handleViewCollection}
-            className="rounded-sm border border-grey-moss-900 bg-grey-moss-100 px-4 py-2 font-archivo text-sm text-grey-moss-900 hover:bg-grey-moss-200"
-          >
-            view collection
-          </button>
-          <button
-            type="button"
-            onClick={handleCreateMore}
-            className="rounded-sm bg-grey-moss-900 px-4 py-2 font-archivo text-sm text-grey-eggshell hover:bg-grey-moss-700"
-          >
-            create more
-          </button>
+    <>
+      <div className="col-span-1 h-fit">
+        <div className="flex w-full items-end gap-3">
+          <div className="relative w-full">
+            <p className="font-archivo-medium text-2xl md:text-4xl xl:text-5xl">
+              {tokenIds.length} moment{tokenIds.length !== 1 ? "s" : ""} created
+            </p>
+            <p className="font-archivo text-sm text-grey-moss-500">{new Date().toLocaleString()}</p>
+            <div className="relative flex flex-col gap-4 pr-4 pt-4 md:gap-2">
+              <div className="absolute -right-10 bottom-0 hidden aspect-[1/1] w-1/2 md:block">
+                <Image
+                  src="/semi-transparent.png"
+                  alt=""
+                  layout="fill"
+                  objectFit="cover"
+                  objectPosition="center"
+                />
+              </div>
+              <div className="relative flex flex-col gap-4 md:flex-row md:gap-2">
+                <button
+                  type="button"
+                  onClick={handleCreateMore}
+                  className="relative w-full rounded-sm bg-grey-moss-900 py-2 font-archivo text-2xl text-grey-eggshell hover:bg-grey-moss-300"
+                >
+                  create more
+                </button>
+                <button
+                  type="button"
+                  onClick={handleShare}
+                  className="relative w-full rounded-sm border border-grey-moss-900 bg-grey-moss-100 py-2 font-archivo text-2xl text-grey-moss-900 hover:border-grey-moss-300 hover:bg-grey-moss-300 hover:text-grey-eggshell"
+                >
+                  share
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-        {items.map((item, idx) => (
-          <BatchSuccessCard
-            key={item.tokenId || idx}
-            name={item.name}
-            previewUrl={item.previewUrl}
-            tokenId={item.tokenId}
-            contractAddress={contractAddress}
-          />
-        ))}
+      <div className="col-span-1">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {items.map((item, idx) => (
+            <BatchSuccessCard
+              key={item.tokenId || idx}
+              name={item.name}
+              previewUrl={item.previewUrl}
+              tokenId={item.tokenId}
+              contractAddress={contractAddress}
+            />
+          ))}
+        </div>
       </div>
-    </div>
+
+      <div className="col-span-1 w-full md:pl-12">
+        <p className="text-center font-archivo-medium text-2xl md:text-left md:text-4xl">
+          {collectionName}
+        </p>
+        {collectionDescription && (
+          <p className="!m-0 text-center font-archivo text-sm text-grey-moss-500 md:text-left">
+            {collectionDescription}
+          </p>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/components/CreateSuccess/BatchSuccessCard.tsx
+++ b/components/CreateSuccess/BatchSuccessCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { CHAIN, SITE_ORIGINAL_URL } from "@/lib/consts";
+import { getShortNetworkName } from "@/lib/zora/zoraToViem";
+
+interface BatchSuccessCardProps {
+  name: string;
+  previewUrl: string;
+  tokenId: string;
+  contractAddress: string;
+}
+
+const BatchSuccessCard = ({
+  name,
+  previewUrl,
+  tokenId,
+  contractAddress,
+}: BatchSuccessCardProps) => {
+  const shortNetwork = getShortNetworkName(CHAIN.name.toLowerCase());
+  const momentUrl = `${SITE_ORIGINAL_URL}/collect/${shortNetwork}:${contractAddress}/${tokenId}`;
+
+  return (
+    <Link
+      href={momentUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col overflow-hidden rounded-lg border border-grey-moss-300 bg-grey-moss-100 transition-shadow hover:shadow-md"
+    >
+      <div className="relative aspect-square w-full overflow-hidden bg-grey-moss-200">
+        {previewUrl ? (
+          <Image
+            src={previewUrl}
+            alt={name}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            unoptimized
+          />
+        ) : (
+          <div className="flex size-full items-center justify-center text-grey-moss-400">
+            <span className="font-archivo text-2xl">✓</span>
+          </div>
+        )}
+        <div className="absolute inset-0 flex items-center justify-center bg-green-500/10 opacity-0 transition-opacity group-hover:opacity-100">
+          <span className="rounded-full bg-white/90 px-2 py-1 font-archivo text-xs text-grey-moss-900">
+            view →
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-0.5 px-2 py-2">
+        <p className="truncate font-archivo-medium text-xs text-grey-moss-900">{name}</p>
+        <p className="font-archivo text-xs text-grey-moss-500">#{tokenId}</p>
+      </div>
+    </Link>
+  );
+};
+
+export default BatchSuccessCard;

--- a/components/MetadataCreation/FileSelect.tsx
+++ b/components/MetadataCreation/FileSelect.tsx
@@ -1,62 +1,21 @@
 "use client";
 
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
-import { Fragment, useCallback } from "react";
+import { Fragment } from "react";
 import NoFileSelected from "./NoFileSelected";
 import ResetButton from "./ResetButton";
 import PreviewContainer from "./PreviewContainer";
 import { useMetadataUploadProvider } from "@/providers/MetadataUploadProvider";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
-import { validateFile } from "@/lib/fileSelect/validateFile";
-import { handleVideoSelection } from "@/lib/fileSelect/handleVideoSelection";
-import { handleImageSelection } from "@/lib/fileSelect/handleImageSelection";
-import { handleOtherFileSelection } from "@/lib/fileSelect/handleOtherFileSelection";
+import useFileSelect from "@/hooks/useFileSelect";
 
 const FileSelect = () => {
   const { selectFile } = useMetadataUploadProvider();
   const { createdTokenId } = useMomentCreateProvider();
-  const {
-    previewFile,
-    animationFile,
-    imageFile,
-    fileInputRef,
-    setMimeType,
-    setImageFile,
-    setPreviewFile,
-    setAnimationFile,
-  } = useMetadataFormProvider();
+  const { previewFile, animationFile, imageFile, fileInputRef } = useMetadataFormProvider();
+  const { handleSingleFile } = useFileSelect();
   const selected = previewFile || animationFile || imageFile;
   const handleImageClick = () => fileInputRef.current?.click();
-
-  const handleSingleFile = useCallback(
-    async (file: File) => {
-      try {
-        if (!validateFile(file)) return;
-        const mimeType = file.type;
-        const isImage = mimeType.includes("image");
-        const isVideo = mimeType.includes("video");
-
-        if (isVideo) {
-          await handleVideoSelection(file, { setAnimationFile, setMimeType, setPreviewFile });
-        } else if (isImage) {
-          await handleImageSelection(file, { setMimeType, setImageFile, setPreviewFile });
-        } else {
-          await handleOtherFileSelection(file, {
-            setMimeType,
-            setAnimationFile,
-            setPreviewFile,
-          });
-          if (imageFile) {
-            setPreviewFile(imageFile);
-            setImageFile(null);
-          }
-        }
-      } catch {
-        // validateFile already shows toast
-      }
-    },
-    [setMimeType, setImageFile, setPreviewFile, setAnimationFile, imageFile]
-  );
 
   return (
     <Fragment>

--- a/components/MetadataCreation/FileSelect.tsx
+++ b/components/MetadataCreation/FileSelect.tsx
@@ -1,17 +1,62 @@
+"use client";
+
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
-import { Fragment } from "react";
+import { Fragment, useCallback } from "react";
 import NoFileSelected from "./NoFileSelected";
 import ResetButton from "./ResetButton";
 import PreviewContainer from "./PreviewContainer";
 import { useMetadataUploadProvider } from "@/providers/MetadataUploadProvider";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { validateFile } from "@/lib/fileSelect/validateFile";
+import { handleVideoSelection } from "@/lib/fileSelect/handleVideoSelection";
+import { handleImageSelection } from "@/lib/fileSelect/handleImageSelection";
+import { handleOtherFileSelection } from "@/lib/fileSelect/handleOtherFileSelection";
 
 const FileSelect = () => {
   const { selectFile } = useMetadataUploadProvider();
   const { createdTokenId } = useMomentCreateProvider();
-  const { previewFile, animationFile, imageFile, fileInputRef } = useMetadataFormProvider();
+  const {
+    previewFile,
+    animationFile,
+    imageFile,
+    fileInputRef,
+    setMimeType,
+    setImageFile,
+    setPreviewFile,
+    setAnimationFile,
+  } = useMetadataFormProvider();
   const selected = previewFile || animationFile || imageFile;
   const handleImageClick = () => fileInputRef.current?.click();
+
+  const handleSingleFile = useCallback(
+    async (file: File) => {
+      try {
+        if (!validateFile(file)) return;
+        const mimeType = file.type;
+        const isImage = mimeType.includes("image");
+        const isVideo = mimeType.includes("video");
+
+        if (isVideo) {
+          await handleVideoSelection(file, { setAnimationFile, setMimeType, setPreviewFile });
+        } else if (isImage) {
+          await handleImageSelection(file, { setMimeType, setImageFile, setPreviewFile });
+        } else {
+          await handleOtherFileSelection(file, {
+            setMimeType,
+            setAnimationFile,
+            setPreviewFile,
+          });
+          if (imageFile) {
+            setPreviewFile(imageFile);
+            setImageFile(null);
+          }
+        }
+      } catch {
+        // validateFile already shows toast
+      }
+    },
+    [setMimeType, setImageFile, setPreviewFile, setAnimationFile, imageFile]
+  );
 
   return (
     <Fragment>
@@ -19,7 +64,7 @@ const FileSelect = () => {
         ref={fileInputRef}
         id="media"
         type="file"
-        className={`cursor-pointer ${selected ? "hidden" : "z-2 absolute size-full opacity-0"}`}
+        className={`cursor-pointer ${selected ? "hidden" : "z-2 absolute size-full opacity-0 pointer-events-none"}`}
         onChange={selectFile}
         disabled={Boolean(createdTokenId)}
       />
@@ -29,7 +74,7 @@ const FileSelect = () => {
           <PreviewContainer handleImageClick={handleImageClick} />
         </>
       ) : (
-        <NoFileSelected />
+        <NoFileSelected onSingleFile={handleSingleFile} />
       )}
     </Fragment>
   );

--- a/components/MetadataCreation/Layout.tsx
+++ b/components/MetadataCreation/Layout.tsx
@@ -1,15 +1,22 @@
+"use client";
+
 import CreateForm from "../CreateForm";
 import CreateModeSelect from "../CreateModeSelect";
 import MaskLines from "../CreateModeSelect/MaskLines";
 import Preview from "./Preview";
+import BulkCenterGrid from "@/components/BulkUpload/BulkCenterGrid";
+import BulkSideForm from "@/components/BulkUpload/BulkSideForm";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
+  const { isBulkMode } = useBulkCreateProvider();
+
   return (
     <>
       <MaskLines />
       <CreateModeSelect />
-      <Preview>{children}</Preview>
-      <CreateForm />
+      {isBulkMode ? <BulkCenterGrid /> : <Preview>{children}</Preview>}
+      {isBulkMode ? <BulkSideForm /> : <CreateForm />}
     </>
   );
 };

--- a/components/MetadataCreation/NoFileSelected.tsx
+++ b/components/MetadataCreation/NoFileSelected.tsx
@@ -1,30 +1,20 @@
-import Image from "next/image";
+"use client";
 
-const NoFileSelected = () => (
-  <div className="pointer-events-none size-full px-4 pt-10 md:px-10">
-    <div className="relative flex aspect-[1/1] w-full flex-col items-center justify-center gap-2 overflow-hidden rounded-full border border-grey-moss-400">
-      <div className="absolute left-0 right-0 size-full bg-grey-moss-100 opacity-[0.7]" />
-      <p className="z-[2] px-2 text-center font-archivo-medium text-sm md:text-lg">
-        drop an image, video, pdf, link, or embed
-      </p>
-      <button
-        type="button"
-        className="z-[2] rounded-md bg-grey-moss-200 px-4 py-2 font-archivo-medium text-grey-moss-50"
-      >
-        choose media
-      </button>
+import { BulkDropZone } from "@/components/BulkUpload";
+import SimpleDropHint from "./SimpleDropHint";
+
+interface NoFileSelectedProps {
+  onSingleFile?: (file: File) => void;
+}
+
+const NoFileSelected = ({ onSingleFile }: NoFileSelectedProps) => {
+  if (!onSingleFile) return <SimpleDropHint />;
+
+  return (
+    <div className="size-full p-4">
+      <BulkDropZone onSingleFile={onSingleFile} />
     </div>
-    <div className="block flex justify-center py-2 md:hidden">
-      <Image
-        src="/moment.svg"
-        blurDataURL="moment.png"
-        alt="not found moment"
-        width={108}
-        height={186}
-        className="self-center"
-      />
-    </div>
-  </div>
-);
+  );
+};
 
 export default NoFileSelected;

--- a/components/MetadataCreation/SimpleDropHint.tsx
+++ b/components/MetadataCreation/SimpleDropHint.tsx
@@ -1,0 +1,18 @@
+const SimpleDropHint = () => (
+  <div className="pointer-events-none size-full px-4 pt-10 md:px-10">
+    <div className="relative flex aspect-[1/1] w-full flex-col items-center justify-center gap-2 overflow-hidden rounded-full border border-grey-moss-400">
+      <div className="absolute left-0 right-0 size-full bg-grey-moss-100 opacity-[0.7]" />
+      <p className="z-[2] px-2 text-center font-archivo-medium text-sm md:text-lg">
+        drop an image, video, pdf, link, or embed
+      </p>
+      <button
+        type="button"
+        className="z-[2] rounded-md bg-grey-moss-200 px-4 py-2 font-archivo-medium text-grey-moss-50"
+      >
+        choose media
+      </button>
+    </div>
+  </div>
+);
+
+export default SimpleDropHint;

--- a/hooks/useBatchSuccess.ts
+++ b/hooks/useBatchSuccess.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+import { CHAIN, SITE_ORIGINAL_URL } from "@/lib/consts";
+import { getShortNetworkName } from "@/lib/zora/zoraToViem";
+
+const useBatchSuccess = () => {
+  const { result, clearAll } = useBulkCreateProvider();
+  const { push } = useRouter();
+
+  const contractAddress = result?.contractAddress ?? "";
+  const tokenIds = result?.tokenIds ?? [];
+  const items = result?.items ?? [];
+  const shortNetwork = getShortNetworkName(CHAIN.name.toLowerCase());
+
+  const handleCreateMore = useCallback(() => {
+    clearAll();
+    push("/create");
+  }, [clearAll, push]);
+
+  const handleViewCollection = useCallback(() => {
+    window.open(`${SITE_ORIGINAL_URL}/collection/${contractAddress}`, "_blank");
+  }, [contractAddress]);
+
+  const handleCopyAll = useCallback(async () => {
+    const urls = tokenIds
+      .map((id) => `${SITE_ORIGINAL_URL}/collect/${shortNetwork}:${contractAddress}/${id}`)
+      .join("\n");
+    await navigator.clipboard.writeText(urls);
+    toast.success("All links copied!");
+  }, [tokenIds, contractAddress, shortNetwork]);
+
+  return {
+    result,
+    contractAddress,
+    tokenIds,
+    items,
+    handleCreateMore,
+    handleViewCollection,
+    handleCopyAll,
+  };
+};
+
+export default useBatchSuccess;

--- a/hooks/useBatchSuccess.ts
+++ b/hooks/useBatchSuccess.ts
@@ -4,43 +4,45 @@ import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
-import { CHAIN, SITE_ORIGINAL_URL } from "@/lib/consts";
-import { getShortNetworkName } from "@/lib/zora/zoraToViem";
+import { useCollectionsProvider } from "@/providers/CollectionsProvider";
+import { useMetadata } from "@/hooks/useMetadata";
+import { SITE_ORIGINAL_URL } from "@/lib/consts";
 
 const useBatchSuccess = () => {
   const { result, clearAll } = useBulkCreateProvider();
   const { push } = useRouter();
+  const { collections } = useCollectionsProvider();
 
   const contractAddress = result?.contractAddress ?? "";
   const tokenIds = result?.tokenIds ?? [];
   const items = result?.items ?? [];
-  const shortNetwork = getShortNetworkName(CHAIN.name.toLowerCase());
+
+  const collectionItem = collections.find(
+    (c) => c.address.toLowerCase() === contractAddress.toLowerCase()
+  );
+  const { data: metadata } = useMetadata(collectionItem?.uri ?? "");
+  const collectionName = collectionItem?.name ?? "";
+  const collectionDescription = (metadata?.description as string) ?? "";
 
   const handleCreateMore = useCallback(() => {
     clearAll();
     push("/create");
   }, [clearAll, push]);
 
-  const handleViewCollection = useCallback(() => {
-    window.open(`${SITE_ORIGINAL_URL}/collection/${contractAddress}`, "_blank");
+  const handleShare = useCallback(async () => {
+    await navigator.clipboard.writeText(`${SITE_ORIGINAL_URL}/collection/${contractAddress}`);
+    toast.success("copied!");
   }, [contractAddress]);
-
-  const handleCopyAll = useCallback(async () => {
-    const urls = tokenIds
-      .map((id) => `${SITE_ORIGINAL_URL}/collect/${shortNetwork}:${contractAddress}/${id}`)
-      .join("\n");
-    await navigator.clipboard.writeText(urls);
-    toast.success("All links copied!");
-  }, [tokenIds, contractAddress, shortNetwork]);
 
   return {
     result,
     contractAddress,
     tokenIds,
     items,
+    collectionName,
+    collectionDescription,
     handleCreateMore,
-    handleViewCollection,
-    handleCopyAll,
+    handleShare,
   };
 };
 

--- a/hooks/useBulkCenterGrid.ts
+++ b/hooks/useBulkCenterGrid.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+
+const useBulkCenterGrid = () => {
+  const { bulkItems, removeFile, setItemName, addFiles, isCreating } = useBulkCreateProvider();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const onChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      if (files.length > 0) await addFiles(files);
+      if (inputRef.current) inputRef.current.value = "";
+    },
+    [addFiles]
+  );
+
+  return { bulkItems, removeFile, setItemName, isCreating, inputRef, onChange };
+};
+
+export default useBulkCenterGrid;

--- a/hooks/useBulkCreate.ts
+++ b/hooks/useBulkCreate.ts
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import { Address } from "viem";
+
+import { BulkItem, BulkResult } from "@/types/bulk";
+import { validateFile } from "@/lib/fileSelect/validateFile";
+import { processFileToItem } from "@/lib/fileSelect/processFileToItem";
+import { generateSingleFileMetadata } from "@/lib/metadata/generateSingleFileMetadata";
+import { createMomentBatchApi } from "@/lib/moment/createMomentBatchApi";
+import { useAuthorizationProvider } from "@/providers/AuthorizationProvider";
+import { useUserProvider } from "@/providers/UserProvider";
+import { useWalletsProvider } from "@/providers/WalletsProvider";
+import { useMiniAppProvider } from "@/providers/MiniAppProvider";
+import { useSmartAccountProvider } from "@/providers/SmartWalletAccountProvider";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { useCollectionsProvider } from "@/providers/CollectionsProvider";
+import { CHAIN_ID } from "@/lib/consts";
+import buildSalesConfig from "@/lib/zora/buildSalesConfig";
+import resolvePayoutRecipient from "@/lib/wallets/resolvePayoutRecipient";
+import buildBatchContract from "@/lib/moment/buildBatchContract";
+import buildBatchTokens from "@/lib/moment/buildBatchTokens";
+import useRecaptchaToken from "./useRecaptchaToken";
+
+const useBulkCreate = () => {
+  const [bulkItems, setBulkItems] = useState<BulkItem[]>([]);
+  const bulkItemsRef = useRef(bulkItems);
+  bulkItemsRef.current = bulkItems;
+
+  const [isCreating, setIsCreating] = useState(false);
+  const [result, setResult] = useState<BulkResult | null>(null);
+
+  const { getAuthHeaders } = useAuthorizationProvider();
+  const { isPrepared } = useUserProvider();
+  const { walletsReady, primaryWallet, hasEOA } = useWalletsProvider();
+  const { isMiniApp } = useMiniAppProvider();
+  const { smartWallet } = useSmartAccountProvider();
+  const { priceUnit, price, startDate } = useMetadataFormProvider();
+  const { selectedCollection: collection, setSelectedCollection } = useCollectionsProvider();
+  const { push } = useRouter();
+  const recaptcha = useRecaptchaToken("bulk_upload");
+
+  const addFiles = useCallback(async (files: File[]) => {
+    const validFiles = files.filter((f) => {
+      try {
+        return validateFile(f);
+      } catch {
+        return false;
+      }
+    });
+
+    const incomingVideos = validFiles.filter((f) => f.type.includes("video"));
+    const alreadyHasVideo = bulkItemsRef.current.some((i) => i.mimeType.includes("video"));
+
+    if (incomingVideos.length > 1 || (alreadyHasVideo && incomingVideos.length > 0)) {
+      toast.error("Only one video is allowed per batch upload");
+      return;
+    }
+
+    const processed = await Promise.all(validFiles.map(processFileToItem));
+    setBulkItems((prev) => [...prev, ...processed]);
+  }, []);
+
+  const removeFile = useCallback((id: string) => {
+    setBulkItems((prev) => {
+      const item = prev.find((i) => i.id === id);
+      if (item?.previewUrl) URL.revokeObjectURL(item.previewUrl);
+      return prev.filter((i) => i.id !== id);
+    });
+  }, []);
+
+  const setItemName = useCallback((id: string, name: string) => {
+    setBulkItems((prev) => prev.map((i) => (i.id === id ? { ...i, name } : i)));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setBulkItems((prev) => {
+      prev.forEach((i) => {
+        if (i.previewUrl) URL.revokeObjectURL(i.previewUrl);
+      });
+      return [];
+    });
+    setResult(null);
+  }, []);
+
+  const updateItemStatus = (id: string, patch: Partial<BulkItem>) => {
+    setBulkItems((prev) => prev.map((i) => (i.id === id ? { ...i, ...patch } : i)));
+  };
+
+  const createBatch = useCallback(async () => {
+    if (!isPrepared()) return;
+    if (!walletsReady) return;
+    if (bulkItems.length === 0) return;
+
+    const unnamedItems = bulkItems.filter((i) => !i.name.trim());
+    if (unnamedItems.length > 0) {
+      toast.error("Please name all items before creating");
+      return;
+    }
+
+    try {
+      setIsCreating(true);
+      const headers = await getAuthHeaders();
+      const client = { headers, recaptcha };
+      const payoutRecipient = resolvePayoutRecipient(isMiniApp, hasEOA, primaryWallet, smartWallet);
+      if (!payoutRecipient) throw new Error("Wallet not ready. Please try again.");
+
+      const salesConfig = buildSalesConfig(priceUnit, price, startDate);
+
+      const metadataUris: string[] = [];
+
+      for (let i = 0; i < bulkItems.length; i++) {
+        const item = bulkItems[i];
+        updateItemStatus(item.id, { status: "uploading", progress: 0 });
+
+        const mimeType = item.mimeType;
+        const isImage = mimeType.includes("image");
+
+        const imageFile = isImage ? item.file : null;
+        const animationFile = !isImage ? item.file : null;
+
+        const uri = await generateSingleFileMetadata({
+          imageFile,
+          animationFile,
+          previewFile: item.previewFile,
+          mimeType,
+          name: item.name,
+          description: "",
+          link: "",
+          client,
+          onProgress: (p) => updateItemStatus(item.id, { progress: p }),
+        });
+
+        metadataUris.push(uri);
+        updateItemStatus(item.id, { status: "done", progress: 100 });
+      }
+
+      const contract = buildBatchContract(collection, bulkItems[0].name, metadataUris[0]);
+      const tokens = buildBatchTokens(metadataUris, salesConfig, payoutRecipient as string);
+
+      const batchResult = await createMomentBatchApi({
+        contract,
+        tokens,
+        account: primaryWallet as Address,
+        chainId: CHAIN_ID,
+      });
+
+      setSelectedCollection(batchResult.contractAddress);
+
+      const resultData: BulkResult = {
+        contractAddress: batchResult.contractAddress,
+        tokenIds: batchResult.tokenIds,
+        items: bulkItems.map((item, idx) => ({
+          name: item.name,
+          previewUrl: item.previewUrl,
+          tokenId: batchResult.tokenIds[idx] ?? "",
+        })),
+      };
+
+      setResult(resultData);
+      push(
+        `/create/success?collectionAddress=${batchResult.contractAddress}&tokenIds=${batchResult.tokenIds.join(",")}`
+      );
+    } catch (err: any) {
+      toast.error(err?.message || "Error creating moments");
+      setBulkItems((prev) =>
+        prev.map((i) => (i.status === "uploading" ? { ...i, status: "error" } : i))
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  }, [
+    bulkItems,
+    isPrepared,
+    walletsReady,
+    getAuthHeaders,
+    isMiniApp,
+    hasEOA,
+    primaryWallet,
+    smartWallet,
+    priceUnit,
+    price,
+    startDate,
+    collection,
+    setSelectedCollection,
+    push,
+    recaptcha,
+  ]);
+
+  return {
+    bulkItems,
+    isBulkMode: bulkItems.length > 0,
+    addFiles,
+    removeFile,
+    setItemName,
+    clearAll,
+    createBatch,
+    isCreating,
+    result,
+    setResult,
+  };
+};
+
+export default useBulkCreate;

--- a/hooks/useBulkCreate.ts
+++ b/hooks/useBulkCreate.ts
@@ -1,13 +1,11 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback } from "react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { Address } from "viem";
 
-import { BulkItem, BulkResult } from "@/types/bulk";
-import { validateFile } from "@/lib/fileSelect/validateFile";
-import { processFileToItem } from "@/lib/fileSelect/processFileToItem";
+import { BulkResult } from "@/types/bulk";
 import { generateSingleFileMetadata } from "@/lib/metadata/generateSingleFileMetadata";
 import { createMomentBatchApi } from "@/lib/moment/createMomentBatchApi";
 import { useAuthorizationProvider } from "@/providers/AuthorizationProvider";
@@ -23,11 +21,18 @@ import resolvePayoutRecipient from "@/lib/wallets/resolvePayoutRecipient";
 import buildBatchContract from "@/lib/moment/buildBatchContract";
 import buildBatchTokens from "@/lib/moment/buildBatchTokens";
 import useRecaptchaToken from "./useRecaptchaToken";
+import useBulkItems from "./useBulkItems";
 
 const useBulkCreate = () => {
-  const [bulkItems, setBulkItems] = useState<BulkItem[]>([]);
-  const bulkItemsRef = useRef(bulkItems);
-  bulkItemsRef.current = bulkItems;
+  const {
+    bulkItems,
+    addFiles,
+    removeFile,
+    setItemName,
+    updateItemStatus,
+    markUploadingAsError,
+    clearItems,
+  } = useBulkItems();
 
   const [isCreating, setIsCreating] = useState(false);
   const [result, setResult] = useState<BulkResult | null>(null);
@@ -42,52 +47,10 @@ const useBulkCreate = () => {
   const { push } = useRouter();
   const recaptcha = useRecaptchaToken("bulk_upload");
 
-  const addFiles = useCallback(async (files: File[]) => {
-    const validFiles = files.filter((f) => {
-      try {
-        return validateFile(f);
-      } catch {
-        return false;
-      }
-    });
-
-    const incomingVideos = validFiles.filter((f) => f.type.includes("video"));
-    const alreadyHasVideo = bulkItemsRef.current.some((i) => i.mimeType.includes("video"));
-
-    if (incomingVideos.length > 1 || (alreadyHasVideo && incomingVideos.length > 0)) {
-      toast.error("Only one video is allowed per batch upload");
-      return;
-    }
-
-    const processed = await Promise.all(validFiles.map(processFileToItem));
-    setBulkItems((prev) => [...prev, ...processed]);
-  }, []);
-
-  const removeFile = useCallback((id: string) => {
-    setBulkItems((prev) => {
-      const item = prev.find((i) => i.id === id);
-      if (item?.previewUrl) URL.revokeObjectURL(item.previewUrl);
-      return prev.filter((i) => i.id !== id);
-    });
-  }, []);
-
-  const setItemName = useCallback((id: string, name: string) => {
-    setBulkItems((prev) => prev.map((i) => (i.id === id ? { ...i, name } : i)));
-  }, []);
-
   const clearAll = useCallback(() => {
-    setBulkItems((prev) => {
-      prev.forEach((i) => {
-        if (i.previewUrl) URL.revokeObjectURL(i.previewUrl);
-      });
-      return [];
-    });
+    clearItems();
     setResult(null);
-  }, []);
-
-  const updateItemStatus = (id: string, patch: Partial<BulkItem>) => {
-    setBulkItems((prev) => prev.map((i) => (i.id === id ? { ...i, ...patch } : i)));
-  };
+  }, [clearItems]);
 
   const createBatch = useCallback(async () => {
     if (!isPrepared()) return;
@@ -108,24 +71,18 @@ const useBulkCreate = () => {
       if (!payoutRecipient) throw new Error("Wallet not ready. Please try again.");
 
       const salesConfig = buildSalesConfig(priceUnit, price, startDate);
-
       const metadataUris: string[] = [];
 
       for (let i = 0; i < bulkItems.length; i++) {
         const item = bulkItems[i];
         updateItemStatus(item.id, { status: "uploading", progress: 0 });
 
-        const mimeType = item.mimeType;
-        const isImage = mimeType.includes("image");
-
-        const imageFile = isImage ? item.file : null;
-        const animationFile = !isImage ? item.file : null;
-
+        const isImage = item.mimeType.includes("image");
         const uri = await generateSingleFileMetadata({
-          imageFile,
-          animationFile,
+          imageFile: isImage ? item.file : null,
+          animationFile: isImage ? null : item.file,
           previewFile: item.previewFile,
-          mimeType,
+          mimeType: item.mimeType,
           name: item.name,
           description: "",
           link: "",
@@ -165,9 +122,7 @@ const useBulkCreate = () => {
       );
     } catch (err: any) {
       toast.error(err?.message || "Error creating moments");
-      setBulkItems((prev) =>
-        prev.map((i) => (i.status === "uploading" ? { ...i, status: "error" } : i))
-      );
+      markUploadingAsError();
     } finally {
       setIsCreating(false);
     }
@@ -187,6 +142,8 @@ const useBulkCreate = () => {
     setSelectedCollection,
     push,
     recaptcha,
+    updateItemStatus,
+    markUploadingAsError,
   ]);
 
   return {

--- a/hooks/useBulkDropZone.ts
+++ b/hooks/useBulkDropZone.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+
+const useBulkDropZone = (onSingleFile: (file: File) => void) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const { addFiles } = useBulkCreateProvider();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return;
+      if (files.length === 1) {
+        onSingleFile(files[0]);
+      } else {
+        await addFiles(files);
+      }
+    },
+    [addFiles, onSingleFile]
+  );
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      handleFiles(Array.from(e.dataTransfer.files));
+    },
+    [handleFiles]
+  );
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const onDragLeave = useCallback((e: React.DragEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDragging(false);
+    }
+  }, []);
+
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      handleFiles(Array.from(e.target.files ?? []));
+      if (inputRef.current) inputRef.current.value = "";
+    },
+    [handleFiles]
+  );
+
+  const openFileDialog = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  return { isDragging, inputRef, onDrop, onDragOver, onDragLeave, onChange, openFileDialog };
+};
+
+export default useBulkDropZone;

--- a/hooks/useBulkItems.ts
+++ b/hooks/useBulkItems.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { toast } from "sonner";
+
+import { BulkItem } from "@/types/bulk";
+import { validateFile } from "@/lib/fileSelect/validateFile";
+import { processFileToItem } from "@/lib/fileSelect/processFileToItem";
+
+const useBulkItems = () => {
+  const [bulkItems, setBulkItems] = useState<BulkItem[]>([]);
+  const bulkItemsRef = useRef(bulkItems);
+  bulkItemsRef.current = bulkItems;
+
+  const addFiles = useCallback(async (files: File[]) => {
+    const validFiles = files.filter((f) => {
+      try {
+        return validateFile(f);
+      } catch {
+        return false;
+      }
+    });
+
+    const incomingVideos = validFiles.filter((f) => f.type.includes("video"));
+    const alreadyHasVideo = bulkItemsRef.current.some((i) => i.mimeType.includes("video"));
+
+    if (incomingVideos.length > 1 || (alreadyHasVideo && incomingVideos.length > 0)) {
+      toast.error("Only one video is allowed per batch upload");
+      return;
+    }
+
+    const processed = await Promise.all(validFiles.map(processFileToItem));
+    setBulkItems((prev) => [...prev, ...processed]);
+  }, []);
+
+  const removeFile = useCallback((id: string) => {
+    setBulkItems((prev) => {
+      const item = prev.find((i) => i.id === id);
+      if (item?.previewUrl) URL.revokeObjectURL(item.previewUrl);
+      return prev.filter((i) => i.id !== id);
+    });
+  }, []);
+
+  const setItemName = useCallback((id: string, name: string) => {
+    setBulkItems((prev) => prev.map((i) => (i.id === id ? { ...i, name } : i)));
+  }, []);
+
+  const updateItemStatus = useCallback((id: string, patch: Partial<BulkItem>) => {
+    setBulkItems((prev) => prev.map((i) => (i.id === id ? { ...i, ...patch } : i)));
+  }, []);
+
+  const markUploadingAsError = useCallback(() => {
+    setBulkItems((prev) =>
+      prev.map((i) => (i.status === "uploading" ? { ...i, status: "error" } : i))
+    );
+  }, []);
+
+  const clearItems = useCallback(() => {
+    setBulkItems((prev) => {
+      prev.forEach((i) => {
+        if (i.previewUrl) URL.revokeObjectURL(i.previewUrl);
+      });
+      return [];
+    });
+  }, []);
+
+  return {
+    bulkItems,
+    addFiles,
+    removeFile,
+    setItemName,
+    updateItemStatus,
+    markUploadingAsError,
+    clearItems,
+  };
+};
+
+export default useBulkItems;

--- a/hooks/useCollections.ts
+++ b/hooks/useCollections.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useSearchParams } from "next/navigation";
 import { fetchCollections } from "@/lib/collections/fetchCollections";
@@ -16,6 +16,8 @@ export function useCollections() {
   const initialAddress = searchParams.get("collectionAddress") || parsedParamAddress || undefined;
 
   const [selectedCollection, setSelectedCollection] = useState<string | undefined>(initialAddress);
+  const selectedCollectionRef = useRef(selectedCollection);
+  selectedCollectionRef.current = selectedCollection;
 
   const query = useQuery({
     queryKey: ["collections", primaryWallet],
@@ -24,14 +26,20 @@ export function useCollections() {
     staleTime: 60_000,
   });
 
+  useEffect(() => {
+    if (!initialAddress) setSelectedCollection(undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [primaryWallet]);
+
   const collections = query.data?.collections ?? [];
 
   useEffect(() => {
-    if (selectedCollection) return;
+    if (selectedCollectionRef.current) return;
     const loadedCollections = query.data?.collections;
     if (!loadedCollections?.length) return;
-    setSelectedCollection(loadedCollections[0].address);
-  }, [selectedCollection, query.data?.collections]);
+    setSelectedCollection(loadedCollections[0].address.toLowerCase());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.data?.collections]);
 
   return {
     collections,

--- a/hooks/useCollectionsDropdown.ts
+++ b/hooks/useCollectionsDropdown.ts
@@ -14,7 +14,9 @@ export const useCollectionsDropdown = (onSelect?: (collection: CollectionItem) =
   } = useCollectionsProvider();
   const [open, setOpen] = useState(false);
 
-  const selectedItem = collections.find((c) => c.address === selectedCollection);
+  const selectedItem = collections.find(
+    (c) => c.address.toLowerCase() === selectedCollection?.toLowerCase()
+  );
   const { data: metadata, isLoading } = useMetadata(selectedItem?.uri ?? "");
 
   const displayName = selectedItem?.name ?? "Please select a collection";

--- a/hooks/useEmbedCode.ts
+++ b/hooks/useEmbedCode.ts
@@ -1,16 +1,14 @@
 import { uploadViaApi } from "@/lib/arweave/uploadViaApi";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import type { UploadClient } from "@/types/upload";
 
 const useEmbedCode = () => {
   const { embedCode } = useMetadataFormProvider();
 
-  const uploadEmbedCode = async (
-    headers: HeadersInit,
-    getRecaptchaToken: () => Promise<string | undefined>
-  ) => {
+  const uploadEmbedCode = async (client: UploadClient) => {
     const blob = new Blob([`<html>\n      ${embedCode}\n      </html>`], { type: "text/html" });
     const file = new File([blob], "embed", { type: "text/html" });
-    const result = await uploadViaApi(file, headers, getRecaptchaToken);
+    const result = await uploadViaApi(file, client);
     return {
       mime: "text/html" as const,
       animationUrl: result.arweave_uri,
@@ -18,9 +16,7 @@ const useEmbedCode = () => {
     };
   };
 
-  return {
-    uploadEmbedCode,
-  };
+  return { uploadEmbedCode };
 };
 
 export default useEmbedCode;

--- a/hooks/useFileSelect.ts
+++ b/hooks/useFileSelect.ts
@@ -5,54 +5,45 @@ import { handleImageSelection } from "@/lib/fileSelect/handleImageSelection";
 import { handleOtherFileSelection } from "@/lib/fileSelect/handleOtherFileSelection";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 
-/**
- * Hook for file selection only - stores files as blobs.
- * Upload logic is handled in useMetadataUpload.generateMetadataUri()
- */
 const useFileSelect = () => {
   const { setMimeType, setImageFile, setPreviewFile, setAnimationFile, imageFile } =
     useMetadataFormProvider();
 
-  const selectFile = useCallback(
-    async (event: any) => {
-      const file: File = event.target.files[0];
-      if (!file || !validateFile(file)) {
-        return;
-      }
+  const handleSingleFile = useCallback(
+    async (file: File) => {
+      try {
+        if (!validateFile(file)) return;
+        const mimeType = file.type;
+        const isImage = mimeType.includes("image");
+        const isVideo = mimeType.includes("video");
 
-      const mimeType = file.type;
-      const isImage = mimeType.includes("image");
-      const isVideo = mimeType.includes("video");
-
-      // Store files as blobs - no upload happens here
-      if (isVideo) {
-        await handleVideoSelection(file, {
-          setAnimationFile,
-          setMimeType,
-          setPreviewFile,
-        });
-      } else if (isImage) {
-        await handleImageSelection(file, {
-          setMimeType,
-          setImageFile,
-          setPreviewFile,
-        });
-      } else {
-        await handleOtherFileSelection(file, {
-          setMimeType,
-          setAnimationFile,
-          setPreviewFile,
-        });
-        if (imageFile) {
-          setPreviewFile(imageFile);
-          setImageFile(null);
+        if (isVideo) {
+          await handleVideoSelection(file, { setAnimationFile, setMimeType, setPreviewFile });
+        } else if (isImage) {
+          await handleImageSelection(file, { setMimeType, setImageFile, setPreviewFile });
+        } else {
+          await handleOtherFileSelection(file, { setMimeType, setAnimationFile, setPreviewFile });
+          if (imageFile) {
+            setPreviewFile(imageFile);
+            setImageFile(null);
+          }
         }
+      } catch {
+        // validateFile already shows toast
       }
     },
     [setMimeType, setImageFile, setPreviewFile, setAnimationFile, imageFile]
   );
 
-  return { selectFile };
+  const selectFile = useCallback(
+    async (event: any) => {
+      const file: File = event.target.files[0];
+      if (file) await handleSingleFile(file);
+    },
+    [handleSingleFile]
+  );
+
+  return { selectFile, handleSingleFile };
 };
 
 export default useFileSelect;

--- a/hooks/useMetadataForm.ts
+++ b/hooks/useMetadataForm.ts
@@ -1,4 +1,4 @@
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createFormSchema, CreateFormData } from "@/lib/schema/createFormSchema";
 import { useState, useEffect, useRef } from "react";
@@ -7,13 +7,9 @@ import { useBlobUrls } from "./useBlobUrls";
 import { Currency } from "@/types/balances";
 
 const useMetadataForm = () => {
-  // File input ref for resetting file inputs
   const fileInputRef = useRef<HTMLInputElement>(null);
-  // Metadata values state
-  const [name, setName] = useState<string>("");
-  const [priceUnit, setPriceUnit] = useState<Currency>("usdc");
-  const [price, setPrice] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
+
+  // Non-form state (not in react-hook-form schema)
   const [isTimedSale, setIsTimedSale] = useState<boolean>(false);
   const [mimeType, setMimeType] = useState<string>("");
   const [downloadUrl, setDownloadUrl] = useState<string>("");
@@ -21,17 +17,13 @@ const useMetadataForm = () => {
   const [embedCode, setEmbedCode] = useState("");
   const [link, setLink] = useState<string>("");
   const [writingText, setWritingText] = useState<string>("");
-
-  // Store File blobs for deferred upload
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [animationFile, setAnimationFile] = useState<File | null>(null);
   const [previewFile, setPreviewFile] = useState<File | null>(null);
-
-  // Upload progress state
   const [uploadProgress, setUploadProgress] = useState<number>(0);
   const [isUploading, setIsUploading] = useState<boolean>(false);
+  const [isOpenAdvanced, setIsOpenAdvanced] = useState<boolean>(false);
 
-  // Blob URLs for preview display
   const { blobUrls, previewFileUrl, animationFileUrl } = useBlobUrls({
     previewFile,
     imageFile,
@@ -39,13 +31,47 @@ const useMetadataForm = () => {
     mimeType,
   });
 
-  // Advanced values state
-  const [startDate, setStartDate] = useState<Date>();
-  const [isOpenAdvanced, setIsOpenAdvanced] = useState<boolean>(false);
-  const [totalSupply, setTotalSupply] = useState<number | undefined>(undefined);
-
-  // Mask values state
   const mask = useMask(isOpenAdvanced, writingText);
+
+  // react-hook-form is the single source of truth for form fields
+  const form = useForm<CreateFormData>({
+    resolver: zodResolver(createFormSchema),
+    defaultValues: {
+      name: "",
+      price: "1",
+      priceUnit: "usdc" as Currency,
+      description: undefined,
+      startDate: undefined,
+      splits: undefined,
+      totalSupply: undefined,
+    },
+    mode: "onChange",
+  });
+
+  // Derive form field values — form is the single source of truth
+  const name = useWatch({ control: form.control, name: "name" }) ?? "";
+  const price = useWatch({ control: form.control, name: "price" }) ?? "1";
+  const priceUnit = (useWatch({ control: form.control, name: "priceUnit" }) ?? "usdc") as Currency;
+  const description = useWatch({ control: form.control, name: "description" }) ?? "";
+  const startDate = useWatch({ control: form.control, name: "startDate" });
+  const totalSupply = useWatch({ control: form.control, name: "totalSupply" });
+
+  // Reset price to sensible default when currency unit changes
+  useEffect(() => {
+    form.setValue("price", priceUnit === "usdc" ? "1" : "0.000111");
+  }, [priceUnit, form]);
+
+  // Setters — thin wrappers so consumers don't need to know about form internals
+  const setName = (val: string) => form.setValue("name", val, { shouldValidate: false });
+  const setPrice = (val: string) => form.setValue("price", val, { shouldValidate: false });
+  const setPriceUnit = (val: Currency) =>
+    form.setValue("priceUnit", val, { shouldValidate: false });
+  const setDescription = (val: string) =>
+    form.setValue("description", val || undefined, { shouldValidate: false });
+  const setTotalSupply = (val: number | undefined) =>
+    form.setValue("totalSupply", val, { shouldValidate: false });
+  const onChangeStartDate = (val: Date) =>
+    form.setValue("startDate", val, { shouldValidate: false });
 
   const clearMediaState = () => {
     setImageFile(null);
@@ -59,132 +85,24 @@ const useMetadataForm = () => {
   };
 
   const resetForm = () => {
-    setName("");
-    setDescription("");
+    form.setValue("name", "", { shouldValidate: false });
+    form.setValue("description", undefined, { shouldValidate: false });
     clearMediaState();
   };
 
-  /**
-   * Reusable function for resetting file uploads while preserving name and description.
-   * Used in both Create and Manage flows.
-   */
   const resetFiles = () => {
-    // Store current form values BEFORE any operations (preserve name and description)
-    const currentName = form.getValues("name");
-    const currentDescription = form.getValues("description");
-
-    // Clear only files and media-related state, NOT name/description
     clearMediaState();
-
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
-
-    // Ensure form values remain unchanged (preserve name and description)
-    if (currentName !== undefined && currentName !== null) {
-      form.setValue("name", currentName, { shouldValidate: false });
-    }
-    if (currentDescription !== undefined && currentDescription !== null) {
-      form.setValue("description", currentDescription, { shouldValidate: false });
-    }
+    // name and description live in form — clearMediaState doesn't touch them
   };
 
-  // Set default price based on priceUnit
-  useEffect(() => {
-    if (priceUnit === "usdc") {
-      setPrice("1");
-    } else {
-      setPrice("0.000111");
-    }
-  }, [priceUnit]);
-
-  // React Hook Form
-  const form = useForm<CreateFormData>({
-    resolver: zodResolver(createFormSchema),
-    defaultValues: {
-      name,
-      price,
-      priceUnit: priceUnit as Currency,
-      description: description || undefined,
-      startDate: startDate,
-      splits: undefined,
-      totalSupply: totalSupply,
-    },
-    mode: "onChange",
-  });
-
-  // Sync form values to state
-  useEffect(() => {
-    const subscription = form.watch((value, { name }) => {
-      if (name === "name" && value.name !== undefined) {
-        setName(value.name);
-      } else if (name === "price" && value.price !== undefined) {
-        setPrice(value.price);
-      } else if (name === "priceUnit" && value.priceUnit) {
-        setPriceUnit(value.priceUnit);
-      } else if (name === "description") {
-        setDescription(value.description || "");
-      } else if (name === "startDate" && value.startDate) {
-        setStartDate(value.startDate);
-      } else if (name === "totalSupply") {
-        setTotalSupply(value.totalSupply);
-      }
-    });
-    return () => subscription.unsubscribe();
-  }, [form]);
-
-  // Sync state to form
-  useEffect(() => {
-    if (form.getValues("name") !== name) {
-      form.setValue("name", name, { shouldValidate: false });
-    }
-  }, [name, form]);
-
-  useEffect(() => {
-    if (form.getValues("price") !== price) {
-      form.setValue("price", price, { shouldValidate: false });
-    }
-  }, [price, form]);
-
-  useEffect(() => {
-    if (form.getValues("priceUnit") !== priceUnit) {
-      form.setValue("priceUnit", priceUnit as Currency, {
-        shouldValidate: false,
-      });
-    }
-  }, [priceUnit, form]);
-
-  useEffect(() => {
-    const currentDesc = form.getValues("description") || "";
-    if (currentDesc !== (description || "")) {
-      form.setValue("description", description || undefined, {
-        shouldValidate: false,
-      });
-    }
-  }, [description, form]);
-
-  useEffect(() => {
-    if (form.getValues("startDate") !== startDate) {
-      form.setValue("startDate", startDate, { shouldValidate: false });
-    }
-  }, [startDate, form]);
-
-  useEffect(() => {
-    if (form.getValues("totalSupply") !== totalSupply) {
-      form.setValue("totalSupply", totalSupply, { shouldValidate: false });
-    }
-  }, [totalSupply, form]);
-
-  const onChangeStartDate = (value: Date) => setStartDate(value);
-
-  // Check if any media files are selected
   const hasMedia = Boolean(previewFile || imageFile || animationFile);
 
   return {
-    // Form
     form,
 
-    // Metadata values
     name,
     setName,
     priceUnit,
@@ -210,7 +128,6 @@ const useMetadataForm = () => {
     resetForm,
     resetFiles,
 
-    // Advanced values
     startDate,
     onChangeStartDate,
     isOpenAdvanced,
@@ -218,10 +135,8 @@ const useMetadataForm = () => {
     totalSupply,
     setTotalSupply,
 
-    // Mask values
     ...mask,
 
-    // File blobs for deferred upload
     imageFile,
     setImageFile,
     animationFile,
@@ -229,22 +144,17 @@ const useMetadataForm = () => {
     previewFile,
     setPreviewFile,
 
-    // Media state
     hasMedia,
 
-    // Blob URLs for preview display
     blobUrls,
-    // Legacy blob URLs for backward compatibility
     previewFileUrl,
     animationFileUrl,
 
-    // Upload progress
     uploadProgress,
     setUploadProgress,
     isUploading,
     setIsUploading,
 
-    // File input ref
     fileInputRef,
   };
 };

--- a/hooks/useMetadataUpload.ts
+++ b/hooks/useMetadataUpload.ts
@@ -34,32 +34,17 @@ const useMetadataUpload = () => {
     const headers = await getAuthHeaders();
     const client = { headers, recaptcha };
 
-    if (type === "writing") {
-      const writingResult = await uploadWriting(client);
+    if (type === "writing" || type === "embed") {
+      const uploadResult =
+        type === "writing" ? await uploadWriting(client) : await uploadEmbedCode(client);
       const metadataResult = await buildMetadataPayload({
         name,
         description,
         externalUrl: link,
-        image: writingResult.image,
-        animationUrl: writingResult.animationUrl,
-        mime: writingResult.mime,
-        contentUri: writingResult.contentUri,
-        client,
-        existingMetadata,
-      });
-      return metadataResult.arweave_uri;
-    }
-
-    if (type === "embed") {
-      const embedResult = await uploadEmbedCode(client);
-      const metadataResult = await buildMetadataPayload({
-        name,
-        description,
-        externalUrl: link,
-        image: "",
-        animationUrl: embedResult.animationUrl,
-        mime: embedResult.mime,
-        contentUri: embedResult.contentUri,
+        image: "image" in uploadResult ? uploadResult.image : "",
+        animationUrl: uploadResult.animationUrl,
+        mime: uploadResult.mime,
+        contentUri: uploadResult.contentUri,
         client,
         existingMetadata,
       });

--- a/hooks/useMetadataUpload.ts
+++ b/hooks/useMetadataUpload.ts
@@ -2,15 +2,13 @@ import useLinkPreview from "./useLinkPreview";
 import useEmbedCode from "./useEmbedCode";
 import useWriting from "./useWriting";
 import useFileSelect from "./useFileSelect";
+import useRecaptchaToken from "./useRecaptchaToken";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import useTypeParam from "./useTypeParam";
-import { uploadVideoToMuxIfNeeded } from "@/lib/metadata/uploadVideoToMuxIfNeeded";
-import { uploadFilesToArweave } from "@/lib/metadata/uploadFilesToArweave";
+import { generateSingleFileMetadata } from "@/lib/metadata/generateSingleFileMetadata";
 import { buildMetadataPayload } from "@/lib/metadata/buildMetadataPayload";
-import { isModelGltfLike } from "@/lib/media/isModelGltfLike";
-import { MomentMetadata } from "@/types/moment";
 import { useAuthorizationProvider } from "@/providers/AuthorizationProvider";
-import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
+import { MomentMetadata } from "@/types/moment";
 
 const useMetadataUpload = () => {
   const type = useTypeParam();
@@ -29,115 +27,70 @@ const useMetadataUpload = () => {
   const { uploadWriting } = useWriting();
   const { uploadEmbedCode } = useEmbedCode();
   const { selectFile } = useFileSelect();
-  const { executeRecaptcha } = useGoogleReCaptcha();
+  const recaptcha = useRecaptchaToken("upload");
   useLinkPreview();
 
-  const getRecaptchaToken = async () => {
-    if (!executeRecaptcha) throw new Error("Recaptcha is not initialized");
-    return executeRecaptcha("upload").catch(() => undefined);
-  };
-
   const generateMetadataUri = async (existingMetadata?: MomentMetadata | null) => {
-    const authorization = await getAuthHeaders();
-    let mime = mimeType;
-    let animation_url = "";
-    let contentUri = "";
-    let image = "";
+    const headers = await getAuthHeaders();
+    const client = { headers, recaptcha };
+
+    if (type === "writing") {
+      const writingResult = await uploadWriting(client);
+      const metadataResult = await buildMetadataPayload({
+        name,
+        description,
+        externalUrl: link,
+        image: writingResult.image,
+        animationUrl: writingResult.animationUrl,
+        mime: writingResult.mime,
+        contentUri: writingResult.contentUri,
+        client,
+        existingMetadata,
+      });
+      return metadataResult.arweave_uri;
+    }
+
+    if (type === "embed") {
+      const embedResult = await uploadEmbedCode(client);
+      const metadataResult = await buildMetadataPayload({
+        name,
+        description,
+        externalUrl: link,
+        image: "",
+        animationUrl: embedResult.animationUrl,
+        mime: embedResult.mime,
+        contentUri: embedResult.contentUri,
+        client,
+        existingMetadata,
+      });
+      return metadataResult.arweave_uri;
+    }
 
     const hasFilesToUpload = Boolean(previewFile || imageFile || animationFile);
-
-    const isVideo = animationFile && mimeType.includes("video");
-    if (isVideo) {
+    if (hasFilesToUpload) {
       setIsUploading(true);
       setUploadProgress(0);
     }
-    const videoResult = await uploadVideoToMuxIfNeeded(
-      animationFile,
-      mimeType,
-      authorization,
-      setUploadProgress
-    );
-    if (videoResult.animationUrl) {
-      animation_url = videoResult.animationUrl;
-      contentUri = videoResult.contentUri;
-    }
 
-    const hasNonVideoFiles = Boolean(previewFile || imageFile);
-    if (hasNonVideoFiles) {
-      if (!isVideo) {
-        setIsUploading(true);
-        setUploadProgress(0);
-      }
-    }
-
-    const fileUploadResult = await uploadFilesToArweave(
-      authorization,
-      previewFile,
+    const arweaveUri = await generateSingleFileMetadata({
       imageFile,
       animationFile,
-      animation_url,
-      getRecaptchaToken,
-      setUploadProgress,
-      mimeType
-    );
-
-    image = fileUploadResult.image;
-
-    if (isVideo) {
-      // Keep Mux URLs
-    } else {
-      animation_url = fileUploadResult.animationUrl || animation_url;
-
-      const isPdf = mimeType.includes("pdf");
-      const isImage = mimeType.includes("image");
-      const isAudio = mimeType.includes("audio");
-      const isModel = isModelGltfLike(mimeType, animationFile?.name ?? null);
-      if ((isPdf || isImage || isAudio) && animation_url) {
-        contentUri = animation_url;
-      }
-      if (isModel && animation_url) {
-        contentUri = animation_url;
-        if (!mime.trim()) {
-          mime = /\.glb$/i.test(animationFile?.name ?? "")
-            ? "model/gltf-binary"
-            : "model/gltf+json";
-        }
-      }
-    }
+      previewFile,
+      mimeType,
+      name,
+      description,
+      link,
+      client,
+      onProgress: setUploadProgress,
+      existingMetadata,
+    });
 
     if (hasFilesToUpload) {
       setUploadProgress(100);
       setIsUploading(false);
     }
 
-    if (type === "writing") {
-      const writingResult = await uploadWriting(authorization, getRecaptchaToken);
-      mime = writingResult.mime;
-      animation_url = writingResult.animationUrl;
-      contentUri = writingResult.contentUri;
-      image = writingResult.image;
-    }
-
-    if (type === "embed") {
-      const embedResult = await uploadEmbedCode(authorization, getRecaptchaToken);
-      mime = embedResult.mime;
-      animation_url = embedResult.animationUrl;
-      contentUri = embedResult.contentUri;
-    }
-
-    const metadataResult = await buildMetadataPayload(
-      name,
-      description,
-      link,
-      image,
-      animation_url,
-      mime,
-      contentUri,
-      authorization,
-      getRecaptchaToken,
-      existingMetadata
-    );
-    return metadataResult.arweave_uri;
+    return arweaveUri;
   };
 
   return {

--- a/hooks/useMetadataUpload.ts
+++ b/hooks/useMetadataUpload.ts
@@ -57,25 +57,27 @@ const useMetadataUpload = () => {
       setUploadProgress(0);
     }
 
-    const arweaveUri = await generateSingleFileMetadata({
-      imageFile,
-      animationFile,
-      previewFile,
-      mimeType,
-      name,
-      description,
-      link,
-      client,
-      onProgress: setUploadProgress,
-      existingMetadata,
-    });
-
-    if (hasFilesToUpload) {
-      setUploadProgress(100);
-      setIsUploading(false);
+    try {
+      const arweaveUri = await generateSingleFileMetadata({
+        imageFile,
+        animationFile,
+        previewFile,
+        mimeType,
+        name,
+        description,
+        link,
+        client,
+        onProgress: setUploadProgress,
+        existingMetadata,
+      });
+      if (hasFilesToUpload) setUploadProgress(100);
+      return arweaveUri;
+    } catch (err) {
+      if (hasFilesToUpload) setUploadProgress(0);
+      throw err;
+    } finally {
+      if (hasFilesToUpload) setIsUploading(false);
     }
-
-    return arweaveUri;
   };
 
   return {

--- a/hooks/useMomentCreate.tsx
+++ b/hooks/useMomentCreate.tsx
@@ -36,7 +36,8 @@ export default function useMomentCreate() {
       }
       const result = await createMomentApi(parameters);
       setSelectedCollection(result.contractAddress);
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      const INDEXER_SETTLE_MS = 3000; // wait for indexer to pick up newly minted token
+      await new Promise((resolve) => setTimeout(resolve, INDEXER_SETTLE_MS));
 
       setIsUploading(false);
       setUploadProgress(100);

--- a/hooks/useMomentCreateParameters.ts
+++ b/hooks/useMomentCreateParameters.ts
@@ -1,7 +1,7 @@
 import { Address } from "viem";
 import { REFERRAL_RECIPIENT } from "@/lib/consts";
-import getSalesConfig from "@/lib/zora/getSalesConfig";
-import getSaleConfigType from "@/lib/getSaleConfigType";
+import buildSalesConfig from "@/lib/zora/buildSalesConfig";
+import resolvePayoutRecipient from "@/lib/wallets/resolvePayoutRecipient";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import { useMiniAppProvider } from "@/providers/MiniAppProvider";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
@@ -17,19 +17,13 @@ const useMomentCreateParameters = () => {
   const { generateMetadataUri } = useMetadataUploadProvider();
   const { selectedCollection: collection } = useCollectionsProvider();
 
-  // Use priceUnit to determine if USDC
-  const isUsdc = priceUnit === "usdc";
   const fetchParameters = async () => {
-    const payoutRecipient = isMiniApp || hasEOA ? primaryWallet : smartWallet;
+    const payoutRecipient = resolvePayoutRecipient(isMiniApp, hasEOA, primaryWallet, smartWallet);
     if (!payoutRecipient) throw new Error("Wallet not ready. Please try again.");
 
     const momentMetadataUri = await generateMetadataUri();
     if (!name) return;
-    const salesConfig = getSalesConfig(
-      getSaleConfigType(isUsdc ? "erc20Mint" : "fixedPrice"),
-      price,
-      startDate
-    );
+    const salesConfig = buildSalesConfig(priceUnit, price, startDate);
 
     const formSplits = form.getValues("splits");
     const splitsData = formSplits && formSplits.length > 0 ? formSplits : undefined;

--- a/hooks/useRecaptchaToken.ts
+++ b/hooks/useRecaptchaToken.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useCallback } from "react";
+import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
+
+const useRecaptchaToken = (action: string) => {
+  const { executeRecaptcha } = useGoogleReCaptcha();
+  return useCallback(async (): Promise<string | undefined> => {
+    if (!executeRecaptcha) return undefined;
+    return executeRecaptcha(action).catch(() => undefined);
+  }, [executeRecaptcha, action]);
+};
+
+export default useRecaptchaToken;

--- a/hooks/useWriting.ts
+++ b/hooks/useWriting.ts
@@ -1,17 +1,17 @@
+"use client";
+
 import { uploadWritingFile } from "@/lib/arweave/uploadWritingFile";
 import { generateAndUploadPreview } from "@/lib/writing/generateAndUploadPreview";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import type { UploadClient } from "@/types/upload";
 
 const useWriting = () => {
   const { writingText } = useMetadataFormProvider();
 
-  const uploadWriting = async (
-    headers: HeadersInit,
-    getRecaptchaToken: () => Promise<string | undefined>
-  ) => {
+  const uploadWriting = async (client: UploadClient) => {
     const [writingResult, previewResult] = await Promise.all([
-      uploadWritingFile(writingText, headers, getRecaptchaToken),
-      generateAndUploadPreview(writingText, headers, getRecaptchaToken),
+      uploadWritingFile(writingText, client),
+      generateAndUploadPreview(writingText, client),
     ]);
 
     return {

--- a/lib/arweave/uploadJson.ts
+++ b/lib/arweave/uploadJson.ts
@@ -1,11 +1,8 @@
 import { uploadViaApi, type UploadResult } from "./uploadViaApi";
+import type { UploadClient } from "@/types/upload";
 
-export async function uploadJson(
-  json: object,
-  authHeaders: HeadersInit,
-  getRecaptchaToken: () => Promise<string | undefined>
-): Promise<UploadResult> {
+export async function uploadJson(json: object, client: UploadClient): Promise<UploadResult> {
   const jsonString = JSON.stringify(json);
   const file = new File([jsonString], "upload.json", { type: "application/json" });
-  return uploadViaApi(file, authHeaders, getRecaptchaToken);
+  return uploadViaApi(file, client);
 }

--- a/lib/arweave/uploadViaApi.ts
+++ b/lib/arweave/uploadViaApi.ts
@@ -1,21 +1,18 @@
 import { IN_PROCESS_API } from "@/lib/consts";
 import { uploadToBlob } from "@/lib/blob/uploadToBlob";
+import type { UploadClient } from "@/types/upload";
 
 export type UploadResult = {
   arweave_uri: string;
 };
 
-export const uploadViaApi = async (
-  file: File,
-  authHeaders: HeadersInit,
-  getRecaptchaToken: () => Promise<string | undefined>
-): Promise<UploadResult> => {
-  const blobUrl = await uploadToBlob(file, authHeaders, getRecaptchaToken);
+export const uploadViaApi = async (file: File, client: UploadClient): Promise<UploadResult> => {
+  const blobUrl = await uploadToBlob(file, client);
 
-  const uploadToken = await getRecaptchaToken();
+  const uploadToken = await client.recaptcha();
   const uploadHeaders = {
     "Content-Type": "application/json",
-    ...(authHeaders as Record<string, string>),
+    ...(client.headers as Record<string, string>),
     ...(uploadToken && { "X-Recaptcha-Token": uploadToken }),
   };
   const response = await fetch(`${IN_PROCESS_API}/upload`, {

--- a/lib/arweave/uploadWritingFile.ts
+++ b/lib/arweave/uploadWritingFile.ts
@@ -1,11 +1,11 @@
 import { uploadViaApi, type UploadResult } from "./uploadViaApi";
+import type { UploadClient } from "@/types/upload";
 
 export const uploadWritingFile = async (
   content: string,
-  authHeaders: HeadersInit,
-  getRecaptchaToken: () => Promise<string | undefined>
+  client: UploadClient
 ): Promise<UploadResult> => {
   const blob = new Blob([content], { type: "text/plain" });
   const writingFile = new File([blob], "writing.txt", { type: "text/plain" });
-  return uploadViaApi(writingFile, authHeaders, getRecaptchaToken);
+  return uploadViaApi(writingFile, client);
 };

--- a/lib/blob/uploadToBlob.ts
+++ b/lib/blob/uploadToBlob.ts
@@ -1,20 +1,17 @@
 import { upload } from "@vercel/blob/client";
 import { IN_PROCESS_API } from "@/lib/consts";
 import { v4 as uuidv4 } from "uuid";
+import type { UploadClient } from "@/types/upload";
 
-export const uploadToBlob = async (
-  file: File,
-  authHeaders: HeadersInit,
-  getRecaptchaToken: () => Promise<string | undefined>
-): Promise<string> => {
+export const uploadToBlob = async (file: File, client: UploadClient): Promise<string> => {
   const ext = file.name.split(".").pop();
   // Use uuid v4 with explicit options to bypass native crypto.randomUUID(),
   // which throws DOMException in Firefox on non-secure (HTTP) contexts.
   const id = uuidv4({});
   const pathname = ext ? `${id}.${ext}` : id;
-  const recaptchaToken = await getRecaptchaToken();
+  const recaptchaToken = await client.recaptcha();
   const headers = {
-    ...(authHeaders as Record<string, string>),
+    ...(client.headers as Record<string, string>),
     ...(recaptchaToken && { "X-Recaptcha-Token": recaptchaToken }),
   };
   const { url } = await upload(pathname, file, {

--- a/lib/bulkUpload/getMimeTypeIcon.ts
+++ b/lib/bulkUpload/getMimeTypeIcon.ts
@@ -1,0 +1,5 @@
+export const getMimeTypeIcon = (mimeType: string): string => {
+  if (mimeType.includes("pdf")) return "PDF";
+  if (mimeType.includes("audio")) return "♪";
+  return "?";
+};

--- a/lib/bulkUpload/getStatusClass.ts
+++ b/lib/bulkUpload/getStatusClass.ts
@@ -1,0 +1,10 @@
+import { BulkItem } from "@/types/bulk";
+
+const statusClass: Record<BulkItem["status"], string> = {
+  idle: "border-grey-moss-300",
+  uploading: "border-blue-400",
+  done: "border-green-400",
+  error: "border-red-400",
+};
+
+export const getStatusClass = (status: BulkItem["status"]): string => statusClass[status];

--- a/lib/fileSelect/processFileToItem.ts
+++ b/lib/fileSelect/processFileToItem.ts
@@ -1,0 +1,61 @@
+import { v4 as uuidv4 } from "uuid";
+import { BulkItem } from "@/types/bulk";
+import { handleImageSelection } from "./handleImageSelection";
+import { handleVideoSelection } from "./handleVideoSelection";
+import { handleOtherFileSelection } from "./handleOtherFileSelection";
+
+export const processFileToItem = async (file: File): Promise<BulkItem> => {
+  let imageFile: File | null = null;
+  let animationFile: File | null = null;
+  let previewFile: File | null = null;
+  let mimeType = "";
+
+  const mimeHandlers = {
+    setMimeType: (m: string) => {
+      mimeType = m;
+    },
+    setImageFile: (f: File | null) => {
+      imageFile = f;
+    },
+    setPreviewFile: (f: File | null) => {
+      previewFile = f;
+    },
+    setAnimationFile: (f: File | null) => {
+      animationFile = f;
+    },
+  };
+
+  const isImage = file.type.includes("image");
+  const isVideo = file.type.includes("video");
+
+  if (isVideo) {
+    await handleVideoSelection(file, mimeHandlers);
+  } else if (isImage) {
+    await handleImageSelection(file, mimeHandlers);
+  } else {
+    await handleOtherFileSelection(file, mimeHandlers);
+    if (imageFile) {
+      previewFile = imageFile;
+      imageFile = null;
+    }
+  }
+
+  const previewUrl = previewFile
+    ? URL.createObjectURL(previewFile)
+    : imageFile
+      ? URL.createObjectURL(imageFile)
+      : "";
+
+  const baseName = file.name.replace(/\.[^/.]+$/, "");
+
+  return {
+    id: uuidv4(),
+    file,
+    previewFile,
+    mimeType,
+    name: baseName,
+    previewUrl,
+    status: "idle",
+    progress: 0,
+  };
+};

--- a/lib/metadata/buildMetadataPayload.ts
+++ b/lib/metadata/buildMetadataPayload.ts
@@ -1,20 +1,32 @@
 import { isInvalidArUri } from "@/lib/arweave/isInvalidArUri";
 import { uploadJson } from "@/lib/arweave/uploadJson";
 import type { UploadResult } from "@/lib/arweave/uploadViaApi";
+import type { UploadClient } from "@/types/upload";
 import { MomentMetadata } from "@/types/moment";
 
-export const buildMetadataPayload = async (
-  name: string,
-  description: string,
-  externalUrl: string,
-  image: string,
-  animationUrl: string,
-  mime: string,
-  contentUri: string,
-  authHeaders: HeadersInit,
-  getRecaptchaToken: () => Promise<string | undefined>,
-  existingMetadata?: MomentMetadata | null
-): Promise<UploadResult> => {
+export interface BuildMetadataPayloadParams {
+  name: string;
+  description: string;
+  externalUrl: string;
+  image: string;
+  animationUrl: string;
+  mime: string;
+  contentUri: string;
+  client: UploadClient;
+  existingMetadata?: MomentMetadata | null;
+}
+
+export const buildMetadataPayload = async ({
+  name,
+  description,
+  externalUrl,
+  image,
+  animationUrl,
+  mime,
+  contentUri,
+  client,
+  existingMetadata,
+}: BuildMetadataPayloadParams): Promise<UploadResult> => {
   const safeAnimationUrl = animationUrl && !isInvalidArUri(animationUrl) ? animationUrl : "";
   const safeContentUri = contentUri && !isInvalidArUri(contentUri) ? contentUri : "";
 
@@ -30,5 +42,5 @@ export const buildMetadataPayload = async (
     },
   };
 
-  return uploadJson(mergedMetadata, authHeaders, getRecaptchaToken);
+  return uploadJson(mergedMetadata, client);
 };

--- a/lib/metadata/generateSingleFileMetadata.ts
+++ b/lib/metadata/generateSingleFileMetadata.ts
@@ -1,0 +1,73 @@
+import { uploadVideoToMuxIfNeeded } from "./uploadVideoToMuxIfNeeded";
+import { uploadFilesToArweave } from "./uploadFilesToArweave";
+import { buildMetadataPayload } from "./buildMetadataPayload";
+import { resolveContentUri } from "./resolveContentUri";
+import type { UploadClient } from "@/types/upload";
+import { MomentMetadata } from "@/types/moment";
+
+export interface SingleFileMetadataParams {
+  imageFile: File | null;
+  animationFile: File | null;
+  previewFile: File | null;
+  mimeType: string;
+  name: string;
+  description: string;
+  link: string;
+  client: UploadClient;
+  onProgress?: (progress: number) => void;
+  existingMetadata?: MomentMetadata | null;
+}
+
+export const generateSingleFileMetadata = async ({
+  imageFile,
+  animationFile,
+  previewFile,
+  mimeType,
+  name,
+  description,
+  link,
+  client,
+  onProgress,
+  existingMetadata,
+}: SingleFileMetadataParams): Promise<string> => {
+  const isVideo = mimeType.includes("video");
+
+  const videoResult = await uploadVideoToMuxIfNeeded(
+    animationFile,
+    mimeType,
+    client.headers,
+    onProgress
+  );
+
+  const fileUploadResult = await uploadFilesToArweave(
+    client,
+    previewFile,
+    imageFile,
+    animationFile,
+    videoResult.animationUrl,
+    onProgress,
+    mimeType
+  );
+
+  const animation_url = isVideo
+    ? videoResult.animationUrl
+    : fileUploadResult.animationUrl || videoResult.animationUrl;
+
+  const { contentUri, mime } = isVideo
+    ? { contentUri: videoResult.contentUri, mime: mimeType }
+    : resolveContentUri(mimeType, animation_url, animationFile?.name ?? null, mimeType);
+
+  const metadataResult = await buildMetadataPayload({
+    name,
+    description,
+    externalUrl: link,
+    image: fileUploadResult.image,
+    animationUrl: animation_url,
+    mime,
+    contentUri,
+    client,
+    existingMetadata,
+  });
+
+  return metadataResult.arweave_uri;
+};

--- a/lib/metadata/resolveContentUri.ts
+++ b/lib/metadata/resolveContentUri.ts
@@ -1,0 +1,34 @@
+import { isModelGltfLike } from "@/lib/media/isModelGltfLike";
+
+interface ContentUriResult {
+  contentUri: string;
+  mime: string;
+}
+
+export const resolveContentUri = (
+  mimeType: string,
+  animationUrl: string,
+  animationFileName: string | null,
+  initialMime: string
+): ContentUriResult => {
+  let contentUri = "";
+  let mime = initialMime;
+
+  const isPdf = mimeType.includes("pdf");
+  const isImage = mimeType.includes("image");
+  const isAudio = mimeType.includes("audio");
+  const isModel = isModelGltfLike(mimeType, animationFileName);
+
+  if ((isPdf || isImage || isAudio) && animationUrl) {
+    contentUri = animationUrl;
+  }
+
+  if (isModel && animationUrl) {
+    contentUri = animationUrl;
+    if (!mime.trim()) {
+      mime = /\.glb$/i.test(animationFileName ?? "") ? "model/gltf-binary" : "model/gltf+json";
+    }
+  }
+
+  return { contentUri, mime };
+};

--- a/lib/metadata/uploadFilesToArweave.ts
+++ b/lib/metadata/uploadFilesToArweave.ts
@@ -1,4 +1,5 @@
 import { uploadViaApi } from "@/lib/arweave/uploadViaApi";
+import type { UploadClient } from "@/types/upload";
 
 interface FileUploadResult {
   uploadedPreviewUri: string;
@@ -9,12 +10,11 @@ interface FileUploadResult {
 }
 
 export const uploadFilesToArweave = async (
-  authHeaders: HeadersInit,
+  client: UploadClient,
   previewFile: File | null,
   imageFile: File | null,
   animationFile: File | null,
   existingAnimationUrl: string,
-  getRecaptchaToken: () => Promise<string | undefined>,
   setUploadProgress?: (progress: number) => void,
   mimeType?: string
 ): Promise<FileUploadResult> => {
@@ -52,7 +52,7 @@ export const uploadFilesToArweave = async (
 
     setUploadProgress?.(Math.round(fileStartProgress));
 
-    const uploadResult = await uploadViaApi(file, authHeaders, getRecaptchaToken);
+    const uploadResult = await uploadViaApi(file, client);
     const uploadedUri = uploadResult.arweave_uri;
 
     if (name === "preview") {

--- a/lib/moment/buildBatchContract.ts
+++ b/lib/moment/buildBatchContract.ts
@@ -1,0 +1,21 @@
+interface BatchContractWithAddress {
+  address: string;
+}
+
+interface BatchContractWithMetadata {
+  name: string;
+  uri: string;
+}
+
+type BatchContract = BatchContractWithAddress | BatchContractWithMetadata;
+
+const buildBatchContract = (
+  collection: string | null | undefined,
+  firstItemName: string,
+  firstMetadataUri: string
+): BatchContract => {
+  if (collection) return { address: collection };
+  return { name: firstItemName, uri: firstMetadataUri };
+};
+
+export default buildBatchContract;

--- a/lib/moment/buildBatchTokens.ts
+++ b/lib/moment/buildBatchTokens.ts
@@ -1,0 +1,24 @@
+import { REFERRAL_RECIPIENT } from "@/lib/consts";
+
+interface BatchToken {
+  tokenMetadataURI: string;
+  createReferral: string;
+  salesConfig: Record<string, unknown>;
+  mintToCreatorCount: number;
+  payoutRecipient: string;
+}
+
+const buildBatchTokens = (
+  metadataUris: string[],
+  salesConfig: Record<string, unknown>,
+  payoutRecipient: string
+): BatchToken[] =>
+  metadataUris.map((uri) => ({
+    tokenMetadataURI: uri,
+    createReferral: REFERRAL_RECIPIENT,
+    salesConfig,
+    mintToCreatorCount: 1,
+    payoutRecipient,
+  }));
+
+export default buildBatchTokens;

--- a/lib/moment/createMomentBatchApi.ts
+++ b/lib/moment/createMomentBatchApi.ts
@@ -1,0 +1,67 @@
+import { IN_PROCESS_API } from "@/lib/consts";
+import { toast } from "sonner";
+
+interface BatchToken {
+  tokenMetadataURI: string;
+  createReferral: string;
+  salesConfig: Record<string, unknown>;
+  mintToCreatorCount: number;
+  payoutRecipient?: string;
+  maxSupply?: number;
+}
+
+interface CreateMomentBatchParameters {
+  contract: { address?: string; name?: string; uri?: string };
+  tokens: BatchToken[];
+  account: string;
+  splits?: Array<{ address: string; percentAllocation: number }>;
+  chainId: number;
+}
+
+export interface CreateMomentBatchResult {
+  contractAddress: string;
+  hash: string;
+  chainId: number;
+  tokenIds: string[];
+}
+
+export async function createMomentBatchApi(
+  parameters: CreateMomentBatchParameters
+): Promise<CreateMomentBatchResult> {
+  const maxRetries = 3;
+  const retryDelay = 4000;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const response = await fetch(`${IN_PROCESS_API}/moment/create-batch`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(parameters),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      let errorMessage = "Failed to create moments";
+      try {
+        const error = JSON.parse(text);
+        errorMessage = error.message || errorMessage;
+      } catch {
+        // non-JSON response
+      }
+
+      if (errorMessage.includes("failed to estimate gas") && attempt < maxRetries - 1) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        toast.info(`Network is busy. Retrying... ${attempt + 1} of ${maxRetries}`);
+        continue;
+      }
+
+      if (errorMessage.includes("failed to estimate gas")) {
+        toast.info("Gas estimation failed. Please try again in a few minutes.");
+      }
+      throw new Error(errorMessage);
+    }
+
+    return response.json();
+  }
+
+  throw new Error("Failed to create moments after retries");
+}

--- a/lib/wallets/resolvePayoutRecipient.ts
+++ b/lib/wallets/resolvePayoutRecipient.ts
@@ -1,0 +1,10 @@
+const resolvePayoutRecipient = (
+  isMiniApp: boolean,
+  hasEOA: boolean,
+  primaryWallet: string | undefined | null,
+  smartWallet: string | undefined | null
+): string | undefined | null => {
+  return isMiniApp || hasEOA ? primaryWallet : smartWallet;
+};
+
+export default resolvePayoutRecipient;

--- a/lib/writing/generateAndUploadPreview.ts
+++ b/lib/writing/generateAndUploadPreview.ts
@@ -1,16 +1,16 @@
 import { uploadViaApi, type UploadResult } from "@/lib/arweave/uploadViaApi";
 import { generateTextPreview } from "./generateTextPreview";
+import type { UploadClient } from "@/types/upload";
 
 export const generateAndUploadPreview = async (
   writingText: string,
-  authHeaders: HeadersInit,
-  getRecaptchaToken: () => Promise<string | undefined>
+  client: UploadClient
 ): Promise<UploadResult | null> => {
   if (!writingText.trim()) return null;
 
   try {
     const previewFile = await generateTextPreview(writingText);
-    return uploadViaApi(previewFile, authHeaders, getRecaptchaToken);
+    return uploadViaApi(previewFile, client);
   } catch (error) {
     console.error("Failed to generate text preview:", error);
     return null;

--- a/lib/zora/buildSalesConfig.ts
+++ b/lib/zora/buildSalesConfig.ts
@@ -1,0 +1,9 @@
+import getSalesConfig from "./getSalesConfig";
+import getSaleConfigType from "@/lib/getSaleConfigType";
+
+const buildSalesConfig = (priceUnit: string, price: string, startDate: Date | undefined) => {
+  const isUsdc = priceUnit === "usdc";
+  return getSalesConfig(getSaleConfigType(isUsdc ? "erc20Mint" : "fixedPrice"), price, startDate);
+};
+
+export default buildSalesConfig;

--- a/providers/BulkCreateProvider.tsx
+++ b/providers/BulkCreateProvider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import React, { createContext, useContext, useMemo } from "react";
+import useBulkCreate from "@/hooks/useBulkCreate";
+
+const BulkCreateContext = createContext<ReturnType<typeof useBulkCreate> | undefined>(undefined);
+
+const BulkCreateProvider = ({ children }: { children: React.ReactNode }) => {
+  const bulk = useBulkCreate();
+  const value = useMemo(() => ({ ...bulk }), [bulk]);
+  return <BulkCreateContext.Provider value={value}>{children}</BulkCreateContext.Provider>;
+};
+
+const useBulkCreateProvider = () => {
+  const context = useContext(BulkCreateContext);
+  if (!context) {
+    throw new Error("useBulkCreateProvider must be used within a BulkCreateProvider");
+  }
+  return context;
+};
+
+export { BulkCreateProvider, useBulkCreateProvider };

--- a/providers/MomentCreateProvider/MomentCreateProviderWrapper.tsx
+++ b/providers/MomentCreateProvider/MomentCreateProviderWrapper.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { MetadataFormProvider } from "../MetadataFormProvider";
 import { MetadataUploadProvider } from "../MetadataUploadProvider";
 import { MomentCreateProvider } from "./MomentCreateProvider";
+import { BulkCreateProvider } from "../BulkCreateProvider";
 
 interface MomentCreateProviderWrapperProps {
   children: React.ReactNode;
@@ -13,7 +14,9 @@ const MomentCreateProviderWrapper = ({ children }: MomentCreateProviderWrapperPr
   return (
     <MetadataFormProvider>
       <MetadataUploadProvider>
-        <MomentCreateProvider>{children}</MomentCreateProvider>
+        <MomentCreateProvider>
+          <BulkCreateProvider>{children}</BulkCreateProvider>
+        </MomentCreateProvider>
       </MetadataUploadProvider>
     </MetadataFormProvider>
   );

--- a/providers/NounsCreateProvider/NounsCreateProviderWrapper.tsx
+++ b/providers/NounsCreateProvider/NounsCreateProviderWrapper.tsx
@@ -4,13 +4,16 @@ import React from "react";
 import { MetadataFormProvider } from "../MetadataFormProvider";
 import { MetadataUploadProvider } from "../MetadataUploadProvider";
 import { MomentCreateProvider } from "../MomentCreateProvider/MomentCreateProvider";
+import { BulkCreateProvider } from "../BulkCreateProvider";
 import { NounsProposalProvider } from "./NounsProposalProvider";
 
 const NounsCreateProviderWrapper = ({ children }: { children: React.ReactNode }) => (
   <MetadataFormProvider>
     <MetadataUploadProvider>
       <MomentCreateProvider>
-        <NounsProposalProvider>{children}</NounsProposalProvider>
+        <BulkCreateProvider>
+          <NounsProposalProvider>{children}</NounsProposalProvider>
+        </BulkCreateProvider>
       </MomentCreateProvider>
     </MetadataUploadProvider>
   </MetadataFormProvider>

--- a/types/bulk.ts
+++ b/types/bulk.ts
@@ -1,0 +1,20 @@
+export type BulkItemStatus = "idle" | "uploading" | "done" | "error";
+
+export interface BulkItem {
+  id: string;
+  file: File;
+  previewFile: File | null;
+  mimeType: string;
+  name: string;
+  previewUrl: string;
+  status: BulkItemStatus;
+  progress: number;
+  tokenId?: string;
+  error?: string;
+}
+
+export interface BulkResult {
+  contractAddress: string;
+  tokenIds: string[];
+  items: Array<{ name: string; previewUrl: string; tokenId: string }>;
+}

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -1,0 +1,4 @@
+export interface UploadClient {
+  headers: HeadersInit;
+  recaptcha: () => Promise<string | undefined>;
+}


### PR DESCRIPTION
## Summary

- Add bulk upload flow allowing artists to create multiple moments at once from a file grid UI
- Align batch success page with single success 3-column layout (header/cards/collection info)
- Lock price and collection inputs during bulk create process

## Test plan

- [ ] Upload multiple files via drag-and-drop or file picker on `/create`
- [ ] Name all items and select a collection, then click "create N moments"
- [ ] Verify price and collection inputs are disabled during creation
- [ ] Verify button shows "uploading X of N..." then "creating..." states
- [ ] Verify batch success page shows 3-column layout matching single success
- [ ] Verify "share" button copies collection URL and shows "copied!" toast
- [ ] Verify "create more" navigates back to `/create`
- [ ] Verify collection name and description appear in right column of success page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk upload functionality enabling users to create multiple moments in a single batch operation
  * Implemented drag-and-drop file selection with real-time progress tracking during batch uploads
  * Added batch success screen displaying all created moments with collection sharing capabilities

* **Improvements**
  * Collections and pricing controls can now be disabled contextually for better UX in various workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->