### PR TITLE
feat: add saleEnd support to moment sale editor

### DIFF
--- a/components/MomentManagePage/Sale.tsx
+++ b/components/MomentManagePage/Sale.tsx
@@ -42,6 +42,7 @@ const Sale = () => {
               saleEnd={saleEnd}
               currentSaleEnd={saleConfig.saleEnd}
               setSaleEnd={setSaleEnd}
+              saleStart={saleStart}
             />
             <SalePriceInput
               priceInput={priceInput}

--- a/components/MomentManagePage/Sale.tsx
+++ b/components/MomentManagePage/Sale.tsx
@@ -4,6 +4,7 @@ import useSetSale from "@/hooks/useSetSale";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import SaleSkeleton from "./SaleSkeleton";
 import SaleStartPicker from "./SaleStartPicker";
+import SaleEndPicker from "./SaleEndPicker";
 import SalePriceInput from "./SalePriceInput";
 import PermissionErrorModal from "@/components/PermissionErrorModal";
 
@@ -11,6 +12,8 @@ const Sale = () => {
   const {
     saleStart,
     setSaleStart,
+    saleEnd,
+    setSaleEnd,
     priceInput,
     setPriceInput,
     priceUnit,
@@ -34,6 +37,11 @@ const Sale = () => {
               saleStart={saleStart}
               currentSaleStart={saleConfig.saleStart}
               setSaleStart={setSaleStart}
+            />
+            <SaleEndPicker
+              saleEnd={saleEnd}
+              currentSaleEnd={saleConfig.saleEnd}
+              setSaleEnd={setSaleEnd}
             />
             <SalePriceInput
               priceInput={priceInput}

--- a/components/MomentManagePage/SaleEndPicker.tsx
+++ b/components/MomentManagePage/SaleEndPicker.tsx
@@ -1,22 +1,22 @@
-import { maxUint64 } from "viem";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
+import { isOpenEndedSale } from "@/lib/moment/isOpenEndedSale";
 
 interface SaleEndPickerProps {
   saleEnd: Date | undefined;
   currentSaleEnd: number | string;
   setSaleEnd: (date: Date) => void;
+  saleStart: Date;
 }
 
-const SaleEndPicker = ({ saleEnd, currentSaleEnd, setSaleEnd }: SaleEndPickerProps) => {
-  const normalized = BigInt(String(Math.floor(Number(currentSaleEnd))));
-  const isOpenEnded = normalized === BigInt(0) || normalized === maxUint64;
+const SaleEndPicker = ({ saleEnd, currentSaleEnd, setSaleEnd, saleStart }: SaleEndPickerProps) => {
+  const isOpenEnded = isOpenEndedSale(currentSaleEnd);
   return (
     <div>
       <p className="pb-2">
         sale end:{" "}
-        {isOpenEnded ? "Open" : new Date(Number(normalized) * 1000).toLocaleDateString()}
+        {isOpenEnded ? "Open" : new Date(Number(currentSaleEnd) * 1000).toLocaleDateString()}
       </p>
-      <DateTimePicker date={saleEnd} setDate={setSaleEnd} />
+      <DateTimePicker date={saleEnd} setDate={setSaleEnd} minDate={saleStart} />
     </div>
   );
 };

--- a/components/MomentManagePage/SaleEndPicker.tsx
+++ b/components/MomentManagePage/SaleEndPicker.tsx
@@ -1,0 +1,24 @@
+import { maxUint64 } from "viem";
+import { DateTimePicker } from "@/components/ui/date-time-picker";
+
+interface SaleEndPickerProps {
+  saleEnd: Date | undefined;
+  currentSaleEnd: number | string;
+  setSaleEnd: (date: Date) => void;
+}
+
+const SaleEndPicker = ({ saleEnd, currentSaleEnd, setSaleEnd }: SaleEndPickerProps) => {
+  const normalized = BigInt(String(Math.floor(Number(currentSaleEnd))));
+  const isOpenEnded = normalized === BigInt(0) || normalized === maxUint64;
+  return (
+    <div>
+      <p className="pb-2">
+        sale end:{" "}
+        {isOpenEnded ? "Open" : new Date(Number(normalized) * 1000).toLocaleDateString()}
+      </p>
+      <DateTimePicker date={saleEnd} setDate={setSaleEnd} />
+    </div>
+  );
+};
+
+export default SaleEndPicker;

--- a/components/ui/date-time-picker.tsx
+++ b/components/ui/date-time-picker.tsx
@@ -14,10 +14,20 @@ import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 interface DatetimePickerProps {
   date: Date | undefined;
   setDate: (_value: Date) => void;
+  /** Dates on or before this day are not selectable. */
+  minDate?: Date;
 }
 
-export function DateTimePicker({ date, setDate }: DatetimePickerProps) {
+export function DateTimePicker({ date, setDate, minDate }: DatetimePickerProps) {
   const [isOpen, setIsOpen] = React.useState(false);
+
+  const disabledBefore = React.useMemo(() => {
+    if (!minDate) return undefined;
+    const boundary = new Date(minDate);
+    boundary.setHours(0, 0, 0, 0);
+    boundary.setDate(boundary.getDate() + 1);
+    return boundary;
+  }, [minDate]);
 
   const hours = Array.from({ length: 24 }, (_, i) => i);
   const handleDateSelect = (selectedDate: Date | undefined) => {
@@ -62,6 +72,7 @@ export function DateTimePicker({ date, setDate }: DatetimePickerProps) {
             captionLayout="dropdown"
             fromYear={1969}
             toYear={2030}
+            disabled={disabledBefore ? { before: disabledBefore } : undefined}
           />
           <div className="flex flex-col divide-y sm:h-[300px] sm:flex-row sm:divide-x sm:divide-y-0">
             <ScrollArea className="w-64 sm:w-auto">

--- a/hooks/useSetSale.ts
+++ b/hooks/useSetSale.ts
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
-import { formatEther, formatUnits, maxUint64, parseEther, parseUnits } from "viem";
+import { formatEther, formatUnits, parseEther, parseUnits } from "viem";
 import { toast } from "sonner";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import { setSale } from "@/lib/moment/setSale";
 import { MomentType } from "@/types/moment";
 import { isPermissionError } from "@/lib/errors/isPermissionError";
+import { isOpenEndedSale } from "@/lib/moment/isOpenEndedSale";
 
 const useSetSale = () => {
   const { moment, saleConfig: sale } = useMomentProvider();
@@ -28,9 +29,8 @@ const useSetSale = () => {
         ? new Date()
         : new Date(parseInt(sale.saleStart.toString(), 10) * 1000)
     );
-    const saleEndBigInt = BigInt(sale.saleEnd);
     setSaleEnd(
-      saleEndBigInt === BigInt(0) || saleEndBigInt === maxUint64
+      isOpenEndedSale(sale.saleEnd)
         ? undefined
         : new Date(parseInt(sale.saleEnd.toString(), 10) * 1000)
     );

--- a/hooks/useSetSale.ts
+++ b/hooks/useSetSale.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
-import { formatEther, formatUnits, parseEther, parseUnits } from "viem";
+import { formatEther, formatUnits, maxUint64, parseEther, parseUnits } from "viem";
 import { toast } from "sonner";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import { setSale } from "@/lib/moment/setSale";
@@ -12,6 +12,7 @@ const useSetSale = () => {
   const { moment, saleConfig: sale } = useMomentProvider();
   const { getAccessToken } = usePrivy();
   const [saleStart, setSaleStart] = useState<Date>(new Date());
+  const [saleEnd, setSaleEnd] = useState<Date | undefined>(undefined);
   const [priceInput, setPriceInput] = useState<string>("");
   const [isErc20, setIsErc20] = useState(false);
   const [showPermissionModal, setShowPermissionModal] = useState(false);
@@ -27,6 +28,12 @@ const useSetSale = () => {
         ? new Date()
         : new Date(parseInt(sale.saleStart.toString(), 10) * 1000)
     );
+    const saleEndBigInt = BigInt(sale.saleEnd);
+    setSaleEnd(
+      saleEndBigInt === BigInt(0) || saleEndBigInt === maxUint64
+        ? undefined
+        : new Date(parseInt(sale.saleEnd.toString(), 10) * 1000)
+    );
     setPriceInput(
       erc20 ? formatUnits(BigInt(sale.pricePerToken), 6) : formatEther(BigInt(sale.pricePerToken))
     );
@@ -40,7 +47,8 @@ const useSetSale = () => {
         ? parseUnits(priceInput, 6).toString()
         : parseEther(priceInput).toString();
       const saleStartUnix = Math.floor(saleStart.getTime() / 1000);
-      return setSale(accessToken, moment, saleStartUnix, pricePerToken);
+      const saleEndUnix = saleEnd ? Math.floor(saleEnd.getTime() / 1000) : undefined;
+      return setSale(accessToken, moment, saleStartUnix, pricePerToken, saleEndUnix);
     },
     onSuccess: () => toast.success("Sale updated successfully"),
     onError: (error: any) => {
@@ -55,6 +63,8 @@ const useSetSale = () => {
   return {
     saleStart,
     setSaleStart,
+    saleEnd,
+    setSaleEnd,
     priceInput,
     setPriceInput,
     priceUnit,

--- a/lib/moment/isOpenEndedSale.ts
+++ b/lib/moment/isOpenEndedSale.ts
@@ -1,0 +1,12 @@
+// JS Date's representable range is +/-8,640,000,000,000,000ms from epoch.
+// saleEnd's on-chain "forever" sentinel (uint64 max) is far beyond that, and
+// loses precision when serialized as a JS number, so compare by magnitude
+// rather than exact equality to the sentinel value.
+const MAX_VALID_DATE_MS = 8640000000000000;
+
+export const isOpenEndedSale = (saleEnd: number | string): boolean => {
+  const seconds = Number(saleEnd);
+  return seconds <= 0 || seconds * 1000 > MAX_VALID_DATE_MS;
+};
+
+export default isOpenEndedSale;

--- a/lib/moment/setSale.ts
+++ b/lib/moment/setSale.ts
@@ -5,7 +5,8 @@ export const setSale = async (
   accessToken: string,
   moment: Moment,
   saleStart: number,
-  pricePerToken?: string
+  pricePerToken?: string,
+  saleEnd?: number
 ): Promise<{ hash: string; chainId: number }> => {
   const res = await fetch(`${IN_PROCESS_API}/moment/sale`, {
     method: "POST",
@@ -21,6 +22,7 @@ export const setSale = async (
       },
       saleStart,
       ...(pricePerToken !== undefined && { pricePerToken }),
+      ...(saleEnd !== undefined && { saleEnd }),
     }),
   });
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- Add `SaleEndPicker` component (mirrors `SaleStartPicker`) to the manage page sale editor, which previously only supported `saleStart`
- Thread `saleEnd` through `useSetSale` and `setSale`; when unset/open-ended (`maxUint64`) it's displayed as "Open"
- `saleEnd` is only included in the API request when the user actually picks a new date, so an existing open-ended sale isn't accidentally set to end immediately
- Backend (`in_process_api`) already supported `saleEnd` end-to-end — no backend changes needed

## Test plan
- [ ] Open a moment's manage page with an active, open-ended sale — confirm "sale end: Open" shows and submitting without touching the end date leaves the sale open-ended
- [ ] Set a new sale end date and submit — confirm the on-chain sale end updates and the UI reflects the new date on reload
- [ ] Open a moment with an existing fixed sale end date — confirm it's pre-filled correctly in the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an optional sale end time.
  * The sale settings UI now includes an end-time picker alongside the existing start-time controls.
  * Open-ended sales are clearly labeled; scheduled end times display as formatted dates.
  * Sale updates now persist the selected end time when provided.
* **UI Improvements**
  * Date/time picker now supports a minimum date constraint to prevent selecting an end time earlier than the sale start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->