### PR TITLE
fix: update getSmartWallet to use accountId query param

### DIFF
--- a/lib/smartwallets/getSmartWallet.ts
+++ b/lib/smartwallets/getSmartWallet.ts
@@ -1,8 +1,8 @@
 import { IN_PROCESS_API } from "@/lib/consts";
 
-const getSmartWallet = async (artistId: string): Promise<string | null> => {
+const getSmartWallet = async (accountId: string): Promise<string | null> => {
   try {
-    const response = await fetch(`${IN_PROCESS_API}/smartwallet?artistId=${artistId}`);
+    const response = await fetch(`${IN_PROCESS_API}/smartwallet?accountId=${accountId}`);
     if (!response.ok) return null;
 
     const data = (await response.json()) as { address?: string };


### PR DESCRIPTION
## Summary
- `getSmartWallet` was calling `GET /smartwallet?artistId=...` which no longer matches the API
- Updated query param to `?accountId=` to align with sweetmantech/in_process_api#378

## Test plan
- [ ] Smart wallet lookup resolves correctly via `accountId` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)