### PR TITLE
Redesign Admins tab and fix remove-admin permission gap

### DIFF
--- a/components/CollectionManagePage/AddCollectionAdmin.tsx
+++ b/components/CollectionManagePage/AddCollectionAdmin.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Input } from "@/components/ui/input";
 import useAddCollectionAdmin from "@/hooks/useAddCollectionAdmin";
 import useIsCollectionOwner from "@/hooks/useIsCollectionOwner";
 import { useCollectionProvider } from "@/providers/CollectionProvider";
@@ -30,13 +31,13 @@ const AddCollectionAdmin = () => {
         <span className={FIELD_LABEL_CLASS}>add new admin</span>
       </div>
       <div className="flex gap-2.5">
-        <input
+        <Input
           type="text"
           placeholder="Admin address or ENS name (0x… or name.eth)"
           value={newAdminAddress}
           onChange={(e) => setNewAdminAddress(e.target.value)}
           disabled={isDisabled}
-          className="min-w-0 flex-1 rounded-md border border-grey-moss-100 bg-white px-3 py-2 font-archivo text-[13.5px] text-grey-moss-900 placeholder:text-grey-moss-200 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-w-0 flex-1 rounded-md border-grey-moss-100 bg-white font-archivo text-[13.5px] text-grey-moss-900 placeholder:text-grey-moss-200"
         />
         <button
           type="button"

--- a/components/CollectionManagePage/AddCollectionAdmin.tsx
+++ b/components/CollectionManagePage/AddCollectionAdmin.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import useAddCollectionAdmin from "@/hooks/useAddCollectionAdmin";
 import useIsCollectionOwner from "@/hooks/useIsCollectionOwner";
 import { useCollectionProvider } from "@/providers/CollectionProvider";
 import PermissionErrorModal from "@/components/PermissionErrorModal";
 import { Address } from "viem";
+
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
 
 const AddCollectionAdmin = () => {
   const {
@@ -21,27 +21,35 @@ const AddCollectionAdmin = () => {
   const { data } = useCollectionProvider();
 
   const isDisabled = isAdding || !isOwner;
+  const hasValue = Boolean(newAdminAddress.trim());
 
   return (
-    <div className="flex flex-col gap-2 border-t border-grey-secondary pt-4">
-      <h3 className="font-archivo-medium text-lg">Add New Admin</h3>
-      <div className="flex gap-2">
-        <Input
+    <div>
+      <div className="mb-3 flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-[#887bff]" />
+        <span className={FIELD_LABEL_CLASS}>add new admin</span>
+      </div>
+      <div className="flex gap-2.5">
+        <input
           type="text"
-          placeholder="Enter admin address or ENS name (0x... or name.eth)"
+          placeholder="Admin address or ENS name (0x… or name.eth)"
           value={newAdminAddress}
           onChange={(e) => setNewAdminAddress(e.target.value)}
           disabled={isDisabled}
-          className="flex-1"
+          className="min-w-0 flex-1 rounded-md border border-grey-moss-100 bg-white px-3 py-2 font-archivo text-[13.5px] text-grey-moss-900 placeholder:text-grey-moss-200 disabled:cursor-not-allowed disabled:opacity-50"
         />
-        <Button
+        <button
           type="button"
           onClick={handleAddAdmin}
-          disabled={!newAdminAddress.trim() || isDisabled}
-          className="w-fit rounded-md bg-black px-8 py-2 text-grey-eggshell disabled:opacity-50"
+          disabled={!hasValue || isDisabled}
+          className={`shrink-0 rounded-full border px-[18px] py-2 font-archivo text-xs font-semibold transition-colors disabled:opacity-50 ${
+            hasValue
+              ? "border-grey-moss-900 bg-grey-moss-900 text-white hover:bg-black"
+              : "border-grey-moss-100 bg-grey-moss-50 text-grey-moss-300"
+          }`}
         >
           {isAdding ? "Adding..." : "Add"}
-        </Button>
+        </button>
       </div>
       <PermissionErrorModal
         open={showPermissionModal}

--- a/components/CollectionManagePage/Admins.tsx
+++ b/components/CollectionManagePage/Admins.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { Address } from "viem";
+import { Fragment } from "react";
 import CollectionAdmin from "./CollectionAdmin";
 import AddCollectionAdmin from "./AddCollectionAdmin";
 import { useCollectionProvider } from "@/providers/CollectionProvider";
-import { Fragment } from "react";
+
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
 
 const Admins = () => {
   const { data } = useCollectionProvider();
@@ -14,23 +16,25 @@ const Admins = () => {
   const { admins } = data;
 
   return (
-    <div className="w-full font-archivo">
-      <div className="mt-4 flex w-full max-w-md flex-col gap-4 rounded-2xl bg-white p-4 pt-4">
-        <div className="flex flex-col gap-2">
-          <h3 className="font-archivo-medium text-lg">Current Admins</h3>
-          {admins.length === 0 ? (
-            <p className="font-spectral-italic text-sm text-grey-secondary">No admins added yet.</p>
-          ) : (
-            <div className="space-y-2">
-              {admins.map((address: Address) => (
-                <CollectionAdmin key={address} address={address} />
-              ))}
-            </div>
-          )}
-        </div>
-
-        <AddCollectionAdmin />
+    <div className="rounded-lg border border-grey-moss-100 bg-white p-4 shadow-sm md:p-6">
+      <div className="mb-4 flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-[#7FD58A]" />
+        <span className={FIELD_LABEL_CLASS}>current admins</span>
       </div>
+
+      {admins.length === 0 ? (
+        <p className="font-spectral-italic text-sm text-grey-moss-300">No admins added yet.</p>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {admins.map((address: Address) => (
+            <CollectionAdmin key={address} address={address} />
+          ))}
+        </div>
+      )}
+
+      <div className="my-5 border-t border-grey-moss-50" />
+
+      <AddCollectionAdmin />
     </div>
   );
 };

--- a/components/CollectionManagePage/CollectionAdmin.tsx
+++ b/components/CollectionManagePage/CollectionAdmin.tsx
@@ -1,37 +1,49 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import truncateAddress from "@/lib/truncateAddress";
 import { Address } from "viem";
 import useRemoveCollectionAdmin from "@/hooks/useRemoveCollectionAdmin";
 import { useArtistProfile } from "@/hooks/useArtistProfile";
 import { useIsNotOwnWallet } from "@/hooks/useIsNotOwnWallet";
+import useIsCollectionOwner from "@/hooks/useIsCollectionOwner";
 
 const CollectionAdmin = ({ address }: { address: Address }) => {
   const { handleRemoveAdmin, isRemoving } = useRemoveCollectionAdmin();
-  const { data: artistProfile } = useArtistProfile(address);
+  const { data: artistProfile, isLoading } = useArtistProfile(address);
   const isNotOwnWallet = useIsNotOwnWallet(address);
+  const isOwner = useIsCollectionOwner();
+
+  const label = artistProfile?.username || truncateAddress(address);
+  const initial = artistProfile?.username ? artistProfile.username.charAt(0).toUpperCase() : "0x";
 
   return (
-    <div className="flex items-center justify-between rounded-lg border border-grey-secondary bg-grey-eggshell p-3">
-      {artistProfile ? (
-        <p className="font-archivo text-sm text-grey-moss-600">
-          {artistProfile.username || truncateAddress(address)}
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-grey-moss-100 bg-grey-moss-50/60 px-3.5 py-2.5">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-grey-moss-300 font-archivo text-[11px] font-bold text-white">
+          {initial}
+        </span>
+        <p className="truncate font-archivo text-[13.5px] text-grey-moss-900">
+          {isLoading ? "Loading..." : label}
         </p>
+      </div>
+      {!isNotOwnWallet ? (
+        <span className="shrink-0 rounded-full bg-grey-moss-50 px-2.5 py-1 font-archivo text-[10px] font-semibold uppercase tracking-wider text-grey-moss-300">
+          you
+        </span>
       ) : (
-        <p className="font-archivo text-sm text-grey-moss-600">Loading...</p>
+        isOwner && (
+          <button
+            type="button"
+            onClick={() => handleRemoveAdmin(address)}
+            disabled={isRemoving}
+            aria-label="Remove admin"
+            className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-red-200 text-red-500 transition-colors hover:bg-red-50 disabled:opacity-50"
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+        )
       )}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => handleRemoveAdmin(address)}
-        disabled={isRemoving || !isNotOwnWallet}
-        className="border-red-300 text-red-600 hover:bg-red-50"
-      >
-        <Trash2 className="h-4 w-4" />
-      </Button>
     </div>
   );
 };

--- a/components/Media/CollectionMediaCard.tsx
+++ b/components/Media/CollectionMediaCard.tsx
@@ -26,7 +26,7 @@ const CollectionMediaCard = () => {
   } = useCollectionMedia();
 
   return (
-    <div className="rounded-lg border border-grey-moss-100 bg-white p-6 shadow-sm">
+    <div className="rounded-lg border border-grey-moss-100 bg-white p-4 md:p-6 shadow-sm">
       <div className="mb-[18px] flex items-center gap-1.5">
         <span className="size-1.5 rounded-full bg-tan" />
         <span className={FIELD_LABEL_CLASS}>media</span>


### PR DESCRIPTION
## Summary
- Restyled the Admins tab (`Admins.tsx`, `CollectionAdmin.tsx`, `AddCollectionAdmin.tsx`) to match the Media tab's card design: eyebrow-labeled white card, avatar-initial rows, restyled add-admin input and pill button. Logic (add/remove API calls, permission modal) is unchanged — presentation only.
- Fixed a permission bug carried over from the old implementation: the remove button was gated only on `useIsNotOwnWallet` ("this row isn't my wallet"), never on whether the viewer is actually the collection owner. Any visitor — owner or not — saw an active delete button on every admin row but their own. It's now hidden unless `useIsCollectionOwner()` is true.
- Removed the "Admins can update media, manage moments, and add other admins." caption per request.
- `CollectionMediaCard.tsx`: minor responsive padding tweak (`p-4 md:p-6`) to match the Admins card.

## Test plan
- [x] `tsc --noEmit` — no new type errors
- [x] `pnpm dev` — `/manage/[collection]` route compiles and responds 200
- [ ] Manually verify: as owner, delete button shows on other admins' rows; as a non-owner visitor, no delete button shows on any row; own row always shows the "you" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)