### PR TITLE
Route MomentItem card and collection-name link to the correct pages

### DIFF
--- a/components/ArtistPage/ArtistPage.tsx
+++ b/components/ArtistPage/ArtistPage.tsx
@@ -24,9 +24,7 @@ const ArtistPage = () => {
           {isMobile ? <MobileProfile /> : <DesktopProfile />}
           <AltToggle alt={alt} setAlt={setAlt} />
         </div>
-        <div
-          className={`flex grow flex-col px-2 md:px-0 ${alt === "timeline" && "md:px-10 md:pt-20"}`}
-        >
+        <div className={`flex grow flex-col px-2 md:px-10 ${alt === "timeline" && "md:pt-20"}`}>
           <TimelineProvider artistAddress={address} curated={false}>
             <MomentsTimeline alt={alt} />
           </TimelineProvider>

--- a/components/CollectionManagePage/CollectionManagePage.tsx
+++ b/components/CollectionManagePage/CollectionManagePage.tsx
@@ -31,7 +31,7 @@ const CollectionManagePage = () => {
           <h2 className="text-xl font-semibold">Moments</h2>
         </div>
         <TimelineProvider collection={collection} includeHidden={true}>
-          <Moments variant="moment" />
+          <Moments />
         </TimelineProvider>
       </MetadataUploadProvider>
     </MetadataFormProvider>

--- a/components/CollectionPage/CollectionPage.tsx
+++ b/components/CollectionPage/CollectionPage.tsx
@@ -27,9 +27,7 @@ const CollectionPage = () => {
           <CollectionInfo />
           <AltToggle alt={alt} setAlt={setAlt} />
         </div>
-        <div
-          className={`grow flex flex-col px-2 md:px-0 ${alt === "timeline" && "md:pt-20 md:px-10"}`}
-        >
+        <div className={`grow flex flex-col px-2 md:px-10 ${alt === "timeline" && "md:pt-20"}`}>
           <TimelineProvider collection={collection}>
             <MomentsTimeline alt={alt} />
           </TimelineProvider>

--- a/components/MomentsGrid/MomentItem.tsx
+++ b/components/MomentsGrid/MomentItem.tsx
@@ -2,7 +2,7 @@ import truncateAddress from "@/lib/truncateAddress";
 import { usePathname, useRouter } from "next/navigation";
 import truncated from "@/lib/truncated";
 import HideButton from "@/components/TimelineMoments/HideButton";
-import { type TimelineMoment, Protocol } from "@/types/moment";
+import { type TimelineMoment } from "@/types/moment";
 import { ArrowUpRight } from "lucide-react";
 import Preview from "./Preview";
 import useCanHideMoment from "@/hooks/useCanHideMoment";
@@ -11,14 +11,11 @@ import ProtocolBadge from "./ProtocolBadge";
 import ChainLogo from "./ChainLogo";
 import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
 
-export type MomentItemVariant = "collection" | "moment";
-
 interface MomentItemProps {
   m: TimelineMoment;
-  variant?: MomentItemVariant;
 }
 
-const MomentItem = ({ m, variant = "collection" }: MomentItemProps) => {
+const MomentItem = ({ m }: MomentItemProps) => {
   const data = m.metadata;
   const hasName = Boolean(data?.name?.trim());
   const { push } = useRouter();
@@ -26,22 +23,18 @@ const MomentItem = ({ m, variant = "collection" }: MomentItemProps) => {
   const pathname = usePathname();
   const isManagePage = pathname.includes("/manage");
 
-  const buildPath = (includeTokenId: boolean) => {
-    const shortName = getShortNameFromChainId(m.chain_id);
-    if (!shortName) return null;
-    return `/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}${includeTokenId ? `/${m.token_id}` : ""}`;
-  };
-
   const handleClick = () => {
-    const includeTokenId = variant === "moment" || m.protocol === Protocol.ZoraMedia;
-    const path = buildPath(includeTokenId);
-    if (path) push(path);
+    const shortName = getShortNameFromChainId(m.chain_id);
+    if (!shortName) return;
+    push(`/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}/${m.token_id}`);
   };
 
   const handleViewCollection = (e: React.MouseEvent) => {
     e.stopPropagation();
-    const path = buildPath(false);
-    if (path) push(path);
+    const shortName = getShortNameFromChainId(m.chain_id);
+    if (!shortName) return;
+    const base = isManagePage ? "manage" : "collection";
+    push(`/${base}/${shortName}:${m.address}`);
   };
 
   return (

--- a/components/MomentsGrid/Moments.tsx
+++ b/components/MomentsGrid/Moments.tsx
@@ -2,13 +2,9 @@ import { useTimelineProvider } from "@/providers/TimelineProvider";
 import { type TimelineMoment } from "@/types/moment";
 import MomentsSkeleton from "./MomentsSkeleton";
 import NoMomentsFound from "./NoMomentsFound";
-import MomentItem, { type MomentItemVariant } from "./MomentItem";
+import MomentItem from "./MomentItem";
 
-interface MomentsProps {
-  variant?: MomentItemVariant;
-}
-
-const Moments = ({ variant = "collection" }: MomentsProps) => {
+const Moments = () => {
   const { moments, isLoading } = useTimelineProvider();
 
   if (isLoading) return <MomentsSkeleton />;
@@ -17,7 +13,7 @@ const Moments = ({ variant = "collection" }: MomentsProps) => {
   return (
     <div className="grid w-full grow grid-cols-1 gap-3 pt-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {moments.map((m: TimelineMoment) => (
-        <MomentItem m={m} key={m.id} variant={variant} />
+        <MomentItem m={m} key={m.id} />
       ))}
     </div>
   );

--- a/components/MomentsGrid/index.ts
+++ b/components/MomentsGrid/index.ts
@@ -3,4 +3,3 @@ export { default as MomentItem } from "./MomentItem";
 export { default as MomentItemSkeleton } from "./MomentItemSkeleton";
 export { default as MomentsSkeleton } from "./MomentsSkeleton";
 export { default as NoMomentsFound } from "./NoMomentsFound";
-export type { MomentItemVariant } from "./MomentItem";

--- a/components/Timeline/MomentsTimeline.tsx
+++ b/components/Timeline/MomentsTimeline.tsx
@@ -31,7 +31,7 @@ const MomentsTimeline = ({ alt }: MomentsTimelineProps) => {
   if (alt === "grid")
     return (
       <>
-        {isMobile ? <VerticalFeed /> : <Moments variant="moment" />}
+        {isMobile ? <VerticalFeed /> : <Moments />}
         <FetchMoreInspector fetchMore={fetchMore} />
       </>
     );


### PR DESCRIPTION
## Summary
- Card click now always opens the moment's manage/collect page with its token id, instead of depending on a `variant` prop most callers left unset (so it previously landed on the collection-level page by default).
- The collection-name link now routes to `/manage/{address}` on manage pages and `/collection/{address}` (collection timeline) elsewhere, instead of building a nonexistent `/collect/{address}` (no token id) path on non-manage pages like the artist/collection timeline.
- Removed the now-dead `variant` prop from `MomentItem`/`Moments` and its callers (`MomentsTimeline`, `CollectionManagePage`, the `MomentsGrid` barrel export) since routing no longer depends on it.

## Test plan
- [ ] From `/manage/moments`, click a card body → lands on that moment's manage page (with token id)
- [ ] From `/manage/moments`, click the collection-name link → lands on `/manage/{address}`
- [ ] From an artist timeline page (`/[artistAddress]`), click the collection-name link → lands on `/collection/{address}`, not a broken `/collect/{address}`
- [ ] From a collection timeline page (`/collection/[collection]`), click a card body → lands on `/collect/{address}/{tokenId}`