### PR TITLE
Redesign SMS moment page (Edit Moment)

### DIFF
--- a/components/Media/DescriptionInput.tsx
+++ b/components/Media/DescriptionInput.tsx
@@ -1,20 +1,30 @@
 import { Textarea } from "../ui/textarea";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { cn } from "@/lib/utils";
 
 interface DescriptionInputProps {
   disabled: boolean;
   labelHidden: boolean;
+  textareaClassName?: string;
+  labelClassName?: string;
 }
-const DescriptionInput = ({ disabled, labelHidden }: DescriptionInputProps) => {
+const DescriptionInput = ({
+  disabled,
+  labelHidden,
+  textareaClassName,
+  labelClassName,
+}: DescriptionInputProps) => {
   const { form } = useMetadataFormProvider();
   return (
     <fieldset>
       {!labelHidden && (
-        <label className="text-grey-moss-600 mb-1 block font-archivo text-sm">description</label>
+        <label className={cn("text-grey-moss-600 mb-1 block font-archivo text-sm", labelClassName)}>
+          description
+        </label>
       )}
       <Textarea
         {...form.register("description")}
-        className="focus:border-grey-moss-500 !font-spectral !text-md"
+        className={cn("focus:border-grey-moss-500 !font-spectral !text-md", textareaClassName)}
         minRows={3}
         maxRows={10}
         placeholder="enter a description"

--- a/components/Media/TitleInput.tsx
+++ b/components/Media/TitleInput.tsx
@@ -1,24 +1,29 @@
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { Input } from "../ui/input";
+import { cn } from "@/lib/utils";
 
 interface TitleInputProps {
   disabled: boolean;
   labelHidden: boolean;
+  inputClassName?: string;
+  labelClassName?: string;
 }
-const TitleInput = ({ disabled, labelHidden }: TitleInputProps) => {
+const TitleInput = ({ disabled, labelHidden, inputClassName, labelClassName }: TitleInputProps) => {
   const { form } = useMetadataFormProvider();
 
   return (
     <fieldset>
       {!labelHidden && (
-        <label className="text-grey-moss-600 mb-1 block font-archivo text-sm">title</label>
+        <label className={cn("text-grey-moss-600 mb-1 block font-archivo text-sm", labelClassName)}>
+          title
+        </label>
       )}
       <Input
         type="text"
         {...form.register("name")}
         placeholder="enter a title"
         disabled={disabled}
-        className="font-spectral !text-md"
+        className={cn("font-spectral !text-md", inputClassName)}
       />
       {form.formState.errors.name && (
         <p className="mt-1 font-spectral text-xs text-red-500">

--- a/components/MomentAirdrop/AirdropButton.tsx
+++ b/components/MomentAirdrop/AirdropButton.tsx
@@ -1,19 +1,10 @@
 import { AirdropItem } from "@/types/airdrop";
 import { useAirdropProvider } from "@/providers/AirdropProvider";
-import { useMomentProvider } from "@/providers/MomentProvider";
-import { useWalletsProvider } from "@/providers/WalletsProvider";
-import { getAddress } from "viem";
+import useCanAirdropMoment from "@/hooks/useCanAirdropMoment";
 
 const AirdropButton = () => {
   const { airdropToItems, onAirdrop, loading } = useAirdropProvider();
-  const { owner, momentAdmins } = useMomentProvider();
-  const { primaryWallet } = useWalletsProvider();
-  const canAirdrop =
-    Boolean(primaryWallet && owner && getAddress(owner) === getAddress(primaryWallet)) ||
-    Boolean(
-      primaryWallet &&
-      momentAdmins?.some((admin) => getAddress(admin) === getAddress(primaryWallet))
-    );
+  const canAirdrop = useCanAirdropMoment();
 
   return (
     <button

--- a/components/MomentManagePage/SaveMediaButton.tsx
+++ b/components/MomentManagePage/SaveMediaButton.tsx
@@ -6,8 +6,13 @@ import PermissionErrorModal from "@/components/PermissionErrorModal";
 import { useMomentEditProvider } from "@/providers/MomentEditProvider";
 import useSaveMomentButton from "@/hooks/useSaveMomentButton";
 import { useCollectionsProvider } from "@/providers/CollectionsProvider";
+import { cn } from "@/lib/utils";
 
-const SaveMediaButton = () => {
+interface SaveMediaButtonProps {
+  className?: string;
+}
+
+const SaveMediaButton = ({ className }: SaveMediaButtonProps = {}) => {
   const { moment } = useMomentProvider();
   const {
     showPermissionModal,
@@ -21,7 +26,10 @@ const SaveMediaButton = () => {
   return (
     <div>
       <button
-        className="w-fit rounded-md bg-black px-4 md:px-8 md:py-2 py-1 text-grey-eggshell transition-colors hover:bg-grey-moss-300 disabled:opacity-50"
+        className={cn(
+          "w-fit rounded-md bg-black px-4 md:px-8 md:py-2 py-1 text-grey-eggshell transition-colors hover:bg-grey-moss-300 disabled:opacity-50",
+          className
+        )}
         onClick={handleSave}
         disabled={isDisabled}
       >

--- a/components/SMSMomentPage/AddressChip.tsx
+++ b/components/SMSMomentPage/AddressChip.tsx
@@ -1,0 +1,40 @@
+import { X } from "lucide-react";
+import { AirdropItem } from "@/types/airdrop";
+import truncateAddress from "@/lib/truncateAddress";
+import { useAirdropProvider } from "@/providers/AirdropProvider";
+
+interface AddressChipProps {
+  item: AirdropItem;
+  index: number;
+}
+
+const AddressChip = ({ item, index }: AddressChipProps) => {
+  const { removeAddress } = useAirdropProvider();
+  const isInvalid = item.status === "invalid";
+
+  return (
+    <span
+      className={`flex items-center gap-1.5 rounded-full py-1 pl-3 pr-1 font-archivo text-xs font-semibold ${
+        isInvalid ? "bg-red text-white" : "bg-grey-moss-50 text-grey-moss-900"
+      }`}
+    >
+      {item.status === "validating"
+        ? "validating..."
+        : item.ensName || truncateAddress(item.address)}
+      <button
+        type="button"
+        onClick={() => removeAddress(index)}
+        aria-label="Remove recipient"
+        className={`flex h-[15px] w-[15px] items-center justify-center rounded-full ${
+          isInvalid
+            ? "bg-white/30 text-white"
+            : "bg-grey-moss-100 text-grey-moss-300 hover:bg-grey-moss-900 hover:text-white"
+        }`}
+      >
+        <X className="h-2.5 w-2.5" />
+      </button>
+    </span>
+  );
+};
+
+export default AddressChip;

--- a/components/SMSMomentPage/AddressChipInput.tsx
+++ b/components/SMSMomentPage/AddressChipInput.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useAirdropProvider } from "@/providers/AirdropProvider";
+import useAirdropInput from "@/hooks/useAirdropInput";
+import { AirdropItem } from "@/types/airdrop";
+import AddressChip from "./AddressChip";
+
+const AddressChipInput = () => {
+  const { airdropToItems } = useAirdropProvider();
+  const { handleInput, handlePaste, handleBlur, value, setValue } = useAirdropInput();
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 border-b-2 border-grey-moss-900 py-2">
+      {airdropToItems.map((item: AirdropItem, index) => (
+        <AddressChip item={item} index={index} key={`${index}-${item.address || item.ensName}`} />
+      ))}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleInput}
+        onPaste={handlePaste}
+        onBlur={handleBlur}
+        placeholder="wallet address or ENS"
+        className="min-w-[130px] flex-1 border-none bg-transparent py-1.5 font-archivo text-sm text-grey-moss-900 outline-none"
+      />
+    </div>
+  );
+};
+
+export default AddressChipInput;

--- a/components/SMSMomentPage/AirdropCard.tsx
+++ b/components/SMSMomentPage/AirdropCard.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useMomentProvider } from "@/providers/MomentProvider";
+import AirdropProvider from "@/providers/AirdropProvider";
+import AddressChipInput from "./AddressChipInput";
+import RecentRecipientsRow from "./RecentRecipientsRow";
+import RecipientSearchSheet from "./RecipientSearchSheet";
+import AirdropSubmitButton from "./AirdropSubmitButton";
+
+const AirdropCard = () => {
+  const { isOwner } = useMomentProvider();
+
+  if (!isOwner) return null;
+
+  return (
+    <AirdropProvider>
+      <div className="rounded-md border border-grey-moss-100 bg-white p-4 shadow-[0_4px_16px_-6px_rgba(27,21,4,0.14)]">
+        <div className="mb-1.5 flex items-center gap-1.5">
+          <span className="h-1.5 w-1.5 rounded-full bg-[#887bff] shadow-[0_0_8px_rgba(136,123,255,0.7)]" />
+          <span className="font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300">
+            airdrop this moment
+          </span>
+        </div>
+        <AddressChipInput />
+        <RecentRecipientsRow />
+        <AirdropSubmitButton />
+        <RecipientSearchSheet />
+      </div>
+    </AirdropProvider>
+  );
+};
+
+export default AirdropCard;

--- a/components/SMSMomentPage/AirdropSubmitButton.tsx
+++ b/components/SMSMomentPage/AirdropSubmitButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Send } from "lucide-react";
+import { useAirdropProvider } from "@/providers/AirdropProvider";
+import useCanAirdropMoment from "@/hooks/useCanAirdropMoment";
+import { AirdropItem } from "@/types/airdrop";
+
+const AirdropSubmitButton = () => {
+  const { airdropToItems, onAirdrop, loading } = useAirdropProvider();
+  const canAirdrop = useCanAirdropMoment();
+
+  const isDisabled =
+    airdropToItems.length === 0 ||
+    airdropToItems.some((item: AirdropItem) => item.status === "invalid") ||
+    loading ||
+    !canAirdrop;
+
+  return (
+    <button
+      type="button"
+      onClick={onAirdrop}
+      disabled={isDisabled}
+      className="mt-3.5 flex w-full items-center justify-center gap-2 rounded-full bg-grey-moss-900 py-2.5 font-archivo text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-grey-moss-200"
+    >
+      <Send className="h-3.5 w-3.5" />
+      {loading ? "Loading..." : "Airdrop"}
+    </button>
+  );
+};
+
+export default AirdropSubmitButton;

--- a/components/SMSMomentPage/CollectLinkRow.tsx
+++ b/components/SMSMomentPage/CollectLinkRow.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Copy, Link as LinkIcon } from "lucide-react";
+import useShareMoment from "@/hooks/useShareMoment";
+
+const CollectLinkRow = () => {
+  const { share, displayUrl } = useShareMoment();
+
+  return (
+    <div className="flex items-center gap-2 border-b border-grey-moss-100 pb-3">
+      <LinkIcon className="h-3.5 w-3.5 shrink-0 text-tan-gold" />
+      <span className="min-w-0 flex-1 truncate font-archivo text-xs text-tan-gold">
+        {displayUrl}
+      </span>
+      <button
+        type="button"
+        onClick={share}
+        className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-grey-moss-50 px-3 py-1.5 font-archivo text-xs font-semibold text-grey-moss-900 hover:bg-grey-moss-100"
+      >
+        <Copy className="h-3 w-3" />
+        Copy link
+      </button>
+    </div>
+  );
+};
+
+export default CollectLinkRow;

--- a/components/SMSMomentPage/MomentDetailsCard.tsx
+++ b/components/SMSMomentPage/MomentDetailsCard.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useMomentProvider } from "@/providers/MomentProvider";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { useMetadataUploadProvider } from "@/providers/MetadataUploadProvider";
+import { useMomentUriUpdateProvider } from "@/providers/MomentUriUpdateProvider";
+import TitleInput from "../Media/TitleInput";
+import DescriptionInput from "../Media/DescriptionInput";
+import Description from "../MomentPage/Description";
+import SaveMediaButton from "../MomentManagePage/SaveMediaButton";
+import CollectLinkRow from "./CollectLinkRow";
+import MomentThumbnailField from "./MomentThumbnailField";
+
+const MomentDetailsCard = () => {
+  const { metadata, isOwner } = useMomentProvider();
+  const { fileInputRef, blobUrls, previewFileUrl } = useMetadataFormProvider();
+  const { selectFile } = useMetadataUploadProvider();
+  const { isLoading: isUpdating } = useMomentUriUpdateProvider();
+  const canEdit = isOwner && !isUpdating;
+
+  const imageUrl =
+    blobUrls?.image || previewFileUrl || metadata?.image || "/images/placeholder.png";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-grey-moss-100 bg-white p-4 shadow-[0_4px_16px_-6px_rgba(27,21,4,0.14)]">
+      <CollectLinkRow />
+      <MomentThumbnailField
+        imageUrl={imageUrl}
+        alt={metadata?.name || "Moment thumbnail"}
+        isOwner={isOwner}
+        disabled={!canEdit}
+        fileInputRef={fileInputRef}
+        onFileChange={selectFile}
+      />
+      {isOwner ? (
+        <TitleInput
+          disabled={!canEdit}
+          labelHidden={false}
+          inputClassName="rounded-md"
+          labelClassName="text-[10.5px] uppercase tracking-wider text-grey-moss-300"
+        />
+      ) : (
+        <p className="font-spectral text-sm text-grey-moss-900">{metadata?.name}</p>
+      )}
+      {isOwner ? (
+        <DescriptionInput
+          disabled={!canEdit}
+          labelHidden={false}
+          textareaClassName="rounded-md"
+          labelClassName="text-[10.5px] uppercase tracking-wider text-grey-moss-300"
+        />
+      ) : (
+        <Description />
+      )}
+      {isOwner && (
+        <div className="flex items-center justify-end">
+          <SaveMediaButton className="rounded-full px-5 py-1.5 font-archivo text-sm font-semibold" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MomentDetailsCard;

--- a/components/SMSMomentPage/MomentThumbnailField.tsx
+++ b/components/SMSMomentPage/MomentThumbnailField.tsx
@@ -1,0 +1,55 @@
+import { ChangeEvent, RefObject } from "react";
+import { Pencil } from "lucide-react";
+import CollectionImage from "../CollectionImage";
+
+interface MomentThumbnailFieldProps {
+  imageUrl: string;
+  alt: string;
+  isOwner: boolean;
+  disabled: boolean;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  onFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const MomentThumbnailField = ({
+  imageUrl,
+  alt,
+  isOwner,
+  disabled,
+  fileInputRef,
+  onFileChange,
+}: MomentThumbnailFieldProps) => {
+  const handleEditClick = () => fileInputRef.current?.click();
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-16 shrink-0 font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300">
+        media
+      </span>
+      <div className="relative shrink-0">
+        <CollectionImage src={imageUrl} alt={alt} className="h-14 w-14 rounded-lg" />
+        {isOwner && (
+          <button
+            type="button"
+            onClick={handleEditClick}
+            disabled={disabled}
+            aria-label="Edit media"
+            className="absolute -bottom-1.5 -right-1.5 flex h-[18px] w-[18px] items-center justify-center rounded-full border border-tan-secondary bg-tan-primary text-grey-moss-900 hover:bg-tan-secondary/40 disabled:opacity-50"
+          >
+            <Pencil className="h-2.5 w-2.5" />
+          </button>
+        )}
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={onFileChange}
+        className="hidden"
+        disabled={disabled}
+      />
+    </div>
+  );
+};
+
+export default MomentThumbnailField;

--- a/components/SMSMomentPage/Note.tsx
+++ b/components/SMSMomentPage/Note.tsx
@@ -2,7 +2,7 @@ import { InfoIcon } from "lucide-react";
 
 const Note = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="rounded-lg border border-grey-moss-200 bg-grey-moss-50 p-4 mb-4">
+    <div className="rounded-lg border border-grey-moss-200 bg-grey-moss-50 p-4">
       <div className="flex items-start gap-3">
         <InfoIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-grey-moss-600" />
         <p className="font-archivo text-sm text-grey-moss-900">{children}</p>

--- a/components/SMSMomentPage/RecentRecipientsRow.tsx
+++ b/components/SMSMomentPage/RecentRecipientsRow.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import useRecipientSearch from "@/hooks/useRecipientSearch";
+import truncateAddress from "@/lib/truncateAddress";
+
+const RecentRecipientsRow = () => {
+  const {
+    isLoading,
+    visibleRecipients,
+    moreCount,
+    toggleRecipient,
+    openSearch,
+    isRecipientActive,
+  } = useRecipientSearch();
+
+  if (isLoading || visibleRecipients.length === 0) return null;
+
+  return (
+    <div className="mt-3.5">
+      <div className="mb-2 font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300">
+        recent recipients
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {visibleRecipients.map((recipient) => (
+          <button
+            type="button"
+            key={recipient.address}
+            onClick={() => toggleRecipient(recipient.address)}
+            className={`rounded-full px-3.5 py-1.5 font-archivo text-xs font-semibold text-grey-moss-900 ${
+              isRecipientActive(recipient.address) ? "bg-grey-moss-100" : "bg-grey-moss-50"
+            }`}
+          >
+            {recipient.username || truncateAddress(recipient.address)}
+          </button>
+        ))}
+        {moreCount > 0 && (
+          <button
+            type="button"
+            onClick={openSearch}
+            className="rounded-full border border-dashed border-grey-moss-200 px-3.5 py-1 font-archivo text-xs font-semibold text-grey-moss-300 hover:border-grey-moss-900 hover:text-grey-moss-900"
+          >
+            +{moreCount} more
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RecentRecipientsRow;

--- a/components/SMSMomentPage/RecipientSearchSheet.tsx
+++ b/components/SMSMomentPage/RecipientSearchSheet.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { Search, Send, X } from "lucide-react";
+import useRecipientSearch from "@/hooks/useRecipientSearch";
+import truncateAddress from "@/lib/truncateAddress";
+
+const RecipientSearchSheet = () => {
+  const {
+    isSearchOpen,
+    closeSearch,
+    query,
+    setQuery,
+    filteredRecipients,
+    selectFromSearch,
+    isRecipientActive,
+  } = useRecipientSearch();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted || !isSearchOpen) return null;
+
+  return createPortal(
+    <div className="fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 flex flex-col overflow-hidden bg-white">
+      <div className="flex items-center gap-3 border-b border-grey-moss-100 px-5 py-4">
+        <Search className="h-[18px] w-[18px] shrink-0 text-grey-moss-900" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search recipients"
+          autoFocus
+          className="flex-1 border-none bg-transparent font-archivo text-base text-grey-moss-900 outline-none"
+        />
+        <button
+          type="button"
+          onClick={closeSearch}
+          aria-label="Close"
+          className="text-grey-moss-900"
+        >
+          <X className="h-[18px] w-[18px]" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto px-3 py-2">
+        {filteredRecipients.map((recipient) => (
+          <button
+            type="button"
+            key={recipient.address}
+            onClick={() => selectFromSearch(recipient.address)}
+            className={`flex w-full items-center gap-3 border-b border-grey-moss-50 px-2.5 py-2.5 text-left ${
+              isRecipientActive(recipient.address) ? "bg-grey-moss-50" : "hover:bg-grey-moss-50"
+            }`}
+          >
+            <span className="min-w-0 flex-1">
+              <span className="block font-archivo text-sm font-semibold text-grey-moss-900">
+                {recipient.username || truncateAddress(recipient.address)}
+              </span>
+              {recipient.username && (
+                <span className="block font-archivo text-xs text-grey-moss-200">
+                  {truncateAddress(recipient.address)}
+                </span>
+              )}
+            </span>
+            <Send className="h-4 w-4 shrink-0 text-grey-moss-200" />
+          </button>
+        ))}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default RecipientSearchSheet;

--- a/components/SMSMomentPage/SMSMoment.tsx
+++ b/components/SMSMomentPage/SMSMoment.tsx
@@ -1,38 +1,17 @@
 "use client";
 
 import { useMomentProvider } from "@/providers/MomentProvider";
-import MomentAirdrop from "../MomentAirdrop/MomentAirdrop";
 import Notes from "./Notes";
 import { Skeleton } from "../ui/skeleton";
-import CollectionImage from "../CollectionImage";
 import useMediaInitialization from "@/hooks/useMediaInitialization";
-import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
-import { useMetadataUploadProvider } from "@/providers/MetadataUploadProvider";
-import SaveMediaButton from "../MomentManagePage/SaveMediaButton";
 import { MomentEditProvider } from "@/providers/MomentEditProvider";
-import { useMomentUriUpdateProvider } from "@/providers/MomentUriUpdateProvider";
-import TitleInput from "../Media/TitleInput";
-import DescriptionInput from "../Media/DescriptionInput";
-import Description from "../MomentPage/Description";
-import ShareButton from "../MomentPage/ShareButton";
+import MomentDetailsCard from "./MomentDetailsCard";
+import AirdropCard from "./AirdropCard";
 
 const SMSMoment = () => {
-  const { metadata, isOwner, isLoading } = useMomentProvider();
-  const { fileInputRef, blobUrls, previewFileUrl } = useMetadataFormProvider();
-  const { selectFile } = useMetadataUploadProvider();
-  const { isLoading: isUpdating } = useMomentUriUpdateProvider();
-  const canEdit = isOwner && !isUpdating;
+  const { metadata, isLoading } = useMomentProvider();
 
   useMediaInitialization(metadata ?? undefined);
-
-  const handleImageClick = () => {
-    if (isOwner && !isUpdating) {
-      fileInputRef.current?.click();
-    }
-  };
-
-  const imageUrl =
-    blobUrls?.image || previewFileUrl || metadata?.image || "/images/placeholder.png";
 
   if (!metadata || isLoading)
     return (
@@ -46,36 +25,9 @@ const SMSMoment = () => {
 
   return (
     <MomentEditProvider>
-      <div className="px-3 md:px-10 pt-12">
-        <div className="flex items-center gap-2">
-          <CollectionImage
-            src={imageUrl}
-            alt={metadata.name || "Moment thumbnail"}
-            className="h-14 w-14"
-            onClick={isOwner ? handleImageClick : undefined}
-          />
-          {isOwner ? (
-            <TitleInput disabled={!canEdit} labelHidden />
-          ) : (
-            <p className="font-archivo text-lg text-grey-moss-900">{metadata.name}</p>
-          )}
-        </div>
-
-        {isOwner ? <DescriptionInput disabled={!canEdit} labelHidden /> : <Description />}
-
-        <div className="flex items-center gap-2 pt-4 pb-2">
-          <ShareButton />
-          {isOwner && <SaveMediaButton />}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            onChange={selectFile}
-            className="hidden"
-            disabled={!isOwner || isUpdating}
-          />
-        </div>
-        <MomentAirdrop />
+      <div className="flex flex-col gap-3 px-3 pb-8 pt-3 md:px-10">
+        <MomentDetailsCard />
+        <AirdropCard />
         <Notes />
       </div>
     </MomentEditProvider>

--- a/hooks/useAirdropInput.ts
+++ b/hooks/useAirdropInput.ts
@@ -4,24 +4,26 @@ import { useAirdropProvider } from "@/providers/AirdropProvider";
 const useAirdropInput = () => {
   const [value, setValue] = useState("");
   const { onChangeAddress } = useAirdropProvider();
-  // When the user presses Enter we want to submit whatever is currently in the
-  // input. The user might have typed or pasted multiple lines, so we split the
-  // value on new-lines, trim each entry and ignore blank rows.
+  // When the user presses Enter, a comma, or a space we want to submit
+  // whatever is currently in the input. The user might have typed or pasted
+  // multiple lines, so we split the value on new-lines, trim each entry and
+  // ignore blank rows.
   const handleInput = async (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      const items = value
-        .split(/\r?\n/) // handle both Windows and Unix newlines
-        .map((item) => item.trim())
-        .filter(Boolean);
+    if (e.key !== "Enter" && e.key !== "," && e.key !== " ") return;
+    e.preventDefault();
 
-      if (items.length > 0) {
-        // Add to airdropToItems immediately for UI feedback (ENS names will be resolved automatically)
-        for (const item of items) {
-          onChangeAddress(item);
-        }
+    const items = value
+      .split(/\r?\n/) // handle both Windows and Unix newlines
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    if (items.length > 0) {
+      // Add to airdropToItems immediately for UI feedback (ENS names will be resolved automatically)
+      for (const item of items) {
+        onChangeAddress(item);
       }
-      setValue("");
     }
+    setValue("");
   };
 
   // Support pasting a column of cells (e.g. from Google Sheets / Docs). We

--- a/hooks/useCanAirdropMoment.ts
+++ b/hooks/useCanAirdropMoment.ts
@@ -1,0 +1,18 @@
+import { getAddress } from "viem";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import { useWalletsProvider } from "@/providers/WalletsProvider";
+
+const useCanAirdropMoment = () => {
+  const { owner, momentAdmins } = useMomentProvider();
+  const { primaryWallet } = useWalletsProvider();
+
+  return (
+    Boolean(primaryWallet && owner && getAddress(owner) === getAddress(primaryWallet)) ||
+    Boolean(
+      primaryWallet &&
+      momentAdmins?.some((admin) => getAddress(admin) === getAddress(primaryWallet))
+    )
+  );
+};
+
+export default useCanAirdropMoment;

--- a/hooks/useRecipientSearch.ts
+++ b/hooks/useRecipientSearch.ts
@@ -1,0 +1,40 @@
+import { useMemo, useState } from "react";
+import { useAirdropRecipientsProvider } from "@/providers/AirdropRecipientsProvider";
+import useAirdropRecipientsPopup from "@/hooks/useAirdropRecipientsPopup";
+
+const VISIBLE_RECIPIENT_COUNT = 3;
+
+const useRecipientSearch = () => {
+  const { recipients, isLoading } = useAirdropRecipientsProvider();
+  const { isOpen, setIsOpen, handleRecipientClick, isRecipientActive } =
+    useAirdropRecipientsPopup();
+  const [query, setQuery] = useState("");
+
+  const filteredRecipients = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return recipients;
+    return recipients.filter((recipient) =>
+      (recipient.username || recipient.address).toLowerCase().includes(normalizedQuery)
+    );
+  }, [recipients, query]);
+
+  return {
+    isLoading,
+    visibleRecipients: recipients.slice(0, VISIBLE_RECIPIENT_COUNT),
+    moreCount: Math.max(recipients.length - VISIBLE_RECIPIENT_COUNT, 0),
+    toggleRecipient: handleRecipientClick,
+    isRecipientActive,
+    isSearchOpen: isOpen,
+    openSearch: () => setIsOpen(true),
+    closeSearch: () => setIsOpen(false),
+    query,
+    setQuery,
+    filteredRecipients,
+    selectFromSearch: (address: string) => {
+      handleRecipientClick(address);
+      setIsOpen(false);
+    },
+  };
+};
+
+export default useRecipientSearch;

--- a/hooks/useShareMoment.ts
+++ b/hooks/useShareMoment.ts
@@ -1,20 +1,26 @@
 import { CHAIN, SITE_ORIGINAL_URL } from "@/lib/consts";
 import { getShortNetworkName } from "@/lib/zora/zoraToViem";
 import { useMomentProvider } from "@/providers/MomentProvider";
+import truncateAddress from "@/lib/truncateAddress";
 import { toast } from "sonner";
 
 const useShareMoment = () => {
   const { moment } = useMomentProvider();
+  const shortNetworkName = getShortNetworkName(CHAIN.name.toLowerCase());
+  const path = `/collect/${shortNetworkName}:${moment.collectionAddress}/${moment.tokenId}`;
 
   const share = async () => {
-    const shortNetworkName = getShortNetworkName(CHAIN.name.toLowerCase());
-    await navigator.clipboard.writeText(
-      `${SITE_ORIGINAL_URL}/collect/${shortNetworkName}:${moment.collectionAddress}/${moment.tokenId}`
-    );
+    await navigator.clipboard.writeText(`${SITE_ORIGINAL_URL}${path}`);
     toast.success("copied!");
   };
+
+  const displayUrl = `${SITE_ORIGINAL_URL.replace(/^https?:\/\//, "")}/collect/${shortNetworkName}:${truncateAddress(
+    moment.collectionAddress
+  )}/${moment.tokenId}`;
+
   return {
     share,
+    displayUrl,
   };
 };
 


### PR DESCRIPTION
## Summary
- Rebuilds the `/sms/[collection]/[tokenId]` edit screen into a "Moment details" card (collect link, media edit, title/description, save) and an "Airdrop" card (chip input, recent recipients, full-screen recipient search sheet), matching the new Edit Moment design.
- Address chip input now accepts comma, space, or enter as separators.
- Extracts shared airdrop eligibility check into `useCanAirdropMoment` and reuses it in the existing `AirdropButton` (no visual change there).
- Adds optional `className`/`labelClassName` passthrough props to `TitleInput`, `DescriptionInput`, and `SaveMediaButton` so the new styling doesn't affect their other call sites (`Media.tsx`).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on touched files (one pre-existing, unrelated warning left as-is)
- [x] Verified locally against a live mainnet moment via headless browser: collect link, media thumbnail, title, sign-in note all render correctly for a non-owner viewer
- [ ] Manual QA as a moment owner/admin: title/description edit + save, address chip input (comma/space/enter), recent recipients selection state, "+N more" full-screen search sheet, airdrop submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer moment management view with editable title, description, media thumbnail, share link, and airdrop controls.
  * Added recipient search and recent recipient chips for quicker selection.
  * Added support for customizing styling on media title/description inputs and save buttons.

* **Bug Fixes**
  * Improved airdrop eligibility and submission behavior, including smarter input entry handling for commas and spaces.
  * Enhanced share link display and copy behavior with a cleaner, shorter URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->