### PR TITLE
fix: replace percentage-based hidden transform on mobile drawer panels

### DIFF
--- a/components/Timeline/MobileHome/MobileCollectDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileCollectDrawer.tsx
@@ -43,7 +43,7 @@ const MobileCollectDrawer = () => {
       )}
       <div
         className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out will-change-transform ${
-          isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
+          isOpen ? "translate-y-0" : "pointer-events-none translate-y-[2000px]"
         }`}
       >
         {moment && selectedMoment && (

--- a/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileFeedbackDrawerPanel.tsx
@@ -32,7 +32,7 @@ const MobileFeedbackDrawerPanel = ({
       {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
       <div
         className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out will-change-transform ${
-          isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
+          isOpen ? "translate-y-0" : "pointer-events-none translate-y-[2000px]"
         }`}
       >
         <div className="flex flex-col px-6 pb-4 pt-7">

--- a/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileSearchDrawerPanel.tsx
@@ -37,7 +37,7 @@ const MobileSearchDrawerPanel = ({
   return (
     <div
       className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 flex flex-col bg-white transition-transform duration-300 ease-out will-change-transform ${
-        isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
+        isOpen ? "translate-y-0" : "pointer-events-none translate-y-[2000px]"
       }`}
     >
       <div className="flex items-center gap-3 border-b border-grey-moss-100 px-5">

--- a/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileUserDrawerPanel.tsx
@@ -32,7 +32,7 @@ const MobileUserDrawerPanel = ({
     {isOpen && <div className="fixed inset-0 z-40" onClick={onClose} />}
     <div
       className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 z-50 overflow-hidden bg-grey-moss-900 shadow-2xl transition-transform duration-300 ease-out will-change-transform ${
-        isOpen ? "translate-y-0" : "pointer-events-none translate-y-full"
+        isOpen ? "translate-y-0" : "pointer-events-none translate-y-[2000px]"
       }`}
     >
       <button onClick={onTimeline} className={ITEM_CLASS}>


### PR DESCRIPTION
## Summary
Follow-up to #1410, which added `will-change-transform` but did not fix the issue — the same drawer panel peek-then-vanish still reproduced.

- Root cause (revised): `translate-y-full` is `translateY(100%)`, computed against the panel's *own* height, which is derived from `top-0` + `bottom: calc(74px+safe-area)` — both resolved against the live viewport. During an active touch-scroll on Android Chrome, the toolbar-collapse animation resizes the viewport continuously on the compositor thread, while the main-thread layout pass that recomputes the panel's height (and thus the transform's percentage basis) can lag behind. For a few frames the panel is translated by a stale, too-small amount, revealing a sliver — until the gesture ends, layout catches up, and it snaps fully off-screen again.
- Fix: replace the percentage-based hidden transform with a fixed, large pixel offset (`translate-y-[2000px]`) that requires no live height calculation, so the hidden position is correct on every frame regardless of viewport-resize timing.
- Verified locally (Pixel 7 emulation): opening/closing each drawer via its trigger icon still works correctly (`translateY(0)` when open, static offset when closed).
- No changes to Header, Footer, or Layout.

## Test plan
- [x] Verified open/closed transform values via automated browser check
- [ ] Verify on a real Android device: scroll the mobile home feed with a sustained touch and confirm no drawer panel appears/drags during the gesture
- [ ] Confirm feedback/search/user/collect drawers still open/close normally via their trigger icons