### PR TITLE
fix: wrap mobile header logo in Link to enable homepage navigation

### DIFF
--- a/components/Header/MobileHeader.tsx
+++ b/components/Header/MobileHeader.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { useWindowScrolled } from "@/hooks/useWindowScrolled";
 
@@ -12,9 +13,9 @@ const MobileHeader = () => {
         isScrolled ? "bg-white" : "bg-transparent"
       )}
     >
-      <div className="relative h-[22px] w-[97px]">
+      <Link href="/" className="relative h-[22px] w-[97px] block">
         <Image src="/logo.svg" alt="in process" fill />
-      </div>
+      </Link>
       <div className="flex items-center gap-3">
         <a
           href="https://x.com/stayinprocess"


### PR DESCRIPTION
## Summary
- Mobile header logo was a plain `<div>` with no click handler, so tapping it did nothing
- Replaced the wrapper `<div>` with a Next.js `<Link href="/">` so tapping the logo navigates to the homepage

## Test plan
- [ ] Tap the logo on a mobile viewport — should navigate to `/`
- [ ] Desktop header logo still navigates to `/` (unchanged, uses existing `Logo` component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The mobile header logo is now clickable and takes users to the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->