### PR TITLE
feat: restrict manage tabs to in_process collections on Base chains

### DIFF
--- a/components/CollectionManagePage/Tabs.tsx
+++ b/components/CollectionManagePage/Tabs.tsx
@@ -1,6 +1,5 @@
 import TabButton from "./TabButton";
-import { useCollectionProvider } from "@/providers/CollectionProvider";
-import { Protocol } from "@/types/moment";
+import useIsManageableCollection from "@/hooks/useIsManageableCollection";
 
 export enum COLLECTION_MANAGE_TABS {
   MEDIA,
@@ -13,8 +12,7 @@ interface TabsProps {
 }
 
 const Tabs = ({ selectedTab, onChangeTab }: TabsProps) => {
-  const { data } = useCollectionProvider();
-  const hideNonMedia = data?.protocol === Protocol.SoundXyz || data?.protocol === Protocol.Catalog;
+  const hideNonMedia = !useIsManageableCollection();
 
   return (
     <section className="w-full px-2 pt-4 md:px-10">

--- a/components/MomentManagePage/ManageTabs.tsx
+++ b/components/MomentManagePage/ManageTabs.tsx
@@ -1,6 +1,5 @@
 import TabButton from "./TabButton";
-import { useCollectionProvider } from "@/providers/CollectionProvider";
-import { Protocol } from "@/types/moment";
+import useIsManageableCollection from "@/hooks/useIsManageableCollection";
 
 export enum MANAGE_TABS {
   MEDIA,
@@ -13,8 +12,7 @@ interface ManageTabsProps {
   selectedTab: number;
 }
 const ManageTabs = ({ selectedTab, onChangeTab }: ManageTabsProps) => {
-  const { data } = useCollectionProvider();
-  const hideNonMedia = data?.protocol === Protocol.SoundXyz || data?.protocol === Protocol.Catalog;
+  const hideNonMedia = !useIsManageableCollection();
   return (
     <section className="w-full pt-4 md:px-10">
       <div className="flex gap-1 md:gap-4">

--- a/hooks/useIsManageableCollection.ts
+++ b/hooks/useIsManageableCollection.ts
@@ -1,0 +1,10 @@
+import { CHAIN_ID } from "@/lib/consts";
+import { useCollectionProvider } from "@/providers/CollectionProvider";
+import { Protocol } from "@/types/moment";
+
+const useIsManageableCollection = () => {
+  const { data } = useCollectionProvider();
+  return data?.protocol === Protocol.InProcess && data?.chain_id === CHAIN_ID;
+};
+
+export default useIsManageableCollection;


### PR DESCRIPTION
## Summary
- Non-media tabs (Admins, Airdrop, Sale) are now shown only for `in_process` collections on Base mainnet (8453) or Base Sepolia (84532)
- Replaces the old protocol-blocklist approach (hide for Sound.xyz/Catalog) with an allowlist
- Extracts shared check into `useIsManageableCollection` hook, removing duplication between `CollectionManagePage/Tabs` and `MomentManagePage/ManageTabs`

## Test plan
- [ ] Open a collection with `protocol = in_process` on chain 8453 → all tabs visible
- [ ] Open a collection with `protocol = in_process` on chain 84532 → all tabs visible
- [ ] Open a Sound.xyz or Catalog collection → only Media tab visible
- [ ] Open an in_process collection on any other chain → only Media tab visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated collection management detection logic across components for improved code organization and maintainability. No impact to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->