### PR TITLE
Show a styled scrollbar on desktop and fix missing bottom gap

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -129,6 +129,29 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
+
+  .modern-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: #999999 transparent;
+  }
+
+  .modern-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  .modern-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .modern-scrollbar::-webkit-scrollbar-thumb {
+    background-color: #999999;
+    border-radius: 9999px;
+  }
+
+  .modern-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: #605f5c;
+  }
 }
 
 .rpv-default-layout__sidebar-tabs {

--- a/app/manage/layout.tsx
+++ b/app/manage/layout.tsx
@@ -12,7 +12,7 @@ const ManagePage = ({ children }: { children: ReactNode }) => {
 
   return (
     // md:h: fills the viewport below the sticky 63px header so only the content column scrolls
-    <main className="flex w-full flex-col md:flex-row grow gap-4 px-2 pt-0 md:mx-auto md:h-[calc(100vh-66px)] md:max-w-[95%] md:gap-11 md:overflow-hidden md:px-10 md:pt-6">
+    <main className="flex w-full flex-col md:flex-row grow gap-4 px-2 pt-0 md:mx-auto md:h-[calc(100vh-66px)] md:max-w-[95%] md:gap-11 md:overflow-hidden md:px-10 pb-4">
       <div className="fixed inset-x-0 top-[calc(72px+env(safe-area-inset-top,0px))] z-20 flex w-full shrink-0 flex-row gap-1.5 px-2 py-1 overflow-x-auto no-scrollbar md:static md:inset-x-auto md:top-auto md:z-auto md:w-[210px] md:flex-col md:gap-0.5 md:overflow-visible md:p-0">
         <NavButton label="account" href="/manage/account" icon={User} />
         <NavButton label="payment" href="/manage/payment" icon={CreditCard} />
@@ -21,7 +21,7 @@ const ManagePage = ({ children }: { children: ReactNode }) => {
           <NavButton label="mutual moments" href="/manage/mutual-moments" icon={Users} />
         )}
       </div>
-      <div className="fixed inset-x-0 top-[calc(113px+env(safe-area-inset-top,0px))] bottom-[calc(74px+env(safe-area-inset-bottom,0px))] overflow-y-auto px-2 pt-3 no-scrollbar md:static md:inset-auto md:h-full md:grow md:overflow-y-auto md:px-0 md:pb-10 md:pt-0">
+      <div className="no-scrollbar fixed inset-x-0 top-[calc(113px+env(safe-area-inset-top,0px))] bottom-[calc(74px+env(safe-area-inset-bottom,0px))] overflow-y-auto px-2 pb-2 pt-3 md:static md:inset-auto md:h-full md:grow md:modern-scrollbar md:overflow-y-auto md:pl-0 md:pr-3 md:pt-0">
         {children}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- The manage page's content pane used `no-scrollbar` unconditionally, hiding the scroll indicator on every screen size. Desktop now shows a thin custom-styled scrollbar (`modern-scrollbar`, defined in `globals.css`) with enough contrast to see before hovering; mobile keeps `no-scrollbar` since that wasn't the complaint.
- Fixes desktop content sitting flush against the bottom edge when scrolled all the way down. The trailing space lived in `md:pb-10` on the `overflow-y-auto` flex child, which flexbox wasn't reliably honoring. Moved it to `pb-4` on `main` itself instead.

## Test plan
- [x] `tsc --noEmit` — no new type errors
- [ ] Manually verify on desktop: scrollbar is visible and styled (not the OS default), thumb has visible contrast before hover
- [ ] Manually verify on desktop: scrolling the content pane to the very bottom leaves a gap below the last card
- [ ] Manually verify on mobile: no scrollbar shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a modern scrollbar appearance for supported browsers.
  * Updated the management area layout with improved spacing and sidebar scrolling behavior across screen sizes.
  * Hid scrollbar visuals on smaller screens while preserving scrolling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->