### PR TITLE
Make MomentItem grid card tooltip match its page context

### DIFF
--- a/components/MomentsGrid/MomentItem.tsx
+++ b/components/MomentsGrid/MomentItem.tsx
@@ -85,8 +85,8 @@ const MomentItem = ({ m }: MomentItemProps) => {
               {m.collection?.name?.trim() || truncateAddress(m.address)}
             </span>
           </span>
-          <span className="pointer-events-none absolute right-0 top-full z-10 mt-1.5 hidden items-center gap-1 whitespace-nowrap rounded-lg bg-grey-moss-900 px-2.5 py-1.5 font-archivo text-[10.5px] font-semibold text-white shadow-lg group-hover/link:flex">
-            view collection
+          <span className="uppercase pointer-events-none absolute right-0 top-full z-10 mt-1.5 hidden items-center gap-1 whitespace-nowrap rounded-lg bg-grey-moss-900 px-2.5 py-1.5 font-archivo text-[10.5px] text-white shadow-lg group-hover/link:flex">
+            {isManagePage ? "manage collection" : "open collection timeline"}
             <ArrowUpRight className="size-3" />
           </span>
         </button>


### PR DESCRIPTION
## Summary
- The hover tooltip on the collection link in `MomentItem.tsx` always showed "view collection" on both the Manage page and the Timeline page, even though the click target (`handleViewCollection`) already routes differently per page (`/manage/...` vs `/collection/...`).
- Tooltip label now switches based on `isManagePage`: "manage collection" on the Manage page, "open collection timeline" on the Timeline page, styled uppercase via Tailwind.

## Test plan
- [ ] Manually hover the collection link on a Manage page moment card — tooltip reads "manage collection"
- [ ] Manually hover the collection link on a Timeline page moment card — tooltip reads "open collection timeline"

🤖 Generated with [Claude Code](https://claude.com/claude-code)