### PR TITLE
feat: add user drawer to mobile home tab bar

### DIFF
--- a/components/Timeline/MobileHome/MobileHomePage.tsx
+++ b/components/Timeline/MobileHome/MobileHomePage.tsx
@@ -15,7 +15,7 @@ const MobileHomePage = () => {
 
   return (
     <div className="flex h-full flex-col">
-      <div ref={scrollRef} className="flex-1 overflow-y-auto overflow-x-hidden">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto overflow-x-hidden pb-[74px]">
         <MobileHomeHeader isScrolled={isScrolled} />
         <MobileHero totalCount={totalCount} todayCount={todayCount} onCreateClick={onCreateClick} />
         <div className="flex flex-col px-4 pb-2">

--- a/components/Timeline/MobileHome/MobileTabBar.tsx
+++ b/components/Timeline/MobileHome/MobileTabBar.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { House, Search, Bell, User } from "lucide-react";
+import { House, Search, Bell } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
 import NotificationCountBadge from "@/components/Header/NotificationCountBadge";
+import MobileUserDrawer from "./MobileUserDrawer";
 
 const MobileTabBar = () => {
   const { push } = useRouter();
   const pathname = usePathname();
 
   return (
-    <div className="flex h-[74px] flex-none items-center justify-around border-t border-[#EDEAE2] bg-white/[0.92] px-[30px] backdrop-blur-md">
+    <div className="fixed bottom-0 left-0 right-0 z-[60] flex h-[74px] items-center justify-around border-t border-[#EDEAE2] bg-white/[0.92] px-[30px] backdrop-blur-md">
       <button type="button" onClick={() => push("/")}>
         <House
           className="h-[23px] w-[23px]"
@@ -24,9 +25,7 @@ const MobileTabBar = () => {
         <Bell className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
         <NotificationCountBadge />
       </button>
-      <button type="button" onClick={() => push("/manage/account")}>
-        <User className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
-      </button>
+      <MobileUserDrawer />
     </div>
   );
 };

--- a/components/Timeline/MobileHome/MobileUserDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileUserDrawer.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { User } from "lucide-react";
+import { Dialog } from "@/components/ui/dialog";
+import FeedbackModalContents from "@/components/Footer/FeedbackModalContents";
+import { useMobileUserDrawer } from "@/hooks/useMobileUserDrawer";
+import MobileUserDrawerPanel from "./MobileUserDrawerPanel";
+
+const MobileUserDrawer = () => {
+  const {
+    isOpen,
+    toggle,
+    close,
+    onTimeline,
+    onManage,
+    onManifesto,
+    onFaq,
+    onFeedback,
+    onLogout,
+    isMiniApp,
+    displayName,
+    submitFeedbackHook,
+  } = useMobileUserDrawer();
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <>
+      <button type="button" onClick={toggle}>
+        <User
+          className="h-[23px] w-[23px]"
+          strokeWidth={1.75}
+          color={isOpen ? "#1B1504" : "#B6B2A8"}
+        />
+      </button>
+
+      {mounted &&
+        createPortal(
+          <MobileUserDrawerPanel
+            isOpen={isOpen}
+            onClose={close}
+            onTimeline={onTimeline}
+            onManage={onManage}
+            onManifesto={onManifesto}
+            onFaq={onFaq}
+            onFeedback={onFeedback}
+            onLogout={onLogout}
+            isMiniApp={isMiniApp}
+            displayName={displayName}
+          />,
+          document.body
+        )}
+
+      <Dialog
+        open={submitFeedbackHook.isOpenModal}
+        onOpenChange={() => submitFeedbackHook.setIsOpenModal(!submitFeedbackHook.isOpenModal)}
+      >
+        <FeedbackModalContents submitFeedbackHook={submitFeedbackHook} />
+      </Dialog>
+    </>
+  );
+};
+
+export default MobileUserDrawer;

--- a/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
@@ -1,0 +1,85 @@
+import { Clock, Settings, ScrollText, HelpCircle, MessageSquare, LogOut } from "lucide-react";
+
+const ITEM_CLASS =
+  "flex w-full items-center gap-4 px-7 py-[16px] text-left font-archivo text-[17px] text-white active:bg-[#333333]";
+
+const Divider = () => <div className="mx-5 border-b border-white/10" />;
+
+interface MobileUserDrawerPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onTimeline: () => void;
+  onManage: () => void;
+  onManifesto: () => void;
+  onFaq: () => void;
+  onFeedback: () => void;
+  onLogout: () => void;
+  isMiniApp: boolean;
+  displayName: string | null;
+}
+
+const MobileUserDrawerPanel = ({
+  isOpen,
+  onClose,
+  onTimeline,
+  onManage,
+  onManifesto,
+  onFaq,
+  onFeedback,
+  onLogout,
+  isMiniApp,
+  displayName,
+}: MobileUserDrawerPanelProps) => (
+  <>
+    {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
+    <div
+      className={`fixed bottom-[74px] left-0 right-0 z-50 overflow-hidden bg-grey-moss-900 shadow-2xl transition-transform duration-300 ease-out ${
+        isOpen ? "translate-y-0" : "translate-y-full"
+      }`}
+    >
+      <button onClick={onTimeline} className={ITEM_CLASS}>
+        <Clock className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
+        Timeline
+      </button>
+      <Divider />
+      <button onClick={onManage} className={ITEM_CLASS}>
+        <Settings className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
+        Manage
+      </button>
+      <Divider />
+      <button onClick={onManifesto} className={ITEM_CLASS}>
+        <ScrollText className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
+        Manifesto
+      </button>
+      <Divider />
+      <button onClick={onFaq} className={ITEM_CLASS}>
+        <HelpCircle className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
+        FAQ
+      </button>
+      <Divider />
+      <button onClick={onFeedback} className={ITEM_CLASS}>
+        <MessageSquare className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
+        Feedback
+      </button>
+      {!isMiniApp && (
+        <>
+          <Divider />
+          <button
+            onClick={onLogout}
+            className="flex w-full items-center gap-4 px-7 py-[16px] active:bg-[#333333]"
+          >
+            <LogOut className="h-[18px] w-[18px] shrink-0 text-white/40" strokeWidth={1.5} />
+            <div className="flex flex-col items-start">
+              {displayName && (
+                <span className="font-archivo-medium text-[13px] text-white/60">{displayName}</span>
+              )}
+              <span className="font-archivo text-[15px] text-white/40">Log out</span>
+            </div>
+          </button>
+        </>
+      )}
+    </div>
+  </>
+);
+
+export default MobileUserDrawerPanel;

--- a/hooks/useMobileUserDrawer.ts
+++ b/hooks/useMobileUserDrawer.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { usePrivy } from "@privy-io/react-auth";
+import { useWalletsProvider } from "@/providers/WalletsProvider";
+import { useMiniAppProvider } from "@/providers/MiniAppProvider";
+import { useUserProvider } from "@/providers/UserProvider";
+import useSubmitFeedback from "@/hooks/useSubmitFeedback";
+import truncated from "@/lib/truncated";
+import truncateAddress from "@/lib/truncateAddress";
+
+export const useMobileUserDrawer = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { push } = useRouter();
+  const { logout, login } = usePrivy();
+  const { primaryWallet } = useWalletsProvider();
+  const { isMiniApp } = useMiniAppProvider();
+  const { username } = useUserProvider();
+  const displayName = primaryWallet
+    ? truncated(username || "", 14) || truncateAddress(primaryWallet)
+    : null;
+  const submitFeedbackHook = useSubmitFeedback();
+
+  const toggle = () => {
+    if (!primaryWallet) {
+      login();
+      return;
+    }
+    setIsOpen((prev) => !prev);
+  };
+  const close = () => setIsOpen(false);
+
+  const onTimeline = () => {
+    close();
+    push(primaryWallet ? `/${primaryWallet}` : "/");
+  };
+
+  const onManage = () => {
+    close();
+    push("/manage");
+  };
+
+  const onManifesto = () => {
+    close();
+    window.open("/manifesto", "_blank");
+  };
+
+  const onFaq = () => {
+    close();
+    window.open("/faq", "_blank");
+  };
+
+  const onFeedback = () => {
+    close();
+    submitFeedbackHook.setIsOpenModal(true);
+  };
+
+  const onLogout = () => {
+    close();
+    logout();
+  };
+
+  return {
+    isOpen,
+    toggle,
+    close,
+    onTimeline,
+    onManage,
+    onManifesto,
+    onFaq,
+    onFeedback,
+    onLogout,
+    isMiniApp,
+    displayName,
+    submitFeedbackHook,
+  };
+};


### PR DESCRIPTION
## Summary

- Tapping the User icon in the mobile tab bar opens a slide-up drawer rendered via `createPortal` (avoids stacking context conflicts with the fixed tab bar)
- Drawer animates from the tab bar's top edge using `translate-y-full` → `translate-y-0`
- Menu items with icons: Timeline (Clock), Manage (Settings), Manifesto (ScrollText), FAQ (HelpCircle), Feedback (MessageSquare → opens existing modal)
- Log out row shows LogOut icon + user's name or truncated address above "Log out" text
- If signed out, tapping the User icon triggers Privy login instead of opening the drawer

## Test plan

- [ ] Signed-in: User icon opens drawer, all menu items navigate correctly
- [ ] Signed-out: User icon triggers Privy login flow
- [ ] Drawer animates up from tab bar top edge, closes on backdrop tap or second User icon tap
- [ ] Feedback item opens feedback modal
- [ ] Manifesto and FAQ open in new tab
- [ ] Log out row displays correct name/address and logs out on tap
- [ ] Tab bar remains fully visible when drawer is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)