### PR TITLE
fix: SMS save redirects to collect page after 3s

### DIFF
--- a/components/SMSMomentPage/SMSMomentPage.tsx
+++ b/components/SMSMomentPage/SMSMomentPage.tsx
@@ -39,7 +39,7 @@ const SMSMomentPage = () => {
                 chainId,
               }}
             >
-              <MomentUriUpdateProvider>
+              <MomentUriUpdateProvider redirectTo="collect" redirectDelayMs={3000}>
                 <SMSMoment />
               </MomentUriUpdateProvider>
             </MomentProvider>

--- a/hooks/useUpdateMomentURI.ts
+++ b/hooks/useUpdateMomentURI.ts
@@ -9,7 +9,19 @@ import { Address } from "viem";
 import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
 import { useRouter } from "next/navigation";
 
-const useUpdateMomentURI = () => {
+export type MomentUriUpdateRedirectTo = "manage" | "collect";
+
+interface UseUpdateMomentURIOptions {
+  redirectTo?: MomentUriUpdateRedirectTo;
+  redirectDelayMs?: number;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const useUpdateMomentURI = ({
+  redirectTo = "manage",
+  redirectDelayMs = 0,
+}: UseUpdateMomentURIOptions = {}) => {
   const { moment, metadata } = useMomentProvider();
   const {
     name,
@@ -67,9 +79,11 @@ const useUpdateMomentURI = () => {
       });
       // Reset media state after successful save (for all file types)
       resetMediaState();
-      push(
-        `/manage/${getShortNameFromChainId(moment.chainId)}:${result.contractAddress}/${result.tokenId}`
-      );
+      if (redirectDelayMs > 0) {
+        await sleep(redirectDelayMs);
+      }
+      const shortNetwork = getShortNameFromChainId(moment.chainId);
+      push(`/${redirectTo}/${shortNetwork}:${result.contractAddress}/${result.tokenId}`);
     } catch (error: any) {
       throw error;
     } finally {

--- a/providers/MomentUriUpdateProvider.tsx
+++ b/providers/MomentUriUpdateProvider.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import React, { createContext, useContext, useMemo } from "react";
-import useUpdateMomentURI from "@/hooks/useUpdateMomentURI";
+import useUpdateMomentURI, { type MomentUriUpdateRedirectTo } from "@/hooks/useUpdateMomentURI";
 
 const MomentUriUpdateContext = createContext<ReturnType<typeof useUpdateMomentURI> | undefined>(
   undefined
 );
 
-const MomentUriUpdateProvider = ({ children }: { children: React.ReactNode }) => {
-  const momentUriUpdate = useUpdateMomentURI();
+const MomentUriUpdateProvider = ({
+  children,
+  redirectTo = "manage",
+  redirectDelayMs = 0,
+}: {
+  children: React.ReactNode;
+  redirectTo?: MomentUriUpdateRedirectTo;
+  redirectDelayMs?: number;
+}) => {
+  const momentUriUpdate = useUpdateMomentURI({ redirectTo, redirectDelayMs });
 
   const value = useMemo(() => ({ ...momentUriUpdate }), [momentUriUpdate]);
 


### PR DESCRIPTION
## Summary
- Add `redirectTo` and `redirectDelayMs` options to `MomentUriUpdateProvider` / `useUpdateMomentURI`.
- SMS moment save now redirects to `/collect/...` after a 3 second delay instead of immediately sending users to `/manage/...`.
- Manage moment save behavior is unchanged (immediate redirect to `/manage/...`).

## Test plan
- [ ] On `/sms/{collection}/{tokenId}`, save as owner and confirm redirect to `/collect/...` after ~3 seconds
- [ ] On `/manage/{collection}/{tokenId}` media tab, save and confirm immediate redirect to `/manage/...`
- [ ] Confirm failed save does not redirect on either page


Made with [Cursor](https://cursor.com)