### PR TITLE
feat: migrate web to in_process_hidden for moment visibility

### DIFF
--- a/hooks/useIsMomentAdmin.ts
+++ b/hooks/useIsMomentAdmin.ts
@@ -4,7 +4,7 @@ import { TimelineMoment } from "@/types/moment";
 const useIsMomentAdmin = (moment: TimelineMoment) => {
   const { primaryWallet } = useWalletsProvider();
   if (!primaryWallet) return false;
-  return moment.admins.some((admin) => admin.address.toLowerCase() === primaryWallet.toLowerCase());
+  return moment.admins.some((admin) => admin.toLowerCase() === primaryWallet.toLowerCase());
 };
 
 export default useIsMomentAdmin;

--- a/hooks/useMomentAdminHidden.ts
+++ b/hooks/useMomentAdminHidden.ts
@@ -1,32 +1,12 @@
 import { useMemo } from "react";
 import { type TimelineMoment } from "@/types/moment";
-import { useWalletsProvider } from "@/providers/WalletsProvider";
+import { useUserProvider } from "@/providers/UserProvider";
 
-/**
- * Hook to get the hidden state for the current user's admin status on a moment
- * Returns the hidden state from creator if user is the creator,
- * otherwise returns the hidden state from the matching admin entry
- */
 export const useMomentAdminHidden = (moment: TimelineMoment): boolean => {
-  const { primaryWallet } = useWalletsProvider();
+  const { userId } = useUserProvider();
 
   return useMemo(() => {
-    if (!primaryWallet) {
-      return moment.creator.hidden;
-    }
-
-    const normalizedWallet = primaryWallet.toLowerCase();
-    const normalizedCreator = moment.creator.address.toLowerCase();
-
-    // Check if user is the creator
-    if (normalizedCreator === normalizedWallet) {
-      return moment.creator.hidden;
-    }
-
-    // Find matching admin entry
-    const admin = moment.admins.find((admin) => admin.address.toLowerCase() === normalizedWallet);
-
-    // Return admin's hidden state if found, otherwise default to creator
-    return admin?.hidden ?? moment.creator.hidden;
-  }, [moment, primaryWallet]);
+    if (!userId) return false;
+    return moment.hidden.includes(userId);
+  }, [moment.hidden, userId]);
 };

--- a/hooks/useToggleMoment.ts
+++ b/hooks/useToggleMoment.ts
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { type TimelineMoment } from "@/types/moment";
 import { toggleMoment } from "@/lib/timeline/toggleMoment";
 import { toast } from "sonner";
-import { Address } from "viem";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMomentAdminHidden } from "./useMomentAdminHidden";
 import { useAuthorizationProvider } from "@/providers/AuthorizationProvider";
@@ -20,11 +19,7 @@ export const useToggleMoment = (moment: TimelineMoment) => {
 
   const toggle = async (): Promise<void> => {
     try {
-      const response = await toggleMoment(await getAuthHeaders(), {
-        collectionAddress: moment.address as Address,
-        tokenId: moment.token_id,
-        chainId: moment.chain_id,
-      });
+      const response = await toggleMoment(await getAuthHeaders(), moment.id);
 
       if (response.success) {
         const newHidden = !isHidden;

--- a/lib/timeline/toggleMoment.ts
+++ b/lib/timeline/toggleMoment.ts
@@ -1,9 +1,8 @@
-import { Moment } from "@/types/moment";
 import { IN_PROCESS_API } from "@/lib/consts";
 
 export const toggleMoment = async (
   authHeaders: HeadersInit,
-  moment: Moment
+  momentId: string
 ): Promise<{ success: boolean }> => {
   const response = await fetch(`${IN_PROCESS_API}/moment/hide`, {
     method: "POST",
@@ -11,7 +10,7 @@ export const toggleMoment = async (
       "content-type": "application/json",
       ...authHeaders,
     },
-    body: JSON.stringify({ moment }),
+    body: JSON.stringify({ momentId }),
   });
 
   if (!response.ok) {

--- a/types/moment.ts
+++ b/types/moment.ts
@@ -56,12 +56,9 @@ export interface TimelineMoment {
   creator: {
     address: string;
     username: string | null;
-    hidden: boolean;
   };
-  admins: Array<{
-    address: string;
-    hidden: boolean;
-  }>;
+  admins: string[];
+  hidden: string[];
   created_at: string;
   metadata?: MomentMetadata;
 }


### PR DESCRIPTION
## Summary
- Update `TimelineMoment`: `admins` → `string[]`, add `hidden: string[]` (artist UUIDs), remove `hidden` from `creator`
- Rewrite `useMomentAdminHidden`: checks `moment.hidden.includes(userId)` via `useUserProvider` instead of matching wallet to admin/creator entry
- Simplify `useIsMomentAdmin`: match against flat address strings
- Update `toggleMoment`: sends `{ momentId: string }` instead of `{ moment: {collectionAddress, tokenId, chainId} }`
- Update `useToggleMoment`: passes `moment.id` to `toggleMoment`

## Test plan
- [ ] `pnpm build` passes
- [ ] Toggle hide/reveal on a moment works correctly
- [ ] Hidden state reflects correctly for current user (checks `moment.hidden` array)
- [ ] Admin check still works with flat address array

🤖 Generated with [Claude Code](https://claude.com/claude-code)