### PR TITLE
fix: null context defaults and missing CollectionsProviders on SMS/Nouns

### DIFF
--- a/app/nouns/layout.tsx
+++ b/app/nouns/layout.tsx
@@ -2,16 +2,19 @@
 
 import { ReactNode } from "react";
 import NounsCreateProviderWrapper from "@/providers/NounsCreateProvider/NounsCreateProviderWrapper";
+import { CollectionsProvider } from "@/providers/CollectionsProvider";
 
 const NounsLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <NounsCreateProviderWrapper>
-      <main className="w-screen grow">
-        <div className="relative mt-12 grid w-full grid-cols-1 gap-6 px-6 md:mt-24 md:grid-cols-3 md:px-10">
-          {children}
-        </div>
-      </main>
-    </NounsCreateProviderWrapper>
+    <CollectionsProvider>
+      <NounsCreateProviderWrapper>
+        <main className="w-screen grow">
+          <div className="relative mt-12 grid w-full grid-cols-1 gap-6 px-6 md:mt-24 md:grid-cols-3 md:px-10">
+            {children}
+          </div>
+        </main>
+      </NounsCreateProviderWrapper>
+    </CollectionsProvider>
   );
 };
 

--- a/components/SMSMomentPage/SMSMomentPage.tsx
+++ b/components/SMSMomentPage/SMSMomentPage.tsx
@@ -9,6 +9,7 @@ import { Address } from "viem";
 import { MetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { MetadataUploadProvider } from "@/providers/MetadataUploadProvider";
 import { MomentUriUpdateProvider } from "@/providers/MomentUriUpdateProvider";
+import { CollectionsProvider } from "@/providers/CollectionsProvider";
 
 const SMSMomentPage = () => {
   const params = useParams();
@@ -28,21 +29,23 @@ const SMSMomentPage = () => {
         chainId,
       }}
     >
-      <MetadataFormProvider>
-        <MetadataUploadProvider>
-          <MomentProvider
-            moment={{
-              collectionAddress: address as Address,
-              tokenId,
-              chainId,
-            }}
-          >
-            <MomentUriUpdateProvider>
-              <SMSMoment />
-            </MomentUriUpdateProvider>
-          </MomentProvider>
-        </MetadataUploadProvider>
-      </MetadataFormProvider>
+      <CollectionsProvider>
+        <MetadataFormProvider>
+          <MetadataUploadProvider>
+            <MomentProvider
+              moment={{
+                collectionAddress: address as Address,
+                tokenId,
+                chainId,
+              }}
+            >
+              <MomentUriUpdateProvider>
+                <SMSMoment />
+              </MomentUriUpdateProvider>
+            </MomentProvider>
+          </MetadataUploadProvider>
+        </MetadataFormProvider>
+      </CollectionsProvider>
     </CollectionProvider>
   );
 };

--- a/providers/AirdropProvider.tsx
+++ b/providers/AirdropProvider.tsx
@@ -4,7 +4,7 @@ import AirdropRecipientsProvider from "./AirdropRecipientsProvider";
 
 interface AirdropContextValue extends ReturnType<typeof useAirdrop> {}
 
-const AirdropContext = createContext<AirdropContextValue>({} as AirdropContextValue);
+const AirdropContext = createContext<AirdropContextValue | null>(null);
 
 const AirdropProvider = ({ children }: { children: React.ReactNode }) => {
   const airDrop = useAirdrop();

--- a/providers/AirdropRecipientsProvider.tsx
+++ b/providers/AirdropRecipientsProvider.tsx
@@ -5,9 +5,7 @@ import { createContext, useMemo, useContext } from "react";
 
 interface AirdropRecipientsContextValue extends ReturnType<typeof useAirdropRecipients> {}
 
-const AirdropRecipientsContext = createContext<AirdropRecipientsContextValue>(
-  {} as AirdropRecipientsContextValue
-);
+const AirdropRecipientsContext = createContext<AirdropRecipientsContextValue | null>(null);
 
 const AirdropRecipientsProvider = ({ children }: { children: React.ReactNode }) => {
   const recipientsData = useAirdropRecipients();

--- a/providers/ApiKeyProvider.tsx
+++ b/providers/ApiKeyProvider.tsx
@@ -1,9 +1,7 @@
 import { createContext, useMemo, useContext } from "react";
 import useApiKey from "@/hooks/useApiKey";
 
-const ApiKeyContext = createContext<ReturnType<typeof useApiKey>>(
-  {} as ReturnType<typeof useApiKey>
-);
+const ApiKeyContext = createContext<ReturnType<typeof useApiKey> | null>(null);
 
 const ApiKeyProvider = ({ children }: { children: React.ReactNode }) => {
   const apiKeyData = useApiKey();

--- a/providers/CollectionProvider.tsx
+++ b/providers/CollectionProvider.tsx
@@ -3,15 +3,11 @@ import { Address } from "viem";
 import { createContext, useContext, ReactNode } from "react";
 import useCollection from "@/hooks/useCollection";
 
-const CollectionContext = createContext<
-  ReturnType<typeof useCollection> & {
-    tokens: ReturnType<typeof useCollectionMoments>;
-  }
->(
-  {} as ReturnType<typeof useCollection> & {
-    tokens: ReturnType<typeof useCollectionMoments>;
-  }
-);
+type CollectionContextValue = ReturnType<typeof useCollection> & {
+  tokens: ReturnType<typeof useCollectionMoments>;
+};
+
+const CollectionContext = createContext<CollectionContextValue | null>(null);
 
 export function CollectionProvider({
   children,
@@ -43,7 +39,7 @@ export function CollectionProvider({
 
 export function useCollectionProvider() {
   const context = useContext(CollectionContext);
-  if (context === undefined) {
+  if (!context) {
     throw new Error("useCollectionProvider must be used within a CollectionProvider");
   }
   return context;

--- a/providers/CollectionsProvider.tsx
+++ b/providers/CollectionsProvider.tsx
@@ -3,9 +3,7 @@
 import { createContext, useContext, useMemo, ReactNode } from "react";
 import { useCollections } from "@/hooks/useCollections";
 
-const CollectionsContext = createContext<ReturnType<typeof useCollections>>(
-  {} as ReturnType<typeof useCollections>
-);
+const CollectionsContext = createContext<ReturnType<typeof useCollections> | null>(null);
 
 export const CollectionsProvider = ({ children }: { children: ReactNode }) => {
   const collections = useCollections();

--- a/providers/EmailVerificationProvider.tsx
+++ b/providers/EmailVerificationProvider.tsx
@@ -3,9 +3,7 @@
 import { createContext, useContext, useMemo, ReactNode } from "react";
 import { useEmailVerify } from "@/hooks/useEmailVerify";
 
-const EmailVerificationContext = createContext<ReturnType<typeof useEmailVerify>>(
-  {} as ReturnType<typeof useEmailVerify>
-);
+const EmailVerificationContext = createContext<ReturnType<typeof useEmailVerify> | null>(null);
 
 export const EmailVerificationProvider = ({ children }: { children: ReactNode }) => {
   const emailVerify = useEmailVerify();

--- a/providers/LayoutProvider.tsx
+++ b/providers/LayoutProvider.tsx
@@ -2,9 +2,7 @@ import useLayout from "@/hooks/useLayout";
 import { createContext, useMemo, useContext } from "react";
 import Layout from "@/components/Layout";
 
-const LayoutContext = createContext<ReturnType<typeof useLayout>>(
-  {} as ReturnType<typeof useLayout>
-);
+const LayoutContext = createContext<ReturnType<typeof useLayout> | null>(null);
 
 const LayoutProvider = ({ children }: { children: React.ReactNode }) => {
   const layout = useLayout();

--- a/providers/MiniAppProvider.tsx
+++ b/providers/MiniAppProvider.tsx
@@ -9,7 +9,7 @@ interface MiniAppContextType {
   isMiniApp: boolean;
 }
 
-const MiniAppContext = createContext<MiniAppContextType>({} as MiniAppContextType);
+const MiniAppContext = createContext<MiniAppContextType | null>(null);
 
 export default function MiniAppProvider({ children }: { children: ReactNode }) {
   const [isSDKLoaded, setIsSDKLoaded] = useState<boolean>(false);

--- a/providers/PhoneVerificationProvider.tsx
+++ b/providers/PhoneVerificationProvider.tsx
@@ -3,9 +3,7 @@
 import { createContext, useContext, useMemo, ReactNode } from "react";
 import { usePhoneVerify } from "@/hooks/usePhoneVerify";
 
-const PhoneVerificationContext = createContext<ReturnType<typeof usePhoneVerify>>(
-  {} as ReturnType<typeof usePhoneVerify>
-);
+const PhoneVerificationContext = createContext<ReturnType<typeof usePhoneVerify> | null>(null);
 
 export const PhoneVerificationProvider = ({ children }: { children: ReactNode }) => {
   const phoneVerify = usePhoneVerify();

--- a/providers/ProfileProvider.tsx
+++ b/providers/ProfileProvider.tsx
@@ -5,9 +5,9 @@ import useProfile from "@/hooks/useProfile";
 import { createContext, useMemo, useContext } from "react";
 import { Address } from "viem";
 
-const ProfileContext = createContext<
-  ReturnType<typeof useProfile> & ReturnType<typeof useArtistEdit>
->({} as ReturnType<typeof useProfile> & ReturnType<typeof useArtistEdit>);
+type ProfileContextValue = ReturnType<typeof useProfile> & ReturnType<typeof useArtistEdit>;
+
+const ProfileContext = createContext<ProfileContextValue | null>(null);
 
 interface IProfileProvider {
   children: React.ReactNode;

--- a/providers/SmartWalletAccountProvider.tsx
+++ b/providers/SmartWalletAccountProvider.tsx
@@ -3,9 +3,7 @@
 import useSmartAccount from "@/hooks/useSmartAccount";
 import { createContext, useMemo, useContext } from "react";
 
-const SmartWalletContext = createContext<ReturnType<typeof useSmartAccount>>(
-  {} as ReturnType<typeof useSmartAccount>
-);
+const SmartWalletContext = createContext<ReturnType<typeof useSmartAccount> | null>(null);
 
 interface ISmartWalletAccountProvider {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary
- Replace `{} as` React context defaults with `null` across 11 providers so hooks throw when used outside their provider tree.
- Add `CollectionsProvider` to SMS and Nouns layouts, which mount hooks (`useUpdateMomentURI`, `useMomentCreate`, `useBulkCreate`) that call `useCollectionsProvider()`.
- Unify `CollectionProvider` guard to `if (!context)`.

## Test plan
- [ ] Open `/sms/{collection}/{tokenId}` as owner and confirm Save is enabled after collection data loads
- [ ] Open `/nouns` and confirm page loads without provider errors
- [ ] Open `/create` and confirm moment creation still works
- [ ] Open `/manage/{collection}/{tokenId}` media tab and confirm Save still works
- [ ] Confirm `/manage/api-keys`, `/manage/account`, and artist profile pages still work


Made with [Cursor](https://cursor.com)