### PR TITLE
Stack collection cover image and inputs on mobile, add edit badge

### DIFF
--- a/components/Media/CollectionCoverImage.tsx
+++ b/components/Media/CollectionCoverImage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { ImagePlus } from "lucide-react";
+import { ImagePlus, Pencil } from "lucide-react";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { useMetadataUploadProvider } from "@/providers/MetadataUploadProvider";
 import { useOpenFileDialog } from "@/hooks/useOpenFileDialog";
@@ -21,36 +21,46 @@ const CollectionCoverImage = ({ metadata, isOwner, isSaving }: CollectionCoverIm
   const imageUrl = hasMedia ? previewFileUrl : metadata?.image || undefined;
 
   return (
-    <div
-      role="button"
-      tabIndex={isOwner ? 0 : -1}
-      onClick={openFileDialog}
-      onKeyDown={(e) => e.key === "Enter" && openFileDialog()}
-      className={`relative size-[132px] shrink-0 overflow-hidden rounded-lg border bg-grey-moss-50 ${
-        imageUrl ? "border-grey-moss-100" : "border-dashed border-grey-moss-200"
-      } ${isOwner ? "cursor-pointer" : "cursor-default"}`}
-    >
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        className="hidden"
-        onChange={selectFile}
-        disabled={!isOwner || isSaving}
-      />
-      {imageUrl ? (
-        <Image
-          src={imageUrl}
-          alt={metadata?.name || "cover image"}
-          fill
-          sizes="132px"
-          className="object-cover"
+    <div className="relative size-[132px] shrink-0">
+      <div
+        role="button"
+        tabIndex={isOwner ? 0 : -1}
+        onClick={openFileDialog}
+        onKeyDown={(e) => e.key === "Enter" && openFileDialog()}
+        className={`relative size-full overflow-hidden rounded-lg border bg-grey-moss-50 ${
+          imageUrl ? "border-grey-moss-100" : "border-dashed border-grey-moss-200"
+        } ${isOwner ? "cursor-pointer" : "cursor-default"}`}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={selectFile}
+          disabled={!isOwner || isSaving}
         />
-      ) : (
-        <div className="flex size-full flex-col items-center justify-center gap-1.5 text-grey-moss-300">
-          <ImagePlus className="size-[18px]" strokeWidth={1.5} />
-          <span className="font-mono text-[10px]">cover image</span>
-        </div>
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={metadata?.name || "cover image"}
+            fill
+            sizes="132px"
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex size-full flex-col items-center justify-center gap-1.5 text-grey-moss-300">
+            <ImagePlus className="size-[18px]" strokeWidth={1.5} />
+            <span className="font-mono text-[10px]">cover image</span>
+          </div>
+        )}
+      </div>
+      {isOwner && imageUrl && (
+        <span
+          aria-hidden="true"
+          className="absolute -bottom-1.5 -right-1.5 flex h-[18px] w-[18px] items-center justify-center rounded-full border border-tan-secondary bg-tan-primary text-grey-moss-900"
+        >
+          <Pencil className="h-2.5 w-2.5" />
+        </span>
       )}
     </div>
   );

--- a/components/Media/CollectionMediaCard.tsx
+++ b/components/Media/CollectionMediaCard.tsx
@@ -32,9 +32,9 @@ const CollectionMediaCard = () => {
         <span className={FIELD_LABEL_CLASS}>media</span>
       </div>
 
-      <div className="flex items-center gap-5">
+      <div className="flex flex-col items-center gap-5 md:flex-row md:items-center">
         <CollectionCoverImage metadata={metadata} isOwner={isOwner} isSaving={isSaving} />
-        <div className="flex min-w-0 flex-1 flex-col gap-3.5">
+        <div className="flex w-full min-w-0 flex-1 flex-col gap-3.5">
           <div className="flex flex-col gap-1">
             <label className={FIELD_LABEL_CLASS}>collection name</label>
             <TitleInput


### PR DESCRIPTION
## Summary
- The cover image and the collection name/description inputs sat side by side even on mobile, squeezing the inputs into a too-narrow column with clipped text. They now stack vertically below `md` and go side by side only from `md` up.
- Added a pencil edit badge on the cover image, matching the pattern already used on the SMS moment page (`MomentThumbnailField.tsx`), so it's clearer the image is editable.
- The badge sits on its own non-clipped wrapper so the image box's rounded-corner `overflow-hidden` doesn't cut it off.

## Test plan
- [x] `tsc --noEmit` — no new type errors
- [ ] Manually verify on a mobile viewport that the cover image and inputs stack and inputs are full width
- [ ] Manually verify the pencil badge shows fully (not clipped) on the cover image corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)