### PR TITLE
Replace mobile collect drawer with a centered confirmation modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,12 @@ export const useSomething = () => {
 - **Chain**: Base (mainnet) or Base Sepolia (testnet via `NEXT_PUBLIC_IS_TESTNET`)
 - **Stack**: Next.js, TanStack Query, Privy (auth), Supabase, Viem
 
+### UI Copy Casing Convention
+
+- Buttons, labels, field names, and inline hints stay **lowercase** (e.g. `collect`, `comment`, `moment collection price`, `choose the amount you want to collect`).
+- Confirmation/notice sentences (e.g. "Are you sure you want to collect this moment?") use **normal sentence case** — capitalize the first letter, punctuate as a sentence.
+- Structured detail rows under a confirmation notice use a `label: value` format (e.g. `title: ...`, `price: ...`), not a prose sentence like `collect [title] for [price]`.
+
 ---
 
 ## Sound.xyz Admin Permission System

--- a/components/CommentButton/CommentButton.tsx
+++ b/components/CommentButton/CommentButton.tsx
@@ -17,7 +17,7 @@ export default function CommentButton({ disabled = false, label = "collect" }: C
       className="w-full bg-black py-3 font-archivo text-xl text-grey-eggshell hover:bg-grey-moss-300 disabled:cursor-not-allowed disabled:bg-grey-moss-300"
       disabled={isLoading || disabled}
     >
-      {isLoading ? "collecting..." : label}
+      {isLoading ? "Collecting..." : label}
     </button>
   );
 }

--- a/components/Timeline/MobileHome/MobileCollectDrawer.tsx
+++ b/components/Timeline/MobileHome/MobileCollectDrawer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import MobileCollectDrawerPanel from "@/components/Timeline/MobileHome/MobileCollectDrawerPanel";
 import { getMomentKey } from "@/lib/moment/getMomentKey";
 import { getMomentSeed } from "@/lib/moment/getMomentSeed";
@@ -7,61 +8,35 @@ import { MomentCollectProvider } from "@/providers/MomentCollectProvider";
 import { MomentCommentsProvider } from "@/providers/MomentCommentsProvider";
 import { MomentProvider } from "@/providers/MomentProvider";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
-import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 
 const MobileCollectDrawer = () => {
   const { isDrawerOpen, collectMoment, closeDrawer } = useMobileDrawersProvider();
   const isOpen = isDrawerOpen("collect");
-  const selectedMoment = collectMoment;
-  const [mounted, setMounted] = useState(false);
-  const [backdropReady, setBackdropReady] = useState(false);
 
-  useEffect(() => setMounted(true), []);
+  if (!collectMoment) return null;
 
-  useEffect(() => {
-    if (!isOpen) {
-      setBackdropReady(false);
-      return;
-    }
+  const moment = getMomentKey(collectMoment);
 
-    const timer = window.setTimeout(() => setBackdropReady(true), 300);
-    return () => window.clearTimeout(timer);
-  }, [isOpen]);
-
-  if (!mounted || (!isOpen && !selectedMoment)) return null;
-
-  const moment = selectedMoment ? getMomentKey(selectedMoment) : null;
-
-  return createPortal(
-    <>
-      {isOpen && (
-        <div
-          className={`fixed inset-0 z-40 ${backdropReady ? "" : "pointer-events-none"}`}
-          onClick={backdropReady ? closeDrawer : undefined}
-        />
-      )}
-      <div
-        className={`fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 overflow-y-auto bg-white transition-transform duration-300 ease-out will-change-transform ${
-          isOpen ? "translate-y-0" : "pointer-events-none translate-y-[2000px]"
-        }`}
-      >
-        {moment && selectedMoment && (
-          <MomentProvider
-            key={selectedMoment.id}
-            moment={moment}
-            initialData={getMomentSeed(selectedMoment)}
-          >
-            <MomentCommentsProvider>
-              <MomentCollectProvider>
-                <MobileCollectDrawerPanel onClose={closeDrawer} />
-              </MomentCollectProvider>
-            </MomentCommentsProvider>
-          </MomentProvider>
-        )}
-      </div>
-    </>,
-    document.body
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && closeDrawer()}>
+      <DialogContent className="flex max-h-[85vh] w-[calc(100%-2rem)] max-w-sm flex-col items-center !gap-0 overflow-y-auto !rounded-lg border-none !bg-white px-5 py-5 shadow-lg">
+        <VisuallyHidden>
+          <DialogTitle>Collect</DialogTitle>
+        </VisuallyHidden>
+        <MomentProvider
+          key={collectMoment.id}
+          moment={moment}
+          initialData={getMomentSeed(collectMoment)}
+        >
+          <MomentCommentsProvider>
+            <MomentCollectProvider>
+              <MobileCollectDrawerPanel onClose={closeDrawer} />
+            </MomentCollectProvider>
+          </MomentCommentsProvider>
+        </MomentProvider>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/components/Timeline/MobileHome/MobileCollectDrawerPanel.tsx
+++ b/components/Timeline/MobileHome/MobileCollectDrawerPanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import CollectModalContents from "@/components/MomentPage/CollectModalContents";
 import { useMomentCollectProvider } from "@/providers/MomentCollectProvider";
 import { X } from "lucide-react";
 import { useEffect } from "react";
+import MobileCollectModalContents from "./MobileCollectModalContents";
 
 interface MobileCollectDrawerPanelProps {
   onClose: () => void;
@@ -17,16 +17,16 @@ const MobileCollectDrawerPanel = ({ onClose }: MobileCollectDrawerPanelProps) =>
   }, [collected, onClose]);
 
   return (
-    <div className="relative flex flex-col px-6 pb-4 pt-10">
+    <div className="relative flex w-full flex-col items-center pt-5">
       <button
         type="button"
         onClick={onClose}
-        className="absolute right-5 top-4 flex h-8 w-8 items-center justify-center text-grey-moss-400"
+        className="absolute right-0 top-[-12px] flex h-8 w-8 items-center justify-center text-grey-moss-400"
       >
         <X className="h-5 w-5" strokeWidth={1.5} />
       </button>
 
-      <CollectModalContents />
+      <MobileCollectModalContents />
     </div>
   );
 };

--- a/components/Timeline/MobileHome/MobileCollectModalContents.tsx
+++ b/components/Timeline/MobileHome/MobileCollectModalContents.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import useCollectAvailability from "@/hooks/useCollectAvailability";
+import getPrice from "@/lib/getPrice";
+import getPriceUnit from "@/lib/getPriceUnit";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import { MomentType } from "@/types/moment";
+import CommentButton from "../../CommentButton/CommentButton";
+
+const MobileCollectModalContents = () => {
+  const { isLoading, metadata, saleConfig } = useMomentProvider();
+  const { isCollectDisabled, collectCtaLabel } = useCollectAvailability();
+
+  if (isLoading || !metadata) {
+    return <Skeleton className="h-32 w-full rounded-none" />;
+  }
+
+  const pricePerToken = BigInt(saleConfig?.pricePerToken || 0);
+  const priceLabel =
+    pricePerToken === BigInt(0)
+      ? "free"
+      : `${getPrice(pricePerToken, saleConfig?.type || MomentType.FixedPriceMint)} ${getPriceUnit(saleConfig?.type || MomentType.FixedPriceMint)}`;
+
+  return (
+    <>
+      <p className="text-center font-archivo text-lg">Are you sure you want to collect?</p>
+      <div className="mt-3 w-full space-y-1 font-archivo text-sm text-grey-moss-400">
+        {metadata.name && (
+          <p className="font-spectral-italic text-center text-lg">{metadata.name}</p>
+        )}
+        <p className="font-archivo-bold uppercase text-tan-gold text-center text-lg">
+          {priceLabel}
+        </p>
+      </div>
+      <div className="pt-3 w-full">
+        <CommentButton disabled={isCollectDisabled} label={collectCtaLabel} />
+      </div>
+    </>
+  );
+};
+
+export default MobileCollectModalContents;

--- a/hooks/useCollectAvailability.ts
+++ b/hooks/useCollectAvailability.ts
@@ -11,7 +11,7 @@ const useCollectAvailability = () => {
   const isInProcessOnBase = isInProcess && moment.chainId === base.id;
   const isWalletLoading = isSmartWalletLoading;
   const isCollectDisabled = !isSaleActive || soldOut || !isInProcessOnBase || isWalletLoading;
-  const collectCtaLabel = soldOut || !isInProcessOnBase ? "sold out" : "collect";
+  const collectCtaLabel = soldOut || !isInProcessOnBase ? "Sold out" : "Collect";
 
   return { isCollectDisabled, collectCtaLabel };
 };


### PR DESCRIPTION
## Summary
- Replace the full-screen sliding mobile collect drawer with a compact, centered confirmation dialog (`MobileCollectDrawer.tsx` now uses the shared `Dialog`/`DialogContent` primitives instead of a custom portal/transform drawer)
- Add `MobileCollectModalContents.tsx`: a simple "are you sure you want to collect?" confirmation showing the moment name and price, instead of jumping straight into a comment field
- Uppercase the collect CTA labels (`Collect`, `Sold out`, `Collecting...`) for consistency
- Document the UI copy casing convention (lowercase labels vs. normal-case notices vs. `label: value` detail rows) in `CLAUDE.md` so this doesn't regress

## Test plan
- [ ] On mobile viewport, tap Collect on a home feed card and confirm the centered modal appears (not full-screen)
- [ ] Confirm modal shows moment name and price, and tapping the CTA collects successfully
- [ ] Confirm closing via the X button and via backdrop tap both work
- [ ] Confirm sold-out moments show disabled "Sold out" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed mobile collect flow with a dialog-based drawer and improved confirmation content, including clearer pricing and collection details.
  * Added support for showing “free” when no price is required.

* **Bug Fixes**
  * Improved loading and empty states in the mobile collect experience.
  * Updated button and CTA text casing for more consistent UI copy, including “Collecting...”, “Collect”, and “Sold out”.

* **Documentation**
  * Added UI text casing guidelines for consistent on-screen wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->