### PR TITLE
fix: disable save button for non-in_process or unsupported chain coll…

### DIFF
--- a/components/MomentManagePage/SaveMediaButton.tsx
+++ b/components/MomentManagePage/SaveMediaButton.tsx
@@ -6,6 +6,7 @@ import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { useCollectionChangeWarning } from "@/hooks/useCollectionChangeWarning";
 import CollectionChangeWarningModal from "./CollectionChangeWarningModal";
 import PermissionErrorModal from "@/components/PermissionErrorModal";
+import useIsManageableCollection from "@/hooks/useIsManageableCollection";
 
 interface SaveMediaButtonProps {
   onSuccess?: () => void;
@@ -13,6 +14,7 @@ interface SaveMediaButtonProps {
 
 const SaveMediaButton = ({ onSuccess }: SaveMediaButtonProps) => {
   const { isOwner, moment } = useMomentProvider();
+  const isManageable = useIsManageableCollection();
   const { form } = useMetadataFormProvider();
   const { errors } = useFormState({ control: form.control });
   const {
@@ -57,7 +59,7 @@ const SaveMediaButton = ({ onSuccess }: SaveMediaButtonProps) => {
       <button
         className="w-fit rounded-md bg-black px-4 md:px-8 md:py-2 py-1 text-grey-eggshell transition-colors hover:bg-grey-moss-300 disabled:opacity-50"
         onClick={handleSave}
-        disabled={isSaving || !isOwner || !isFormValid}
+        disabled={isSaving || !isOwner || !isFormValid || !isManageable}
       >
         {isSaving ? "saving..." : "Save"}
       </button>

--- a/hooks/useSaveCollectionButton.ts
+++ b/hooks/useSaveCollectionButton.ts
@@ -4,11 +4,13 @@ import { useFormState } from "react-hook-form";
 import useUpdateCollectionURI from "@/hooks/useUpdateCollectionURI";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import useIsCollectionOwner from "@/hooks/useIsCollectionOwner";
+import useIsManageableCollection from "@/hooks/useIsManageableCollection";
 import { SaveCollectionButtonProps } from "@/components/CollectionManagePage/SaveCollectionButton";
 import { isPermissionError } from "@/lib/errors/isPermissionError";
 
 const useSaveCollectionButton = ({ onSuccess }: SaveCollectionButtonProps) => {
   const isOwner = useIsCollectionOwner();
+  const isManageable = useIsManageableCollection();
   const { updateCollectionURI, isLoading: isSaving } = useUpdateCollectionURI();
   const { form } = useMetadataFormProvider();
   const { errors } = useFormState({ control: form.control });
@@ -19,7 +21,7 @@ const useSaveCollectionButton = ({ onSuccess }: SaveCollectionButtonProps) => {
   const hasValidName = nameValue && typeof nameValue === "string" && nameValue.trim().length > 0;
   const isFormValid = hasValidName && !nameError;
 
-  const isDisabled = !isOwner || !isFormValid;
+  const isDisabled = !isOwner || !isFormValid || !isManageable;
 
   const onSave = useCallback(async () => {
     const isValid = await form.trigger();


### PR DESCRIPTION
…ections

Media save (collection and moment) was silently failing for Sound.xyz and Catalog because the update API only supports Zora ERC1155. Gate the Save button behind useIsManageableCollection so it is disabled for any protocol/chain the API cannot handle.