### PR TITLE
fix: artist timeline unable to view moment

### DIFF
--- a/components/VerticalFeed/SliderFeed.tsx
+++ b/components/VerticalFeed/SliderFeed.tsx
@@ -1,5 +1,6 @@
 import { TimelineMoment } from "@/types/moment";
 import ContentRenderer from "../Renderers";
+import { useMomentClick } from "@/hooks/useMomentClick";
 
 interface SliderFeedProps {
   feed: TimelineMoment;
@@ -7,9 +8,13 @@ interface SliderFeedProps {
 
 const SliderFeed = ({ feed }: SliderFeedProps) => {
   const metadata = feed.metadata;
+  const { handleMomentClick } = useMomentClick(feed);
 
   return (
-    <div className="relative h-[250px] w-full overflow-hidden md:h-auto">
+    <div
+      className="relative h-[250px] w-full overflow-hidden md:h-auto cursor-pointer"
+      onClick={handleMomentClick}
+    >
       <div className="flex size-full flex-col gap-2">
         <div className="relative w-full grow overflow-hidden rounded-[0px] bg-grey-moss-100">
           <ContentRenderer metadata={metadata} />


### PR DESCRIPTION
## Summary
- Adds `useMomentClick` hook to `SliderFeed` so clicking a moment in the artist timeline navigates to it
- Adds `cursor-pointer` class to indicate the item is clickable

## Test plan
- [ ] Open an artist's timeline
- [ ] Click a moment in the slider feed
- [ ] Verify navigation to the moment page works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable interactions to feed items with visual cursor feedback to indicate interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->