### PR TITLE
Switch manage layout and moments grid to fluid, percentage-based widths

### DIFF
--- a/app/manage/layout.tsx
+++ b/app/manage/layout.tsx
@@ -12,7 +12,7 @@ const ManagePage = ({ children }: { children: ReactNode }) => {
 
   return (
     // md:h: fills the viewport below the sticky 63px header so only the content column scrolls
-    <main className="flex w-full flex-col md:flex-row grow gap-4 px-2 pt-0 md:mx-auto md:h-[calc(100vh-66px)] md:max-w-[1080px] md:gap-11 md:overflow-hidden md:px-10 md:pt-6">
+    <main className="flex w-full flex-col md:flex-row grow gap-4 px-2 pt-0 md:mx-auto md:h-[calc(100vh-66px)] md:max-w-[95%] md:gap-11 md:overflow-hidden md:px-10 md:pt-6">
       <div className="fixed inset-x-0 top-[calc(72px+env(safe-area-inset-top,0px))] z-20 flex w-full shrink-0 flex-row gap-1.5 px-2 py-1 overflow-x-auto no-scrollbar md:static md:inset-x-auto md:top-auto md:z-auto md:w-[210px] md:flex-col md:gap-0.5 md:overflow-visible md:p-0">
         <NavButton label="account" href="/manage/account" icon={User} />
         <NavButton label="payment" href="/manage/payment" icon={CreditCard} />
@@ -21,7 +21,7 @@ const ManagePage = ({ children }: { children: ReactNode }) => {
           <NavButton label="mutual moments" href="/manage/mutual-moments" icon={Users} />
         )}
       </div>
-      <div className="fixed inset-x-0 top-[calc(113px+env(safe-area-inset-top,0px))] bottom-[calc(74px+env(safe-area-inset-bottom,0px))] overflow-y-auto px-2 pt-3 no-scrollbar md:static md:inset-auto md:h-full md:max-w-[680px] md:grow md:overflow-y-auto md:px-0 md:pb-10 md:pt-0">
+      <div className="fixed inset-x-0 top-[calc(113px+env(safe-area-inset-top,0px))] bottom-[calc(74px+env(safe-area-inset-bottom,0px))] overflow-y-auto px-2 pt-3 no-scrollbar md:static md:inset-auto md:h-full md:grow md:overflow-y-auto md:px-0 md:pb-10 md:pt-0">
         {children}
       </div>
     </main>

--- a/components/MomentsGrid/Moments.tsx
+++ b/components/MomentsGrid/Moments.tsx
@@ -15,7 +15,7 @@ const Moments = ({ variant = "collection" }: MomentsProps) => {
   if (moments.length === 0) return <NoMomentsFound />;
 
   return (
-    <div className="grid w-full grow grid-cols-1 gap-3 px-4 md:grid-cols-5 md:px-10">
+    <div className="grid w-full grow grid-cols-1 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {moments.map((m: TimelineMoment) => (
         <MomentItem m={m} key={m.id} variant={variant} />
       ))}


### PR DESCRIPTION
## Summary
- Replace hardcoded `max-w-[1080px]`/`max-w-[680px]` pixel caps in the manage page layout with a percentage-based container width, letting the content column grow to fill remaining space instead of leaving dead space on wide viewports.
- Update the moments grid to scale columns by breakpoint (`md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5`) instead of a fixed padding/column count.

## Test plan
- [ ] Verify `/manage/account` (and other manage subpages) render correctly at various desktop widths, with no leftover empty space to the right of the content column
- [ ] Verify moments grid column count scales correctly across md/lg/xl breakpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout sizing across management pages.
  * Updated the moments grid to adapt its column count across medium, large, and extra-large screens.
  * Expanded available content space by removing restrictive desktop width limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->