### PR TITLE
fix: prevent mobile drawer panels from dragging during touch scroll

### DIFF
--- a/components/Timeline/MobileHome/MobileCollectDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileCollectDrawer.tsx
@@ -42,7 +42,7 @@ const MobileCollectDrawer = () => {
         />
       )}
       <div
-        className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out ${
+        className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out will-change-transform ${
           isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
         }`}
       >

--- a/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
@@ -31,7 +31,7 @@ const MobileFeedbackDrawerPanel = ({
     <>
       {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
       <div
-        className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out ${
+        className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out will-change-transform ${
           isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
         }`}
       >

--- a/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
@@ -36,7 +36,7 @@ const MobileSearchDrawerPanel = ({
 
   return (
     <div
-      className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 flex flex-col bg-white transition-transform duration-300 ease-out ${
+      className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 flex flex-col bg-white transition-transform duration-300 ease-out will-change-transform ${
         isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
       }`}
     >

--- a/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
@@ -31,7 +31,7 @@ const MobileUserDrawerPanel = ({
   <>
     {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
     <div
-      className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 z-50 overflow-hidden bg-grey-moss-900 shadow-2xl transition-transform duration-300 ease-out ${
+      className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 z-50 overflow-hidden bg-grey-moss-900 shadow-2xl transition-transform duration-300 ease-out will-change-transform ${
         isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
       }`}
     >


### PR DESCRIPTION
## Summary
- Fixes a regression from the mobile header/footer fix (#1399): the fixed-position drawer panels (feedback, search, user, collect) briefly slide into view and follow an active touch-scroll gesture on the mobile home page, then snap back off-screen on touch release — even though their trigger icon was never tapped.
- Root cause: these panels combine `position: fixed` with a CSS `transform` (`translate-y-full`/`translate-y-0`) for their slide animation. On mobile WebKit/Blink, a fixed element with a transform can lose its GPU-compositing fast path during an active touch-scroll, causing it to visually drag with the gesture instead of staying pinned, then repaint correctly on touchend.
- Fix: add `will-change-transform` to promote each panel to its own compositing layer, keeping it properly pinned throughout the gesture.
- No changes to Header, Footer, or Layout — the header/footer fix from #1399 is untouched.

## Test plan
- [x] Reviewed diff — 4 files, one class addition each
- [ ] Verify on a real mobile device: scroll the mobile home feed with a sustained touch and confirm no drawer panel appears/drags during the gesture
- [ ] Confirm feedback/search/user/collect drawers still open/close normally via their trigger icons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile drawer transitions for a smoother, more responsive sliding experience.
  * Updated several bottom-sheet panels so opening and closing animations render more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->