### PR TITLE
Redesign MomentItem card to match Moments manage page mockup

### DIFF
--- a/components/MomentsGrid/MomentItem.tsx
+++ b/components/MomentsGrid/MomentItem.tsx
@@ -3,9 +3,8 @@ import { usePathname, useRouter } from "next/navigation";
 import truncated from "@/lib/truncated";
 import HideButton from "@/components/TimelineMoments/HideButton";
 import { type TimelineMoment, Protocol } from "@/types/moment";
-import { Copy, Check } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import Preview from "./Preview";
-import useCopy from "@/hooks/useCopy";
 import useCanHideMoment from "@/hooks/useCanHideMoment";
 
 import ProtocolBadge from "./ProtocolBadge";
@@ -21,34 +20,44 @@ interface MomentItemProps {
 
 const MomentItem = ({ m, variant = "collection" }: MomentItemProps) => {
   const data = m.metadata;
+  const hasName = Boolean(data?.name?.trim());
   const { push } = useRouter();
-  const { copied, copy } = useCopy(m.address);
   const canHideMoment = useCanHideMoment(m);
   const pathname = usePathname();
   const isManagePage = pathname.includes("/manage");
 
-  const handleClick = () => {
+  const buildPath = (includeTokenId: boolean) => {
     const shortName = getShortNameFromChainId(m.chain_id);
-    if (!shortName) return;
-    const includeTokenId = variant === "moment" || m.protocol === Protocol.ZoraMedia;
-    push(
-      `/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}${includeTokenId ? `/${m.token_id}` : ""}`
-    );
+    if (!shortName) return null;
+    return `/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}${includeTokenId ? `/${m.token_id}` : ""}`;
   };
+
+  const handleClick = () => {
+    const includeTokenId = variant === "moment" || m.protocol === Protocol.ZoraMedia;
+    const path = buildPath(includeTokenId);
+    if (path) push(path);
+  };
+
+  const handleViewCollection = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const path = buildPath(false);
+    if (path) push(path);
+  };
+
   return (
     <div
       role="button"
       tabIndex={0}
-      className="group col-span-1 w-full h-fit cursor-pointer overflow-hidden rounded-xl bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
+      className="group relative col-span-1 h-fit w-full cursor-pointer rounded-[10px] border border-[#E4E0D7] bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,0.12)] transition-shadow duration-150 hover:z-10 hover:shadow-[0_10px_24px_-8px_rgba(27,21,4,0.22)]"
       onClick={handleClick}
       onKeyDown={(e) => e.key === "Enter" && handleClick()}
     >
-      <div className="relative aspect-square w-full overflow-hidden rounded-t-xl bg-grey-moss-50">
-        <div className="absolute left-1.5 top-1.5 z-20">
+      <div className="relative aspect-square w-full overflow-hidden rounded-t-[9px] bg-grey-moss-50 will-change-transform">
+        <div className="absolute left-2 top-2 z-20">
           <ProtocolBadge protocol={m.protocol} />
         </div>
         {canHideMoment && (
-          <div className="absolute right-1.5 top-1.5 z-20">
+          <div className="absolute right-2 top-2 z-20">
             <HideButton moment={m} />
           </div>
         )}
@@ -60,35 +69,34 @@ const MomentItem = ({ m, variant = "collection" }: MomentItemProps) => {
           </div>
         )}
       </div>
-      <div className="p-2">
-        <div className="flex items-center justify-between gap-2">
+      <div className="px-[13px] pb-[13px] pt-3">
+        <div className="flex items-baseline justify-between gap-2">
           <p
-            className={`truncate font-archivo-medium text-sm ${data ? "text-grey-moss-900" : "text-grey-moss-200"}`}
+            className={`truncate font-spectral text-[14.5px] leading-[1.3] transition-colors ${hasName ? "text-grey-moss-900 hover:text-tan-gold" : "text-grey-moss-200"}`}
           >
-            {data ? truncated(data.name ?? "", 20) : "Unknown"}
+            {data ? (hasName ? truncated(data.name ?? "", 20) : "------") : "Unknown"}
           </p>
-          <span className="shrink-0 font-archivo text-xs text-grey-moss-200">
+          <span className="shrink-0 whitespace-nowrap font-archivo text-[10.5px] text-tan-gold">
             {new Date(m.created_at).toLocaleDateString("en-US")}
           </span>
         </div>
-        <div className="mt-1 flex items-center justify-between gap-2 font-archivo text-xs text-grey-moss-400">
-          <div className="flex min-w-0 items-center gap-1">
-            <ChainLogo chainId={m.chain_id} />
-            <button
-              type="button"
-              onClick={copy}
-              className="flex items-center gap-1 truncate transition-colors hover:text-grey-moss-400"
-            >
-              <span className="truncate">{truncateAddress(m.address)}</span>
-              {copied ? (
-                <Check className="size-3 shrink-0 text-green-500" />
-              ) : (
-                <Copy className="size-3 shrink-0" />
-              )}
-            </button>
-          </div>
-          <span className="shrink-0">{`#${m.token_id}`}</span>
-        </div>
+        <button
+          type="button"
+          onClick={handleViewCollection}
+          className="group/link relative mt-[7px] flex w-full items-center justify-between gap-1.5 text-left"
+        >
+          <ChainLogo chainId={m.chain_id} />
+          <span className="min-w-0 truncate text-right font-spectral-italic text-xs text-grey-moss-200">
+            <span className="font-archivo text-[11px] text-grey-moss-300">#{m.token_id}</span> in{" "}
+            <span className="text-sm text-tan-gold underline decoration-tan-gold underline-offset-[3px] transition-colors group-hover/link:text-grey-moss-900">
+              {m.collection?.name?.trim() || truncateAddress(m.address)}
+            </span>
+          </span>
+          <span className="pointer-events-none absolute right-0 top-full z-10 mt-1.5 hidden items-center gap-1 whitespace-nowrap rounded-lg bg-grey-moss-900 px-2.5 py-1.5 font-archivo text-[10.5px] font-semibold text-white shadow-lg group-hover/link:flex">
+            view collection
+            <ArrowUpRight className="size-3" />
+          </span>
+        </button>
       </div>
     </div>
   );

--- a/components/MomentsGrid/Moments.tsx
+++ b/components/MomentsGrid/Moments.tsx
@@ -15,7 +15,7 @@ const Moments = ({ variant = "collection" }: MomentsProps) => {
   if (moments.length === 0) return <NoMomentsFound />;
 
   return (
-    <div className="grid w-full grow grid-cols-1 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+    <div className="grid w-full grow grid-cols-1 gap-3 pt-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {moments.map((m: TimelineMoment) => (
         <MomentItem m={m} key={m.id} variant={variant} />
       ))}

--- a/types/moment.ts
+++ b/types/moment.ts
@@ -64,6 +64,9 @@ export interface TimelineMoment {
   metadata?: MomentMetadata;
   sale?: MomentSaleConfig | null;
   comments?: number;
+  collection?: {
+    name: string | null;
+  };
 }
 
 export type MomentSaleConfig = {


### PR DESCRIPTION
## Summary
- Restyle `MomentItem` card (borders, corner radii, shadows, spacing, typography) to match the new Figma-based design mockup for the manage/moments page.
- Replace the address + copy-to-clipboard row with a `#tokenId in [collection]` link (chain logo left, text right-aligned) that navigates to the collection and shows a "view collection" hover popover; falls back to the truncated address when `collection.name` isn't set.
- Add an "------" placeholder when a moment has no name, instead of leaving the title blank.
- Fix hover-state rendering bugs introduced along the way: popover getting clipped by the card's own `overflow-hidden`, a border-radius compositing "flip" during hover transforms, and the popover being clipped by the next row's card due to stacking-context capture.
- Add `collection?: { name: string | null }` to `TimelineMoment` (backed by the new `build_moment_json` `p_collection_name` param in `in_process_database`) and give the moments grid a touch of top padding so hover shadows aren't clipped by the scroll container.

## Test plan
- [ ] Verify `/manage/moments` (and `/manage/mutual-moments`) render cards correctly at various widths
- [ ] Hover a card: shadow only (no lift), no border-radius flicker, popover not clipped by the card or by the row below
- [ ] Click a card body vs. the `#id in [collection]` link route to the expected destinations
- [ ] Moment with no name shows "------"; moment with no `collection.name` falls back to truncated address