### PR TITLE
feat: block deprecated external URLs (catalog.works, sound.xyz) from opening externally

### DIFF
--- a/hooks/useMomentClick.ts
+++ b/hooks/useMomentClick.ts
@@ -2,6 +2,7 @@ import { useRouter } from "next/navigation";
 import { TimelineMoment } from "@/types/moment";
 import { validateUrl } from "@/lib/url/validateUrl";
 import { isYoutubeUrl } from "@/lib/url/isYoutubeUrl";
+import { isDeprecatedUrl } from "@/lib/url/isDeprecatedUrl";
 import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
 
 export const useMomentClick = (moment: TimelineMoment | undefined) => {
@@ -13,7 +14,7 @@ export const useMomentClick = (moment: TimelineMoment | undefined) => {
     const { chain_id, address, token_id } = moment;
     if (
       data?.external_url &&
-      !data?.external_url.includes("catalog.works") &&
+      !isDeprecatedUrl(data.external_url) &&
       !isYoutubeUrl(data.external_url)
     ) {
       // Validate URL before opening to prevent phishing

--- a/lib/url/isDeprecatedUrl.ts
+++ b/lib/url/isDeprecatedUrl.ts
@@ -1,0 +1,4 @@
+const DEPRECATED_DOMAINS = ["catalog.works", "sound.xyz"];
+
+export const isDeprecatedUrl = (url: string): boolean =>
+  DEPRECATED_DOMAINS.some((domain) => url.includes(domain));


### PR DESCRIPTION
## Summary
- `sound.xyz` deprecated URLs (e.g. `https://www.sound.xyz/artist/release`) were opening in a new tab instead of routing to the internal `/collect/` page
- Extracted the deprecated domain check into `lib/url/isDeprecatedUrl.ts` — replaces the inline `includes("catalog.works")` check
- Adding new deprecated domains only requires updating `DEPRECATED_DOMAINS` in one place

## Test plan
- [ ] Click a moment with a `sound.xyz` external URL — should route to `/collect/` instead of opening a new tab
- [ ] Click a moment with a `catalog.works` external URL — same behavior as before
- [ ] Click a moment with a valid non-deprecated external URL — should still open in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)