### PR TITLE
feat: add sold-out state to MobileFeedCard Collect button

### DIFF
--- a/components/Timeline/MobileHome/MobileFeedCard.tsx
+++ b/components/Timeline/MobileHome/MobileFeedCard.tsx
@@ -4,13 +4,14 @@ import { TimelineMoment } from "@/types/moment";
 import { ExternalLink } from "lucide-react";
 import ContentRenderer from "@/components/Renderers";
 import { useMobileFeedCard } from "@/hooks/useMobileFeedCard";
+import { cn } from "@/lib/utils";
 
 interface MobileFeedCardProps {
   moment: TimelineMoment;
 }
 
 const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
-  const { metadata, externalUrl, priceLabel, onCollect, onExternalLink } =
+  const { metadata, externalUrl, priceLabel, isSoldOut, onCollect, onExternalLink } =
     useMobileFeedCard(moment);
   const creatorName = moment.creator.username ?? `${moment.creator.address.slice(0, 6)}...`;
   const timeStr = new Date(moment.created_at).toLocaleString();
@@ -47,10 +48,16 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
             )}
             <button
               type="button"
-              onClick={onCollect}
-              className="rounded-[22px] bg-grey-moss-900 px-[18px] py-[9px] font-archivo-medium text-sm text-white active:opacity-80"
+              disabled={isSoldOut}
+              onClick={isSoldOut ? undefined : onCollect}
+              className={cn(
+                "rounded-[22px] px-[18px] py-[9px] font-archivo-medium text-sm",
+                isSoldOut
+                  ? "cursor-not-allowed bg-grey-moss-300 text-white"
+                  : "bg-grey-moss-900 text-white active:opacity-80"
+              )}
             >
-              Collect
+              {isSoldOut ? "Sold Out" : "Collect"}
             </button>
           </div>
         </div>

--- a/hooks/useMobileFeedCard.ts
+++ b/hooks/useMobileFeedCard.ts
@@ -7,10 +7,12 @@ import { isDeprecatedUrl } from "@/lib/url/isDeprecatedUrl";
 import { isYoutubeUrl } from "@/lib/url/isYoutubeUrl";
 import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
 import { formatSalePriceLabel } from "@/lib/moment/formatSalePriceLabel";
+import { isTimelineSaleSoldOut } from "@/lib/moment/isTimelineSaleSoldOut";
 
 export const useMobileFeedCard = (moment: TimelineMoment) => {
   const { push } = useRouter();
   const { chain_id, address, token_id, metadata, sale } = moment;
+  const isSoldOut = isTimelineSaleSoldOut(sale);
 
   const externalUrl = (() => {
     const url = metadata?.external_url;
@@ -32,6 +34,7 @@ export const useMobileFeedCard = (moment: TimelineMoment) => {
     metadata,
     externalUrl,
     priceLabel: formatSalePriceLabel(sale),
+    isSoldOut,
     onCollect,
     onExternalLink,
   };

--- a/lib/moment/isTimelineSaleSoldOut.ts
+++ b/lib/moment/isTimelineSaleSoldOut.ts
@@ -1,0 +1,7 @@
+import { MomentSaleConfig } from "@/types/moment";
+
+/** Timeline feed: saleEnd time only. On-chain supply exhaustion is not available here. */
+export const isTimelineSaleSoldOut = (sale: MomentSaleConfig | null | undefined): boolean => {
+  if (!sale || BigInt(sale.saleEnd) <= BigInt(0)) return false;
+  return sale.saleEnd * 1000 < Date.now();
+};


### PR DESCRIPTION
## Summary
- Adds `isTimelineSaleSoldOut` utility that checks if a moment's sale has ended by comparing `saleEnd` time against `Date.now()`
- Wires `isSoldOut` into `useMobileFeedCard` hook
- Updates `MobileFeedCard` Collect button to show "Sold Out" (disabled, grey) when sale has ended

## Test plan
- [ ] Open mobile feed and verify active sales show "Collect" button in dark moss style
- [ ] Verify moments with expired `saleEnd` show "Sold Out" button in grey, disabled state
- [ ] Confirm clicking "Sold Out" button does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)