### PR TITLE
fix: pin mobile header and footer to clip scroll bleed

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { Suspense } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { Providers } from "@/providers/Providers";
-import { Metadata } from "next";
+import { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
   alternates: {
@@ -13,14 +13,18 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  viewportFit: "cover",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="bg-grey-moss-100">
-      <body className="flex min-h-screen w-full flex-col !overflow-x-hidden !text-grey-moss-900">
+    <html lang="en" className="bg-white md:bg-grey-moss-100">
+      <body className="flex min-h-screen w-full flex-col overflow-x-hidden overscroll-y-none bg-white text-grey-moss-900 md:bg-grey-moss-100">
         <Suspense>
           <Providers>{children}</Providers>
           <Toaster />

--- a/components/Footer/MobileFooter.tsx
+++ b/components/Footer/MobileFooter.tsx
@@ -14,34 +14,36 @@ const MobileFooter = () => {
   const { closeDrawer } = useMobileDrawersProvider();
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-[60] flex h-[74px] items-center justify-around border-t border-[#EDEAE2] bg-white/[0.92] px-[30px] backdrop-blur-md">
-      <button
-        type="button"
-        onClick={() => {
-          closeDrawer();
-          push("/");
-        }}
-      >
-        <House
-          className="h-[23px] w-[23px]"
-          strokeWidth={1.75}
-          color={pathname === "/" ? "#1B1504" : "#B6B2A8"}
-        />
-      </button>
-      <MobileSearchDrawer />
-      <button
-        type="button"
-        onClick={() => {
-          closeDrawer();
-          push("/notifications");
-        }}
-        className="relative"
-      >
-        <Bell className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
-        <NotificationCountBadge className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full p-0 text-[9px] font-bold leading-none" />
-      </button>
-      <MobileFeedbackDrawer />
-      <MobileUserDrawer />
+    <div className="fixed bottom-0 left-0 right-0 z-[60] border-t border-[#EDEAE2] bg-white pb-[env(safe-area-inset-bottom,0px)]">
+      <div className="flex h-[74px] items-center justify-around px-[30px]">
+        <button
+          type="button"
+          onClick={() => {
+            closeDrawer();
+            push("/");
+          }}
+        >
+          <House
+            className="h-[23px] w-[23px]"
+            strokeWidth={1.75}
+            color={pathname === "/" ? "#1B1504" : "#B6B2A8"}
+          />
+        </button>
+        <MobileSearchDrawer />
+        <button
+          type="button"
+          onClick={() => {
+            closeDrawer();
+            push("/notifications");
+          }}
+          className="relative"
+        >
+          <Bell className="h-[23px] w-[23px] text-[#B6B2A8]" strokeWidth={1.75} />
+          <NotificationCountBadge className="absolute -right-1 -top-1 flex h-[14px] min-w-[14px] items-center justify-center rounded-full p-0 text-[9px] font-bold leading-none" />
+        </button>
+        <MobileFeedbackDrawer />
+        <MobileUserDrawer />
+      </div>
     </div>
   );
 };

--- a/components/Header/MobileHeader.tsx
+++ b/components/Header/MobileHeader.tsx
@@ -1,19 +1,10 @@
 import Image from "next/image";
 import Link from "next/link";
-import { cn } from "@/lib/utils";
-import { useWindowScrolled } from "@/hooks/useWindowScrolled";
 
-const MobileHeader = () => {
-  const isScrolled = useWindowScrolled();
-
-  return (
-    <div
-      className={cn(
-        "sticky top-0 z-30 flex items-center justify-between px-[22px] py-4 backdrop-blur-md transition-colors duration-200",
-        isScrolled ? "bg-white" : "bg-transparent"
-      )}
-    >
-      <Link href="/" className="relative h-[22px] w-[97px] block">
+const MobileHeader = () => (
+  <header className="fixed top-0 left-0 right-0 z-30 bg-white pt-[env(safe-area-inset-top,0px)]">
+    <div className="flex items-center justify-between px-[22px] py-4">
+      <Link href="/" className="relative block h-[22px] w-[97px]">
         <Image src="/logo.svg" alt="in process" fill />
       </Link>
       <div className="flex items-center gap-3">
@@ -35,7 +26,7 @@ const MobileHeader = () => {
         </a>
       </div>
     </div>
-  );
-};
+  </header>
+);
 
 export default MobileHeader;

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -19,11 +19,14 @@ const Layout = ({ children }: { children: ReactNode }) => {
         className={cn(
           "flex grow flex-col",
           isOpenNavbar && "h-screen overflow-hidden",
-          isTextureLayout && "bg-[url('/bg-gray.png')] bg-cover bg-fixed bg-top bg-no-repeat"
+          isTextureLayout &&
+            "bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat max-md:bg-scroll md:bg-fixed"
         )}
       >
         <Header />
-        <div className="relative flex grow flex-col pb-[74px] md:pb-0">{children}</div>
+        <div className="relative flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:pb-0 md:pt-0">
+          {children}
+        </div>
         <Footer />
       </div>
     </MobileDrawersProvider>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -15,14 +15,13 @@ const Layout = ({ children }: { children: ReactNode }) => {
 
   return (
     <MobileDrawersProvider>
-      <div
-        className={cn(
-          "flex grow flex-col",
-          isOpenNavbar && "h-screen overflow-hidden",
-          isTextureLayout &&
-            "bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat max-md:bg-scroll md:bg-fixed"
-        )}
-      >
+      {isTextureLayout && (
+        <div
+          aria-hidden
+          className="pointer-events-none fixed inset-0 -z-10 bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat"
+        />
+      )}
+      <div className={cn("flex grow flex-col", isOpenNavbar && "h-screen overflow-hidden")}>
         <Header />
         <div className="relative flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:pb-0 md:pt-0">
           {children}

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -24,13 +24,11 @@ const Layout = ({ children }: { children: ReactNode }) => {
             className="pointer-events-none fixed inset-0 z-0 bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat"
           />
         )}
-        <div className="relative z-10 flex grow flex-col">
-          <Header />
-          <div className="relative flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:pb-0 md:pt-0">
-            {children}
-          </div>
-          <Footer />
+        <Header />
+        <div className="relative z-10 flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:pb-0 md:pt-0">
+          {children}
         </div>
+        <Footer />
       </div>
     </MobileDrawersProvider>
   );

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -15,18 +15,22 @@ const Layout = ({ children }: { children: ReactNode }) => {
 
   return (
     <MobileDrawersProvider>
-      {isTextureLayout && (
-        <div
-          aria-hidden
-          className="pointer-events-none fixed inset-0 -z-10 bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat"
-        />
-      )}
-      <div className={cn("flex grow flex-col", isOpenNavbar && "h-screen overflow-hidden")}>
-        <Header />
-        <div className="relative flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:pb-0 md:pt-0">
-          {children}
+      <div
+        className={cn("relative flex grow flex-col", isOpenNavbar && "h-screen overflow-hidden")}
+      >
+        {isTextureLayout && (
+          <div
+            aria-hidden
+            className="pointer-events-none fixed inset-0 z-0 bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat"
+          />
+        )}
+        <div className="relative z-10 flex grow flex-col">
+          <Header />
+          <div className="relative flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:pb-0 md:pt-0">
+            {children}
+          </div>
+          <Footer />
         </div>
-        <Footer />
       </div>
     </MobileDrawersProvider>
   );

--- a/components/Timeline/MobileHome/MobileCollectDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileCollectDrawer.tsx
@@ -42,7 +42,7 @@ const MobileCollectDrawer = () => {
         />
       )}
       <div
-        className={`fixed bottom-[74px] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out ${
+        className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out ${
           isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
         }`}
       >

--- a/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
@@ -31,7 +31,7 @@ const MobileFeedbackDrawerPanel = ({
     <>
       {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
       <div
-        className={`fixed bottom-[74px] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out ${
+        className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out ${
           isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
         }`}
       >

--- a/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
@@ -36,7 +36,7 @@ const MobileSearchDrawerPanel = ({
 
   return (
     <div
-      className={`fixed bottom-[74px] left-0 right-0 top-0 z-50 flex flex-col bg-white transition-transform duration-300 ease-out ${
+      className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 flex flex-col bg-white transition-transform duration-300 ease-out ${
         isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
       }`}
     >

--- a/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
@@ -31,7 +31,7 @@ const MobileUserDrawerPanel = ({
   <>
     {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
     <div
-      className={`fixed bottom-[74px] left-0 right-0 z-50 overflow-hidden bg-grey-moss-900 shadow-2xl transition-transform duration-300 ease-out ${
+      className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 z-50 overflow-hidden bg-grey-moss-900 shadow-2xl transition-transform duration-300 ease-out ${
         isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
       }`}
     >


### PR DESCRIPTION
Use fixed opaque header and footer with safe-area padding so feed content no longer appears above the header or below the tab bar on mobile home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile layout support for devices with safe-area insets, helping content and controls fit better on modern phones.
  * Updated the app shell to better support full-screen display modes.

* **Bug Fixes**
  * Fixed mobile header and footer placement for more consistent top/bottom spacing.
  * Adjusted mobile drawers and panels so they no longer overlap device home indicators or notch areas.
  * Refined background and scroll behavior for a smoother experience on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->