### PR TITLE
fix: enable Save button on SMS moment page

### DIFF
--- a/components/SMSMomentPage/SMSMomentPage.tsx
+++ b/components/SMSMomentPage/SMSMomentPage.tsx
@@ -2,6 +2,7 @@
 
 import SMSMoment from "./SMSMoment";
 import { MomentProvider } from "@/providers/MomentProvider";
+import { CollectionProvider } from "@/providers/CollectionProvider";
 import { useParams } from "next/navigation";
 import { parseCollectionAddress } from "@/lib/timeline/parseCollectionAddress";
 import { Address } from "viem";
@@ -21,21 +22,28 @@ const SMSMomentPage = () => {
   }
 
   return (
-    <MetadataFormProvider>
-      <MetadataUploadProvider>
-        <MomentProvider
-          moment={{
-            collectionAddress: address as Address,
-            tokenId,
-            chainId,
-          }}
-        >
-          <MomentUriUpdateProvider>
-            <SMSMoment />
-          </MomentUriUpdateProvider>
-        </MomentProvider>
-      </MetadataUploadProvider>
-    </MetadataFormProvider>
+    <CollectionProvider
+      collection={{
+        address: address as Address,
+        chainId,
+      }}
+    >
+      <MetadataFormProvider>
+        <MetadataUploadProvider>
+          <MomentProvider
+            moment={{
+              collectionAddress: address as Address,
+              tokenId,
+              chainId,
+            }}
+          >
+            <MomentUriUpdateProvider>
+              <SMSMoment />
+            </MomentUriUpdateProvider>
+          </MomentProvider>
+        </MetadataUploadProvider>
+      </MetadataFormProvider>
+    </CollectionProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- Mount `CollectionProvider` on `SMSMomentPage` so `useIsManageableCollection` can resolve collection protocol and chain ID.
- Fixes Save staying disabled for valid owners on `/sms/...` even when the moment is In Process and ownership/title checks pass.

## Test plan
- [ ] As moment owner, open `/sms/{collection}/{tokenId}` for an In Process moment and confirm Save is enabled after collection data loads
- [ ] Confirm non-owners still do not see Save
- [ ] Confirm empty title still disables Save
- [ ] Confirm `/manage/...` media tab Save behavior is unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the moment page so it now loads the correct collection context before rendering, helping ensure content appears for the selected item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->