### PR TITLE
feat: restrict collect to Base mainnet, delegate soldOut to API

### DIFF
--- a/components/MomentAirdrop/MomentAirdrop.tsx
+++ b/components/MomentAirdrop/MomentAirdrop.tsx
@@ -5,9 +5,9 @@ import Airdrop from "@/components/MomentAirdrop/Airdrop";
 import { useMomentProvider } from "@/providers/MomentProvider";
 
 const MomentAirdrop = () => {
-  const { isOwner, isSoldOut } = useMomentProvider();
+  const { isOwner } = useMomentProvider();
 
-  if (!isOwner || isSoldOut) return null;
+  if (!isOwner) return null;
 
   return (
     <AirdropProvider>

--- a/components/MomentPage/MomentDetails.tsx
+++ b/components/MomentPage/MomentDetails.tsx
@@ -11,9 +11,11 @@ import DetailButtons from "./DetailButtons";
 import MomentAirdrop from "../MomentAirdrop/MomentAirdrop";
 import Collectors from "./Collectors";
 import ContentRenderer from "../Renderers";
+import useCollectAvailability from "@/hooks/useCollectAvailability";
 
 const MomentDetails = () => {
   const { metadata, fetchMomentData } = useMomentProvider();
+  const { isCollectDisabled } = useCollectAvailability();
   const isMobile = useIsMobile();
   if (!metadata) return null;
 
@@ -42,7 +44,7 @@ const MomentDetails = () => {
       <div className="md:!min-w-[420px]">
         <CollectModal />
         {isMobile && <Comments />}
-        <MomentAirdrop />
+        {!isCollectDisabled && <MomentAirdrop />}
         <Collectors />
       </div>
     </>

--- a/hooks/useCollectAvailability.ts
+++ b/hooks/useCollectAvailability.ts
@@ -4,14 +4,14 @@ import { Protocol } from "@/types/moment";
 import { base } from "viem/chains";
 
 const useCollectAvailability = () => {
-  const { isSoldOut, isSaleActive, protocol, moment } = useMomentProvider();
+  const { soldOut, isSaleActive, protocol, moment } = useMomentProvider();
   const { isLoading: isSmartWalletLoading } = useSmartAccountProvider();
 
   const isInProcess = protocol === Protocol.InProcess;
   const isInProcessOnBase = isInProcess && moment.chainId === base.id;
   const isWalletLoading = isSmartWalletLoading;
-  const isCollectDisabled = !isSaleActive || isSoldOut || !isInProcessOnBase || isWalletLoading;
-  const collectCtaLabel = isSoldOut || !isInProcessOnBase ? "sold out" : "collect";
+  const isCollectDisabled = !isSaleActive || soldOut || !isInProcessOnBase || isWalletLoading;
+  const collectCtaLabel = soldOut || !isInProcessOnBase ? "sold out" : "collect";
 
   return { isCollectDisabled, collectCtaLabel };
 };

--- a/hooks/useMomentData.ts
+++ b/hooks/useMomentData.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import { getMomentApi } from "@/lib/moment/getMomentApi";
-import { Moment, MomentSaleConfig, Protocol } from "@/types/moment";
+import { Moment, MomentSaleConfig } from "@/types/moment";
 import useMigratedCollectionRedirect from "./useMigratedCollectionRedirect";
 
 const useMomentData = (moment: Moment) => {
@@ -24,7 +24,7 @@ const useMomentData = (moment: Moment) => {
   const tokenUri = query.data?.uri ?? null;
   const momentAdmins = query.data?.admins ?? null;
   const protocol = query.data?.protocol ?? null;
-  const apiSoldOut = query.data?.soldOut ?? false;
+  const soldOut = query.data?.soldOut ?? false;
 
   const isSetSale = useMemo(() => {
     return saleConfig ? BigInt(saleConfig.saleEnd) > BigInt(0) : false;
@@ -38,10 +38,6 @@ const useMomentData = (moment: Moment) => {
     if (!saleConfig) return false;
     const saleStartMs = saleConfig.saleStart * 1000;
     return saleStartMs < Date.now();
-  }, [saleConfig]);
-
-  const saleEndMs = useMemo(() => {
-    return saleConfig?.saleEnd ? saleConfig.saleEnd * 1000 : 0;
   }, [saleConfig]);
 
   useMigratedCollectionRedirect(metadata);
@@ -58,7 +54,7 @@ const useMomentData = (moment: Moment) => {
     owner,
     isOwner,
     isSaleActive,
-    isSoldOut: apiSoldOut || saleEndMs < Date.now() || protocol !== Protocol.InProcess,
+    soldOut,
   };
 };
 


### PR DESCRIPTION
## Summary
- Restrict collect/airdrop to InProcess protocol on Base mainnet (chain 8453)
- Remove frontend time-based and protocol-based soldOut logic; delegate entirely to API response
- Rename `isSoldOut` → `soldOut` to match API field name
- Gate `MomentAirdrop` rendering behind `isCollectDisabled` from `useCollectAvailability`

## Test plan
- [ ] Collect button shows "sold out" when API returns `soldOut: true`
- [ ] Airdrop section hidden when collect is disabled (wrong chain, sold out, wallet loading)
- [ ] Airdrop section visible for owner on active InProcess sale on Base mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)