### PR TITLE
Rename Moments tab button label from "Add moment" to "Create"

### DIFF
--- a/components/CollectionManagePage/MomentsTab.tsx
+++ b/components/CollectionManagePage/MomentsTab.tsx
@@ -27,7 +27,7 @@ const MomentsTab = ({ collection }: MomentsTabProps) => {
           className="flex shrink-0 items-center gap-1.5 rounded-full border border-grey-moss-900 bg-grey-moss-900 px-3.5 py-1.5 font-archivo-medium text-[11.5px] text-white transition-colors hover:bg-black"
         >
           <Plus className="size-3.5" strokeWidth={2} />
-          Add moment
+          Create
         </button>
       </div>
       <TimelineProvider collection={collection} includeHidden={true}>


### PR DESCRIPTION
## Summary
- The button in the Moments tab that links to `/create` was labeled "Add moment." Changed to "Create" (reads "+ Create" with the plus icon). Link target unchanged.

## Test plan
- [x] `tsc --noEmit` — no new type errors
- [ ] Manually verify the button reads "+ Create" and still navigates to `/create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)