### PR TITLE
feat: add feedback drawer to mobile home tab bar

### DIFF
--- a/components/Footer/FeedbackMediaAttachment.tsx
+++ b/components/Footer/FeedbackMediaAttachment.tsx
@@ -31,7 +31,7 @@ const FeedbackMediaAttachment = ({
   return (
     <div className="mb-3 w-full">
       <Label className="text-grey-moss-600 mb-1 w-full pt-3 text-left font-archivo text-sm">
-        add media (optional)
+        Add media (optional)
       </Label>
 
       <input
@@ -46,7 +46,7 @@ const FeedbackMediaAttachment = ({
         htmlFor="media-upload"
         className="text-grey-moss-600 flex w-full cursor-pointer items-center justify-center border border-dashed border-black bg-grey-moss-50 p-3 font-spectral transition-colors hover:bg-grey-moss-100"
       >
-        {mediaFile ? "change media" : "click to add media"}
+        {mediaFile ? "Change media" : "Click to add media"}
       </label>
 
       {mediaPreview && mediaFile && (

--- a/components/Timeline/MobileHome/MobileFeedbackDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileFeedbackDrawer.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { MessageSquare } from "lucide-react";
+import { useMobileFeedbackDrawer } from "@/hooks/useMobileFeedbackDrawer";
+import MobileFeedbackDrawerPanel from "./MobileFeedbackDrawerPanel";
+
+const MobileFeedbackDrawer = () => {
+  const { isOpen, toggle, close, feedbackHook } = useMobileFeedbackDrawer();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <>
+      <button type="button" onClick={toggle}>
+        <MessageSquare
+          className="h-[23px] w-[23px]"
+          strokeWidth={1.75}
+          color={isOpen ? "#1B1504" : "#B6B2A8"}
+        />
+      </button>
+
+      {mounted &&
+        createPortal(
+          <MobileFeedbackDrawerPanel isOpen={isOpen} onClose={close} feedbackHook={feedbackHook} />,
+          document.body
+        )}
+    </>
+  );
+};
+
+export default MobileFeedbackDrawer;

--- a/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
@@ -1,0 +1,93 @@
+import { X } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import FeedbackMediaAttachment from "@/components/Footer/FeedbackMediaAttachment";
+import { UseSubmitFeedbackReturn } from "@/hooks/useSubmitFeedback";
+
+interface MobileFeedbackDrawerPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  feedbackHook: UseSubmitFeedbackReturn;
+}
+
+const MobileFeedbackDrawerPanel = ({
+  isOpen,
+  onClose,
+  feedbackHook,
+}: MobileFeedbackDrawerPanelProps) => {
+  const {
+    feedback,
+    setFeedback,
+    name,
+    setName,
+    isLoading,
+    submit,
+    mediaFile,
+    setMediaFile,
+    mediaPreview,
+    setMediaPreview,
+  } = feedbackHook;
+
+  return (
+    <>
+      {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
+      <div
+        className={`fixed bottom-[74px] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out ${
+          isOpen ? "translate-y-0" : "translate-y-full"
+        }`}
+      >
+        <div className="flex flex-col px-6 pb-4 pt-7">
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-5 top-4 flex h-8 w-8 items-center justify-center text-grey-moss-400"
+          >
+            <X className="h-5 w-5" strokeWidth={1.5} />
+          </button>
+
+          <h2 className="mb-0.5 font-archivo text-2xl text-grey-moss-900">Let us hear from you</h2>
+          <p className="mb-4 font-archivo text-sm italic text-grey-primary">
+            How&apos;s your process?
+          </p>
+
+          <Label className="mb-1 font-archivo text-sm text-grey-primary">Email</Label>
+          <input
+            type="email"
+            className="mb-3 w-full border border-black bg-white px-3 py-2 font-spectral outline-none"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+
+          <Label className="mb-1 font-archivo text-sm text-grey-primary">Share feedback</Label>
+          <textarea
+            className="w-full border border-black bg-grey-moss-50 px-3 py-2 font-spectral outline-none"
+            rows={4}
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+          />
+
+          <div className="mt-3">
+            <FeedbackMediaAttachment
+              mediaFile={mediaFile}
+              mediaPreview={mediaPreview}
+              onMediaChange={(file, preview) => {
+                setMediaFile(file);
+                setMediaPreview(preview);
+              }}
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!feedback.trim() || !name.trim() || isLoading}
+            className="mt-1 w-full rounded-lg bg-grey-moss-900 py-2.5 font-archivo text-xl text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? "Sending..." : "Send"}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MobileFeedbackDrawerPanel;

--- a/components/Timeline/MobileHome/MobileTabBar.tsx
+++ b/components/Timeline/MobileHome/MobileTabBar.tsx
@@ -4,6 +4,7 @@ import { House, Search, Bell } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
 import NotificationCountBadge from "@/components/Header/NotificationCountBadge";
 import MobileUserDrawer from "./MobileUserDrawer";
+import MobileFeedbackDrawer from "./MobileFeedbackDrawer";
 
 const MobileTabBar = () => {
   const { push } = useRouter();
@@ -25,6 +26,7 @@ const MobileTabBar = () => {
         <Bell className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
         <NotificationCountBadge />
       </button>
+      <MobileFeedbackDrawer />
       <MobileUserDrawer />
     </div>
   );

--- a/components/Timeline/MobileHome/MobileUserDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileUserDrawer.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { User } from "lucide-react";
-import { Dialog } from "@/components/ui/dialog";
-import FeedbackModalContents from "@/components/Footer/FeedbackModalContents";
 import { useMobileUserDrawer } from "@/hooks/useMobileUserDrawer";
 import MobileUserDrawerPanel from "./MobileUserDrawerPanel";
 
@@ -17,11 +15,9 @@ const MobileUserDrawer = () => {
     onManage,
     onManifesto,
     onFaq,
-    onFeedback,
     onLogout,
     isMiniApp,
     displayName,
-    submitFeedbackHook,
   } = useMobileUserDrawer();
 
   const [mounted, setMounted] = useState(false);
@@ -46,20 +42,12 @@ const MobileUserDrawer = () => {
             onManage={onManage}
             onManifesto={onManifesto}
             onFaq={onFaq}
-            onFeedback={onFeedback}
             onLogout={onLogout}
             isMiniApp={isMiniApp}
             displayName={displayName}
           />,
           document.body
         )}
-
-      <Dialog
-        open={submitFeedbackHook.isOpenModal}
-        onOpenChange={() => submitFeedbackHook.setIsOpenModal(!submitFeedbackHook.isOpenModal)}
-      >
-        <FeedbackModalContents submitFeedbackHook={submitFeedbackHook} />
-      </Dialog>
     </>
   );
 };

--- a/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
@@ -1,4 +1,4 @@
-import { Clock, Settings, ScrollText, HelpCircle, MessageSquare, LogOut } from "lucide-react";
+import { Clock, Settings, ScrollText, HelpCircle, LogOut } from "lucide-react";
 
 const ITEM_CLASS =
   "flex w-full items-center gap-4 px-7 py-[16px] text-left font-archivo text-[17px] text-white active:bg-[#333333]";
@@ -12,7 +12,6 @@ interface MobileUserDrawerPanelProps {
   onManage: () => void;
   onManifesto: () => void;
   onFaq: () => void;
-  onFeedback: () => void;
   onLogout: () => void;
   isMiniApp: boolean;
   displayName: string | null;
@@ -25,7 +24,6 @@ const MobileUserDrawerPanel = ({
   onManage,
   onManifesto,
   onFaq,
-  onFeedback,
   onLogout,
   isMiniApp,
   displayName,
@@ -55,11 +53,6 @@ const MobileUserDrawerPanel = ({
       <button onClick={onFaq} className={ITEM_CLASS}>
         <HelpCircle className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
         FAQ
-      </button>
-      <Divider />
-      <button onClick={onFeedback} className={ITEM_CLASS}>
-        <MessageSquare className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
-        Feedback
       </button>
       {!isMiniApp && (
         <>

--- a/hooks/useMobileFeedbackDrawer.ts
+++ b/hooks/useMobileFeedbackDrawer.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import useSubmitFeedback from "@/hooks/useSubmitFeedback";
+
+export const useMobileFeedbackDrawer = () => {
+  const feedbackHook = useSubmitFeedback();
+  const { isOpenModal: isOpen, setIsOpenModal } = feedbackHook;
+
+  const toggle = () => setIsOpenModal(!isOpen);
+  const close = () => setIsOpenModal(false);
+
+  return { isOpen, toggle, close, feedbackHook };
+};

--- a/hooks/useMobileUserDrawer.ts
+++ b/hooks/useMobileUserDrawer.ts
@@ -6,7 +6,6 @@ import { usePrivy } from "@privy-io/react-auth";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import { useMiniAppProvider } from "@/providers/MiniAppProvider";
 import { useUserProvider } from "@/providers/UserProvider";
-import useSubmitFeedback from "@/hooks/useSubmitFeedback";
 import truncated from "@/lib/truncated";
 import truncateAddress from "@/lib/truncateAddress";
 
@@ -20,8 +19,6 @@ export const useMobileUserDrawer = () => {
   const displayName = primaryWallet
     ? truncated(username || "", 14) || truncateAddress(primaryWallet)
     : null;
-  const submitFeedbackHook = useSubmitFeedback();
-
   const toggle = () => {
     if (!primaryWallet) {
       login();
@@ -51,11 +48,6 @@ export const useMobileUserDrawer = () => {
     window.open("/faq", "_blank");
   };
 
-  const onFeedback = () => {
-    close();
-    submitFeedbackHook.setIsOpenModal(true);
-  };
-
   const onLogout = () => {
     close();
     logout();
@@ -69,10 +61,8 @@ export const useMobileUserDrawer = () => {
     onManage,
     onManifesto,
     onFaq,
-    onFeedback,
     onLogout,
     isMiniApp,
     displayName,
-    submitFeedbackHook,
   };
 };


### PR DESCRIPTION
## Summary
- Add MessageSquare icon to mobile tab bar (between Bell and User icons)
- Tapping it opens a full-screen drawer that slides up from the tab bar top edge to the top of the viewport
- Feedback form (Email, Share feedback, Add media, Send) is rendered inside the drawer — no modal
- Remove Feedback item from user drawer and clean up related hook/component code

## Test plan
- [ ] Tap MessageSquare icon → feedback drawer slides up full screen
- [ ] Close via X button or backdrop tap → drawer slides back down
- [ ] Submit with valid email + feedback → drawer closes on success
- [ ] Submit with empty fields → Send button disabled
- [ ] User drawer no longer shows Feedback item
- [ ] User drawer still works normally (Timeline, Manage, Manifesto, FAQ, Log out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)