### PR TITLE
feat: add artist search drawer to mobile home tab bar

### DIFF
--- a/components/Timeline/MobileHome/MobileSearchDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileSearchDrawer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { Search } from "lucide-react";
+import useSearch from "@/hooks/useSearch";
+import MobileSearchDrawerPanel from "./MobileSearchDrawerPanel";
+
+const MobileSearchDrawer = () => {
+  const {
+    isOpenModal: isOpen,
+    setIsOpenModal,
+    searchKey,
+    suffixHint,
+    artists,
+    isLoadingSearch,
+    onChangeSearchKey,
+    onKeyDown,
+    navigateTo,
+  } = useSearch();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <>
+      <button type="button" onClick={() => setIsOpenModal(true)}>
+        <Search
+          className="h-[23px] w-[23px]"
+          strokeWidth={1.75}
+          color={isOpen ? "#1B1504" : "#B6B2A8"}
+        />
+      </button>
+
+      {mounted &&
+        createPortal(
+          <MobileSearchDrawerPanel
+            isOpen={isOpen}
+            onClose={() => setIsOpenModal(false)}
+            searchKey={searchKey}
+            suffixHint={suffixHint}
+            artists={artists}
+            isLoading={isLoadingSearch}
+            onChangeSearchKey={onChangeSearchKey}
+            onKeyDown={onKeyDown}
+            navigateTo={navigateTo}
+          />,
+          document.body
+        )}
+    </>
+  );
+};
+
+export default MobileSearchDrawer;

--- a/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
@@ -1,0 +1,101 @@
+import { useRef, useEffect } from "react";
+import { X, Search } from "lucide-react";
+import { SearchedArtist } from "@/lib/artists/searchArtists";
+import { getPrimaryWalletAddress } from "@/lib/wallets/getPrimaryWalletAddress";
+import truncateAddress from "@/lib/truncateAddress";
+import { KeyboardEvent, ChangeEvent } from "react";
+
+interface MobileSearchDrawerPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  searchKey: string;
+  suffixHint: string;
+  artists: SearchedArtist[];
+  isLoading: boolean;
+  onChangeSearchKey: (e: ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  navigateTo: (address: string) => void;
+}
+
+const MobileSearchDrawerPanel = ({
+  isOpen,
+  onClose,
+  searchKey,
+  suffixHint,
+  artists,
+  isLoading,
+  onChangeSearchKey,
+  onKeyDown,
+  navigateTo,
+}: MobileSearchDrawerPanelProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) setTimeout(() => inputRef.current?.focus(), 300);
+  }, [isOpen]);
+
+  return (
+    <div
+      className={`fixed bottom-[74px] left-0 right-0 top-0 z-50 flex flex-col bg-white transition-transform duration-300 ease-out ${
+        isOpen ? "translate-y-0" : "translate-y-full"
+      }`}
+    >
+      <div className="flex items-center gap-3 border-b border-grey-moss-100 px-5 py-4">
+        <Search className="h-5 w-5 shrink-0 text-grey-moss-400" strokeWidth={1.75} />
+        <div className="relative flex flex-1 items-center">
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search artists"
+            className="w-full font-archivo text-[17px] placeholder-grey-moss-300 outline-none"
+            value={searchKey}
+            onChange={onChangeSearchKey}
+            onKeyDown={onKeyDown}
+          />
+          {suffixHint && (
+            <div className="pointer-events-none absolute left-0 top-0 flex w-full items-center">
+              <span className="font-archivo text-[17px] opacity-0">{searchKey}</span>
+              <span className="font-archivo text-[17px] text-grey-moss-300">{suffixHint}</span>
+            </div>
+          )}
+        </div>
+        <button type="button" onClick={onClose} className="shrink-0 text-grey-moss-400">
+          <X className="h-5 w-5" strokeWidth={1.5} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {searchKey && !isLoading && artists.length === 0 && (
+          <p className="px-5 py-4 font-archivo text-sm text-grey-moss-300">
+            No results in the matrix, search again
+          </p>
+        )}
+        {artists.map((artist, i) => {
+          const address = getPrimaryWalletAddress(artist.wallets);
+          if (!address) return null;
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => navigateTo(address)}
+              className="flex w-full items-center gap-3 border-b border-grey-moss-100 px-5 py-4 text-left active:bg-grey-moss-50"
+            >
+              <div className="flex flex-col">
+                {artist.username && (
+                  <span className="font-archivo text-[15px] text-grey-moss-900">
+                    {artist.username}
+                  </span>
+                )}
+                <span className="font-archivo text-[13px] text-grey-moss-400">
+                  {truncateAddress(address)}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default MobileSearchDrawerPanel;

--- a/components/Timeline/MobileHome/MobileTabBar.tsx
+++ b/components/Timeline/MobileHome/MobileTabBar.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { House, Search, Bell } from "lucide-react";
+import { House, Bell } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
 import NotificationCountBadge from "@/components/Header/NotificationCountBadge";
 import MobileUserDrawer from "./MobileUserDrawer";
 import MobileFeedbackDrawer from "./MobileFeedbackDrawer";
+import MobileSearchDrawer from "./MobileSearchDrawer";
 
 const MobileTabBar = () => {
   const { push } = useRouter();
@@ -19,9 +20,7 @@ const MobileTabBar = () => {
           color={pathname === "/" ? "#1B1504" : "#B6B2A8"}
         />
       </button>
-      <button type="button">
-        <Search className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
-      </button>
+      <MobileSearchDrawer />
       <button type="button" onClick={() => push("/notifications")} className="relative">
         <Bell className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
         <NotificationCountBadge className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full p-0 text-[9px] font-bold leading-none" />

--- a/hooks/useSearch.ts
+++ b/hooks/useSearch.ts
@@ -19,6 +19,12 @@ const useSearch = () => {
   const firstArtistAddress = firstArtist ? getPrimaryWalletAddress(firstArtist.wallets) : undefined;
   const userSearchData = useMemo(() => ({ artist: firstArtist }), [firstArtist]);
 
+  const navigateTo = (address: string) => {
+    setIsOpenModal(false);
+    setIsExpandedSearchInput(false);
+    push(`/${address}`);
+  };
+
   const suffixHint = useMemo(() => {
     if (!firstArtist?.username) return "";
     return firstArtist.username.slice(searchKey.length);
@@ -58,12 +64,14 @@ const useSearch = () => {
 
   return {
     userSearchData,
+    artists,
     isLoadingSearch,
     onChangeSearchKey,
     onKeyDown,
     suffixHint,
     searchKey,
     redirectToArtist,
+    navigateTo,
     isOpenModal,
     setIsOpenModal,
   };


### PR DESCRIPTION
## Summary
- Replace the no-op Search icon in the mobile tab bar with a functional full-screen search drawer
- Drawer slides up from the tab bar top edge to `top: 0` (same pattern as feedback drawer)
- Input has ghost-hint autocomplete: Tab accepts the hint, Enter navigates to the first result
- All API candidates are listed below the input — each showing username + truncated address — and tapping any item navigates to that artist's page
- Extended `useSearch` with `artists` (full candidate list) and `navigateTo(address)` to avoid a separate hook

## Test plan
- [ ] Tap Search icon → drawer slides up full screen, input auto-focuses
- [ ] Type artist name → ghost hint appears for first candidate
- [ ] Press Tab → input fills with first candidate's username
- [ ] Press Enter → navigates to first candidate's artist page
- [ ] All candidates appear as list items below the input
- [ ] Tap a list item → navigates to that artist's page, drawer closes
- [ ] No results → "No results in the matrix, search again" message shown
- [ ] Tap X → drawer closes, search input clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile search drawer with a dedicated search panel, including search input, loading state, empty state, and tappable results.
  * Search results now open the selected artist directly from the mobile drawer.
  * The mobile tab bar now uses the new drawer-based search experience.

* **Bug Fixes**
  * Improved mobile rendering reliability by waiting for the page to mount before showing the drawer.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->