### PR TITLE
feat: navigate to moment manage page directly for zora_media moments

### DIFF
--- a/components/MomentsGrid/MomentItem.tsx
+++ b/components/MomentsGrid/MomentItem.tsx
@@ -2,7 +2,7 @@ import truncateAddress from "@/lib/truncateAddress";
 import { usePathname, useRouter } from "next/navigation";
 import truncated from "@/lib/truncated";
 import HideButton from "@/components/TimelineMoments/HideButton";
-import { type TimelineMoment } from "@/types/moment";
+import { type TimelineMoment, Protocol } from "@/types/moment";
 import { Copy, Check } from "lucide-react";
 import Preview from "./Preview";
 import useCopy from "@/hooks/useCopy";
@@ -30,8 +30,9 @@ const MomentItem = ({ m, variant = "collection" }: MomentItemProps) => {
   const handleClick = () => {
     const shortName = getShortNameFromChainId(m.chain_id);
     if (!shortName) return;
+    const includeTokenId = variant === "moment" || m.protocol === Protocol.ZoraMedia;
     push(
-      `/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}${variant === "moment" ? `/${m.token_id}` : ""}`
+      `/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}${includeTokenId ? `/${m.token_id}` : ""}`
     );
   };
   return (

--- a/types/moment.ts
+++ b/types/moment.ts
@@ -4,6 +4,7 @@ export enum Protocol {
   InProcess = "in_process",
   Catalog = "catalog",
   SoundXyz = "sound.xyz",
+  ZoraMedia = "zora_media",
 }
 export interface Moment {
   collectionAddress: Address;


### PR DESCRIPTION
## Summary
- `zora_media` is a single shared ERC721 contract, so navigating to the collection manage page has no meaningful context per artist
- Clicking a `zora_media` moment now routes directly to `/manage/{chain}:{address}/{token_id}` instead of the collection-level page
- Added `Protocol.ZoraMedia = "zora_media"` to the `Protocol` enum

## Test plan
- [ ] Go to `/manage/moments`
- [ ] Click a `zora_media` moment — confirm it navigates to the moment manage page (`/manage/.../token_id`)
- [ ] Click a non-zora_media moment — confirm it still navigates to the collection manage page

🤖 Generated with [Claude Code](https://claude.com/claude-code)