### PR TITLE
Always show external link icon on mobile feed cards

### DIFF
--- a/components/Timeline/MobileHome/MobileFeedCard.tsx
+++ b/components/Timeline/MobileHome/MobileFeedCard.tsx
@@ -16,11 +16,10 @@ const actionButtonClass = "inline-flex items-center gap-1.5 text-grey-moss-700 a
 const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
   const {
     metadata,
-    externalUrl,
     priceLabel,
     isSoldOut,
     onCollect,
-    onExternalLink,
+    handleMomentClick,
     commentCount,
     showComments,
   } = useMobileFeedCard(moment);
@@ -66,19 +65,17 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
                 </span>
               </button>
             )}
-            {externalUrl && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onExternalLink();
-                }}
-                className={actionButtonClass}
-                aria-label="Open external link"
-              >
-                <ExternalLink className="h-[17px] w-[17px]" strokeWidth={1.75} />
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleMomentClick();
+              }}
+              className={actionButtonClass}
+              aria-label="Open moment link"
+            >
+              <ExternalLink className="h-[17px] w-[17px]" strokeWidth={1.75} />
+            </button>
           </div>
 
           <div className="flex shrink-0 items-center gap-2">

--- a/components/Timeline/MobileHome/MobileFeedCard.tsx
+++ b/components/Timeline/MobileHome/MobileFeedCard.tsx
@@ -48,6 +48,30 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
         </p>
 
         <div className="flex items-center justify-between gap-3">
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              disabled={isSoldOut}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!isSoldOut) onCollect();
+              }}
+              className={cn(
+                "rounded-[22px] px-[18px] py-[9px] font-archivo-medium text-sm",
+                isSoldOut
+                  ? "cursor-not-allowed bg-grey-moss-300 text-white"
+                  : "bg-grey-moss-900 text-white active:opacity-80"
+              )}
+            >
+              {isSoldOut ? "Sold Out" : "Collect"}
+            </button>
+            {priceLabel && (
+              <span className="font-archivo-bold text-xs uppercase text-tan-gold">
+                {priceLabel}
+              </span>
+            )}
+          </div>
+
           <div className="flex min-w-0 items-center gap-3">
             {showComments && (
               <button
@@ -75,30 +99,6 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
               aria-label="Open moment link"
             >
               <ChainLinkIcon className="h-[17px] w-[17px]" strokeWidth={1.75} />
-            </button>
-          </div>
-
-          <div className="flex shrink-0 items-center gap-2">
-            {priceLabel && (
-              <span className="font-archivo-bold text-xs uppercase text-tan-gold">
-                {priceLabel}
-              </span>
-            )}
-            <button
-              type="button"
-              disabled={isSoldOut}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (!isSoldOut) onCollect();
-              }}
-              className={cn(
-                "rounded-[22px] px-[18px] py-[9px] font-archivo-medium text-sm",
-                isSoldOut
-                  ? "cursor-not-allowed bg-grey-moss-300 text-white"
-                  : "bg-grey-moss-900 text-white active:opacity-80"
-              )}
-            >
-              {isSoldOut ? "Sold Out" : "Collect"}
             </button>
           </div>
         </div>

--- a/components/Timeline/MobileHome/MobileFeedCard.tsx
+++ b/components/Timeline/MobileHome/MobileFeedCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TimelineMoment } from "@/types/moment";
-import { ExternalLink, MessageCircle } from "lucide-react";
+import { Link2, MessageCircle } from "lucide-react";
 import Link from "next/link";
 import ContentRenderer from "@/components/Renderers";
 import { useMobileFeedCard } from "@/hooks/useMobileFeedCard";
@@ -74,7 +74,7 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
               className={actionButtonClass}
               aria-label="Open moment link"
             >
-              <ExternalLink className="h-[17px] w-[17px]" strokeWidth={1.75} />
+              <Link2 className="h-[17px] w-[17px]" strokeWidth={1.75} />
             </button>
           </div>
 

--- a/components/Timeline/MobileHome/MobileFeedCard.tsx
+++ b/components/Timeline/MobileHome/MobileFeedCard.tsx
@@ -57,7 +57,7 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
                 if (!isSoldOut) onCollect();
               }}
               className={cn(
-                "rounded-[22px] px-[18px] py-[9px] font-archivo-medium text-sm",
+                "rounded-[22px] px-4 py-2 font-archivo-medium text-sm",
                 isSoldOut
                   ? "cursor-not-allowed bg-grey-moss-300 text-white"
                   : "bg-grey-moss-900 text-white active:opacity-80"

--- a/components/Timeline/MobileHome/MobileFeedCard.tsx
+++ b/components/Timeline/MobileHome/MobileFeedCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TimelineMoment } from "@/types/moment";
-import { Link2, MessageCircle } from "lucide-react";
+import { Link as ChainLinkIcon, MessageCircle } from "lucide-react";
 import Link from "next/link";
 import ContentRenderer from "@/components/Renderers";
 import { useMobileFeedCard } from "@/hooks/useMobileFeedCard";
@@ -48,7 +48,7 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
         </p>
 
         <div className="flex items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-6">
+          <div className="flex min-w-0 items-center gap-3">
             {showComments && (
               <button
                 type="button"
@@ -74,7 +74,7 @@ const MobileFeedCard = ({ moment }: MobileFeedCardProps) => {
               className={actionButtonClass}
               aria-label="Open moment link"
             >
-              <Link2 className="h-[17px] w-[17px]" strokeWidth={1.75} />
+              <ChainLinkIcon className="h-[17px] w-[17px]" strokeWidth={1.75} />
             </button>
           </div>
 

--- a/hooks/useMobileFeedCard.ts
+++ b/hooks/useMobileFeedCard.ts
@@ -1,41 +1,29 @@
 "use client";
 
 import { Protocol, TimelineMoment } from "@/types/moment";
-import { validateUrl } from "@/lib/url/validateUrl";
-import { isDeprecatedUrl } from "@/lib/url/isDeprecatedUrl";
-import { isYoutubeUrl } from "@/lib/url/isYoutubeUrl";
 import { formatSalePriceLabel } from "@/lib/moment/formatSalePriceLabel";
 import { isSaleEnded } from "@/lib/moment/isSaleEnded";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
+import { useMomentClick } from "@/hooks/useMomentClick";
 
 export const useMobileFeedCard = (moment: TimelineMoment) => {
   const { openCollect } = useMobileDrawersProvider();
-  const { metadata, sale } = moment;
+  const { handleMomentClick, data: metadata } = useMomentClick(moment);
+  const { sale } = moment;
   const isSoldOut = isSaleEnded(sale);
   const commentCount = moment.comments ?? 0;
   const showComments = moment.protocol === Protocol.InProcess;
-
-  const externalUrl = (() => {
-    const url = metadata?.external_url;
-    if (!url || isDeprecatedUrl(url) || isYoutubeUrl(url)) return null;
-    return validateUrl(url);
-  })();
 
   const onCollect = () => {
     openCollect(moment);
   };
 
-  const onExternalLink = () => {
-    if (externalUrl) window.open(externalUrl, "_blank", "noopener,noreferrer");
-  };
-
   return {
     metadata,
-    externalUrl,
     priceLabel: formatSalePriceLabel(sale),
     isSoldOut,
     onCollect,
-    onExternalLink,
+    handleMomentClick,
     commentCount,
     showComments,
   };


### PR DESCRIPTION
## Summary
- Always show the external link icon on mobile feed cards (previously hidden when no valid `external_url`).
- Refactor `useMobileFeedCard` to delegate navigation to `useMomentClick` instead of duplicating URL validation and window.open logic.

## Test plan
- [ ] Open mobile home feed; every card shows the external link icon.
- [ ] Tap icon on a moment with a valid `external_url` — opens in a new tab.
- [ ] Tap icon on a moment without external URL — navigates to `/collect/{shortName}:{address}/{token_id}`.
- [ ] Comment count and Collect button behavior unchanged.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mobile feed cards so the moment link action is available consistently and opens through the new tap behavior.
  * Improved the card’s link interaction to better handle clicks without triggering other card actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->