### PR TITLE
feat: add mobile camera capture on create page drop zone

### DIFF
--- a/components/BulkUpload/BulkDropZone.tsx
+++ b/components/BulkUpload/BulkDropZone.tsx
@@ -38,18 +38,21 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
       <input
         ref={inputRef}
         type="file"
+        multiple
         accept="image/*,video/*,.pdf,audio/*,.glb,.gltf"
         className="hidden"
         onChange={onChange}
       />
-      <input
-        ref={cameraInputRef}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        className="hidden"
-        onChange={onCameraChange}
-      />
+      {isMobile && (
+        <input
+          ref={cameraInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className="hidden"
+          onChange={onCameraChange}
+        />
+      )}
 
       <div
         className={`flex size-16 items-center justify-center rounded-full border-2 transition-all duration-200 ${
@@ -73,7 +76,9 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
 
       <div className="flex flex-col items-center gap-2 px-6 text-center">
         <p className="font-archivo-medium text-lg text-grey-moss-800">drop files here</p>
-        <p className="font-archivo text-sm text-grey-moss-500">or click to browse</p>
+        <p className="font-archivo text-sm text-grey-moss-500">
+          {isMobile ? "or tap to choose files" : "or click to browse"}
+        </p>
         {isMobile && (
           <button
             type="button"
@@ -81,9 +86,10 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
               e.stopPropagation();
               openCameraDialog();
             }}
-            className="mt-1 flex items-center gap-2 rounded-lg border border-grey-moss-400 bg-white px-4 py-2 font-archivo-medium text-sm text-grey-moss-800"
+            onPointerDown={(e) => e.stopPropagation()}
+            className="mt-0.5 flex items-center gap-1.5 rounded-full border border-grey-moss-300 bg-white/90 px-3 py-1 font-archivo-medium text-xs text-grey-moss-700 active:bg-grey-moss-200"
           >
-            <Camera className="size-4" strokeWidth={1.75} />
+            <Camera className="size-3.5 text-grey-moss-500" strokeWidth={1.75} />
             Take a photo
           </button>
         )}

--- a/components/BulkUpload/BulkDropZone.tsx
+++ b/components/BulkUpload/BulkDropZone.tsx
@@ -1,14 +1,27 @@
 "use client";
 
+import { Camera } from "lucide-react";
 import useBulkDropZone from "@/hooks/useBulkDropZone";
+import useIsMobile from "@/hooks/useIsMobile";
 
 interface BulkDropZoneProps {
   onSingleFile: (file: File) => void;
 }
 
 const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
-  const { isDragging, inputRef, onDrop, onDragOver, onDragLeave, onChange, openFileDialog } =
-    useBulkDropZone(onSingleFile);
+  const isMobile = useIsMobile();
+  const {
+    isDragging,
+    inputRef,
+    cameraInputRef,
+    onDrop,
+    onDragOver,
+    onDragLeave,
+    onChange,
+    onCameraChange,
+    openFileDialog,
+    openCameraDialog,
+  } = useBulkDropZone(onSingleFile);
 
   return (
     <div
@@ -25,10 +38,17 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
       <input
         ref={inputRef}
         type="file"
-        multiple
         accept="image/*,video/*,.pdf,audio/*,.glb,.gltf"
         className="hidden"
         onChange={onChange}
+      />
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={onCameraChange}
       />
 
       <div
@@ -54,6 +74,19 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
       <div className="flex flex-col items-center gap-2 px-6 text-center">
         <p className="font-archivo-medium text-lg text-grey-moss-800">drop files here</p>
         <p className="font-archivo text-sm text-grey-moss-500">or click to browse</p>
+        {isMobile && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              openCameraDialog();
+            }}
+            className="mt-1 flex items-center gap-2 rounded-lg border border-grey-moss-400 bg-white px-4 py-2 font-archivo-medium text-sm text-grey-moss-800"
+          >
+            <Camera className="size-4" strokeWidth={1.75} />
+            Take a photo
+          </button>
+        )}
         <p className="mt-1 font-archivo text-xs text-grey-moss-400">
           images · video · PDF · audio · 3D
         </p>

--- a/hooks/useBulkDropZone.ts
+++ b/hooks/useBulkDropZone.ts
@@ -8,6 +8,7 @@ const useBulkDropZone = (onSingleFile: (file: File) => void) => {
   const { addFiles } = useBulkCreateProvider();
   const inputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
+  const suppressFileDialogRef = useRef(false);
 
   const handleFiles = useCallback(
     async (files: File[]) => {
@@ -59,11 +60,16 @@ const useBulkDropZone = (onSingleFile: (file: File) => void) => {
   );
 
   const openFileDialog = useCallback(() => {
+    if (suppressFileDialogRef.current) return;
     inputRef.current?.click();
   }, []);
 
   const openCameraDialog = useCallback(() => {
+    suppressFileDialogRef.current = true;
     cameraInputRef.current?.click();
+    window.setTimeout(() => {
+      suppressFileDialogRef.current = false;
+    }, 500);
   }, []);
 
   return {

--- a/hooks/useBulkDropZone.ts
+++ b/hooks/useBulkDropZone.ts
@@ -7,6 +7,7 @@ const useBulkDropZone = (onSingleFile: (file: File) => void) => {
   const [isDragging, setIsDragging] = useState(false);
   const { addFiles } = useBulkCreateProvider();
   const inputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
 
   const handleFiles = useCallback(
     async (files: File[]) => {
@@ -48,11 +49,35 @@ const useBulkDropZone = (onSingleFile: (file: File) => void) => {
     [handleFiles]
   );
 
+  const onCameraChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) onSingleFile(file);
+      if (cameraInputRef.current) cameraInputRef.current.value = "";
+    },
+    [onSingleFile]
+  );
+
   const openFileDialog = useCallback(() => {
     inputRef.current?.click();
   }, []);
 
-  return { isDragging, inputRef, onDrop, onDragOver, onDragLeave, onChange, openFileDialog };
+  const openCameraDialog = useCallback(() => {
+    cameraInputRef.current?.click();
+  }, []);
+
+  return {
+    isDragging,
+    inputRef,
+    cameraInputRef,
+    onDrop,
+    onDragOver,
+    onDragLeave,
+    onChange,
+    onCameraChange,
+    openFileDialog,
+    openCameraDialog,
+  };
 };
 
 export default useBulkDropZone;


### PR DESCRIPTION
Add a Take a photo button with capture input and remove multiple from the gallery picker so iOS can open the camera directly from /create.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile photo capture support during bulk upload.
  * On mobile, users can tap **Take a photo** to open the camera and capture an image directly.
* **Bug Fixes**
  * Camera-captured files are processed via the same single-file flow and the camera input is cleared after selection to prevent repeat issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->