### PR TITLE
SMS moment page: signed-out labels, sign-in button, note styling, skeleton

### DIFF
--- a/components/SMSMomentPage/MomentDetailsCard.tsx
+++ b/components/SMSMomentPage/MomentDetailsCard.tsx
@@ -40,7 +40,14 @@ const MomentDetailsCard = () => {
           labelClassName="text-[10.5px] uppercase tracking-wider text-grey-moss-300"
         />
       ) : (
-        <p className="font-spectral text-sm text-grey-moss-900">{metadata?.name}</p>
+        <div className="flex items-center gap-3">
+          <span className="w-16 shrink-0 font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300">
+            title
+          </span>
+          <p className="min-w-0 flex-1 truncate font-spectral text-sm text-grey-moss-900">
+            {metadata?.name}
+          </p>
+        </div>
       )}
       {isOwner ? (
         <DescriptionInput
@@ -50,7 +57,16 @@ const MomentDetailsCard = () => {
           labelClassName="text-[10.5px] uppercase tracking-wider text-grey-moss-300"
         />
       ) : (
-        <Description />
+        metadata?.description && (
+          <div className="flex items-start gap-3">
+            <span className="w-16 shrink-0 pt-0.5 font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300">
+              description
+            </span>
+            <div className="min-w-0 flex-1 [&>div]:mt-0">
+              <Description />
+            </div>
+          </div>
+        )
       )}
       {isOwner && (
         <div className="flex items-center justify-end">

--- a/components/SMSMomentPage/Note.tsx
+++ b/components/SMSMomentPage/Note.tsx
@@ -2,10 +2,10 @@ import { InfoIcon } from "lucide-react";
 
 const Note = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="rounded-lg border border-grey-moss-200 bg-grey-moss-50 p-4">
-      <div className="flex items-start gap-3">
-        <InfoIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-grey-moss-600" />
-        <p className="font-archivo text-sm text-grey-moss-900">{children}</p>
+    <div className="rounded-md border-l-2 border-tan-gold bg-grey-moss-50 py-3 pl-4 pr-4">
+      <div className="flex items-center gap-3">
+        <InfoIcon className="h-5 w-5 flex-shrink-0 text-grey-moss-300" />
+        <p className="font-archivo text-sm italic text-grey-moss-900">{children}</p>
       </div>
     </div>
   );

--- a/components/SMSMomentPage/Notes.tsx
+++ b/components/SMSMomentPage/Notes.tsx
@@ -1,21 +1,21 @@
 import { Fragment } from "react";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
-import { LoginButton } from "../LoginButton/LoginButton";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import Note from "./Note";
+import SignInButton from "./SignInButton";
 
 const Notes = () => {
   const { primaryWallet } = useWalletsProvider();
   const { isOwner } = useMomentProvider();
 
-  if (primaryWallet && !isOwner) return <Note>you are not an admin of this moment.</Note>;
+  if (primaryWallet && !isOwner) return <Note>You are not an admin of this moment.</Note>;
 
   if (primaryWallet) return <Fragment />;
 
   return (
     <>
-      <Note>sign in to airdrop and edit the description.</Note>
-      <LoginButton />
+      <Note>Sign in to airdrop and edit the moment.</Note>
+      <SignInButton />
     </>
   );
 };

--- a/components/SMSMomentPage/SMSMoment.tsx
+++ b/components/SMSMomentPage/SMSMoment.tsx
@@ -15,11 +15,20 @@ const SMSMoment = () => {
 
   if (!metadata || isLoading)
     return (
-      <div className="flex flex-col gap-2 w-full px-3">
-        <Skeleton className="w-1/3 h-[40px]" />
-        <Skeleton className="w-1/2 h-[40px]" />
-        <Skeleton className="w-3/4 h-[40px]" />
-        <Skeleton className="w-full h-[40px]" />
+      <div className="flex flex-col gap-3 px-3 pb-8 pt-3 md:px-10">
+        <div className="flex flex-col gap-3 rounded-md border border-grey-moss-100 bg-white p-4">
+          <Skeleton className="h-4 w-2/3" />
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-14 w-14 shrink-0 rounded-lg" />
+            <Skeleton className="h-9 flex-1" />
+          </div>
+          <Skeleton className="h-16 w-full" />
+        </div>
+        <div className="flex flex-col gap-3 rounded-md border border-grey-moss-100 bg-white p-4">
+          <Skeleton className="h-3 w-1/3" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
       </div>
     );
 

--- a/components/SMSMomentPage/SignInButton.tsx
+++ b/components/SMSMomentPage/SignInButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+
+const SignInButton = () => {
+  const { login, ready } = usePrivy();
+
+  if (!ready) return null;
+
+  return (
+    <div className="flex justify-end">
+      <button
+        type="button"
+        onClick={login}
+        className="w-fit rounded-full bg-grey-moss-900 px-5 py-1.5 font-archivo text-sm font-semibold text-white transition-opacity hover:opacity-90"
+      >
+        Sign in
+      </button>
+    </div>
+  );
+};
+
+export default SignInButton;


### PR DESCRIPTION
## Summary
- Signed-out title/description now render as labeled rows (`TITLE` / `DESCRIPTION`), matching the `MEDIA` field style; the description row hides when empty.
- Replaces the header-styled `LoginButton` in the sign-in prompt with a new page-scoped `SignInButton`, right-aligned and styled to match the card's other pill buttons (`Save`, `Airdrop`, `Copy link`).
- Updates note copy to sentence case ("Sign in to airdrop and edit the moment.", "You are not an admin of this moment.") and restyles the note as a flat tinted callout (left accent bar + tint background) instead of a bordered/shadowed card, in italic.
- Updates the loading skeleton to mirror the actual two-card layout instead of generic bars, avoiding a layout jump when content loads.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on touched files
- [x] Verified the note/skeleton rendering locally via headless browser against a live mainnet moment
- [ ] Manual QA: signed-out view (labeled title/description, note, sign-in button), owner view save/airdrop flows unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)