### PR TITLE
feat: default analytics period to last 7 days

### DIFF
--- a/components/AnalyticsPage/AnalyticsPage.tsx
+++ b/components/AnalyticsPage/AnalyticsPage.tsx
@@ -15,7 +15,7 @@ import ArtistsCollectorsStatsProvider from "@/providers/ArtistsCollectorsStatsPr
 import ArtistsCollectorsStatsTable from "./ArtistsCollectorsStatsTable";
 
 const AnalyticsPage = () => {
-  const [filters, setFilters] = useState<AnalyticsFilters>({});
+  const [filters, setFilters] = useState<AnalyticsFilters>({ period: "week" });
 
   return (
     <div className="container mx-auto max-w-6xl px-4 py-8">

--- a/hooks/useActiveArtists.ts
+++ b/hooks/useActiveArtists.ts
@@ -14,7 +14,7 @@ interface UseActiveArtistsOptions {
 
 export function useActiveArtists({ initialPage = 1, limit = 10 }: UseActiveArtistsOptions = {}) {
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>(undefined);
+  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>("week");
   const [artist, setArtist] = useState<string>("");
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORT);
 

--- a/hooks/useArtistsCollectorsStats.ts
+++ b/hooks/useArtistsCollectorsStats.ts
@@ -20,7 +20,7 @@ export function useArtistsCollectorsStats({
   limit = 10,
 }: UseArtistsCollectorsStatsOptions = {}) {
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>(undefined);
+  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>("week");
   const [artist, setArtist] = useState<string>("");
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORT);
 

--- a/hooks/useArweaveUploads.ts
+++ b/hooks/useArweaveUploads.ts
@@ -21,7 +21,7 @@ export function useArweaveUploads({ aggregation }: UseArweaveUploadsParams) {
     [aggregation]
   );
   const [currentPage, setCurrentPage] = useState(1);
-  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>(undefined);
+  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>("week");
   const [artist, setArtist] = useState<string>("");
   const [sorting, setSorting] = useState<SortingState>(defaultSort);
   const activeSort = sorting[0] ?? defaultSort[0];

--- a/hooks/useCollectors.ts
+++ b/hooks/useCollectors.ts
@@ -14,7 +14,7 @@ interface UseCollectorsOptions {
 
 export function useCollectors({ initialPage = 1, limit = 10 }: UseCollectorsOptions = {}) {
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>(undefined);
+  const [period, setPeriod] = useState<AnalyticsPeriod | undefined>("week");
   const [artist, setArtist] = useState<string>("");
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORT);
 


### PR DESCRIPTION
## Summary
- Changed default period for the analytics page timeline chart from "All time" to "Last 7 days"
- Changed default period for all analytics tables (Active Artists, Collectors, Artists & Collectors Stats, Arweave Uploads) from "All time" to "Last 7 days"

## Test plan
- [ ] Open analytics page and verify all selects show "Last 7 days" by default
- [ ] Verify changing the period filter works correctly
- [ ] Verify "All time" option is still available in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)