### PR TITLE
Show displayName in mini app footer user drawer without a logout action

### DIFF
--- a/components/Footer/UserDrawerPanel.tsx
+++ b/components/Footer/UserDrawerPanel.tsx
@@ -1,4 +1,4 @@
-import { Clock, Settings, LogOut } from "lucide-react";
+import { Clock, Settings, LogOut, User } from "lucide-react";
 
 const ITEM_CLASS =
   "flex w-full items-center gap-4 px-7 py-[16px] text-left font-archivo text-[17px] text-white active:bg-[#333333]";
@@ -40,7 +40,17 @@ const UserDrawerPanel = ({
         <Settings className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
         Manage
       </button>
-      {!isMiniApp && (
+      {isMiniApp ? (
+        displayName && (
+          <>
+            <Divider />
+            <div className="flex w-full items-center gap-4 px-7 py-[16px]">
+              <User className="h-[18px] w-[18px] shrink-0 text-white/40" strokeWidth={1.5} />
+              <span className="font-archivo-medium text-[13px] text-white/60">{displayName}</span>
+            </div>
+          </>
+        )
+      ) : (
         <>
           <Divider />
           <button


### PR DESCRIPTION
## Summary
- The "Log out" button in the footer's `UserDrawerPanel` was hidden entirely for Farcaster mini app users, which also removed the only `displayName` label in the drawer since it was nested inside that same conditional button.
- Mini app users now see a non-interactive row with a `User` icon and `displayName` instead, so they can still see which account they're using.
- Web users keep the existing clickable logout button, unchanged.

## Test plan
- [x] `tsc --noEmit` — no type errors introduced
- [ ] Manually verify the footer user drawer in a Farcaster mini app shows the account name without a logout action
- [ ] Manually verify the web drawer still shows and functions as a logout button

🤖 Generated with [Claude Code](https://claude.com/claude-code)