### PR TITLE
feat: resize notification badge for mobile tab bar

### DIFF
--- a/components/Header/NotificationCountBadge.tsx
+++ b/components/Header/NotificationCountBadge.tsx
@@ -3,7 +3,11 @@
 import { useNotificationsProvider } from "@/providers/NotificationsProvider";
 import { Badge } from "@/components/ui/badge";
 
-const NotificationCountBadge = () => {
+interface NotificationCountBadgeProps {
+  className?: string;
+}
+
+const NotificationCountBadge = ({ className }: NotificationCountBadgeProps) => {
   const { unviewedCount } = useNotificationsProvider();
 
   if (unviewedCount === 0) return null;
@@ -11,7 +15,10 @@ const NotificationCountBadge = () => {
   return (
     <Badge
       variant="destructive"
-      className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center p-0 text-xs font-bold"
+      className={
+        className ??
+        "absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center p-0 text-xs font-bold"
+      }
     >
       {unviewedCount > 99 ? "99+" : unviewedCount}
     </Badge>

--- a/components/Timeline/MobileHome/MobileTabBar.tsx
+++ b/components/Timeline/MobileHome/MobileTabBar.tsx
@@ -24,7 +24,7 @@ const MobileTabBar = () => {
       </button>
       <button type="button" onClick={() => push("/notifications")} className="relative">
         <Bell className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
-        <NotificationCountBadge />
+        <NotificationCountBadge className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full p-0 text-[9px] font-bold leading-none" />
       </button>
       <MobileFeedbackDrawer />
       <MobileUserDrawer />


### PR DESCRIPTION
## Summary
- Add optional `className` prop to `NotificationCountBadge` to allow per-context size override
- Mobile tab bar passes `h-[14px] text-[9px] leading-none` for a proportional badge next to 23px icons
- Desktop header badge remains unchanged at `h-5 w-5 text-xs`

## Test plan
- [ ] Mobile tab bar — notification badge is small and fits neatly on the Bell icon
- [ ] Desktop header — notification badge size and position unchanged
- [ ] Badge shows correct unread count; hides when count is 0; shows "99+" when > 99

🤖 Generated with [Claude Code](https://claude.com/claude-code)