### PR TITLE
Add scroll-triggered pagination to Moments grid, persist scroll position across tabs

### DIFF
--- a/components/CollectionManagePage/CollectionManagePage.tsx
+++ b/components/CollectionManagePage/CollectionManagePage.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import { useState, Fragment } from "react";
+import { Fragment } from "react";
 import CollectionOverview from "../Overview/CollectionOverview";
-import { useParams } from "next/navigation";
 import { MetadataFormProvider } from "@/providers/MetadataFormProvider";
 import CollectionMedia from "../Media/CollectionMedia";
 import { MetadataUploadProvider } from "@/providers/MetadataUploadProvider";
 import Tabs, { COLLECTION_MANAGE_TABS } from "./Tabs";
 import Admins from "./Admins";
 import MomentsTab from "./MomentsTab";
+import useCollectionManageTabs from "@/hooks/useCollectionManageTabs";
 
 const CollectionManagePage = () => {
-  const [selectedTab, setSelectedTab] = useState<number>(COLLECTION_MANAGE_TABS.MEDIA);
-  const params = useParams();
-  const collection = params.collection as string;
+  const { selectedTab, hasVisitedMoments, handleChangeTab, collection } = useCollectionManageTabs();
 
   if (!collection) return <Fragment />;
 
@@ -21,11 +19,15 @@ const CollectionManagePage = () => {
     <MetadataFormProvider>
       <MetadataUploadProvider>
         <CollectionOverview />
-        <Tabs selectedTab={selectedTab} onChangeTab={(value: number) => setSelectedTab(value)} />
+        <Tabs selectedTab={selectedTab} onChangeTab={handleChangeTab} />
         <div className="pb-2">
           {selectedTab === COLLECTION_MANAGE_TABS.MEDIA && <CollectionMedia />}
           {selectedTab === COLLECTION_MANAGE_TABS.ADMINS && <Admins />}
-          {selectedTab === COLLECTION_MANAGE_TABS.MOMENTS && <MomentsTab collection={collection} />}
+          {hasVisitedMoments && (
+            <div className={selectedTab === COLLECTION_MANAGE_TABS.MOMENTS ? "" : "hidden"}>
+              <MomentsTab collection={collection} />
+            </div>
+          )}
         </div>
       </MetadataUploadProvider>
     </MetadataFormProvider>

--- a/components/MomentsGrid/Moments.tsx
+++ b/components/MomentsGrid/Moments.tsx
@@ -3,18 +3,26 @@ import { type TimelineMoment } from "@/types/moment";
 import MomentsSkeleton from "./MomentsSkeleton";
 import NoMomentsFound from "./NoMomentsFound";
 import MomentItem from "./MomentItem";
+import FetchMore from "@/components/FetchMore";
+import { useFeedScroll } from "@/hooks/useFeedScroll";
 
 const Moments = () => {
-  const { moments, isLoading } = useTimelineProvider();
+  const { moments, isLoading, hasNextPage, fetchMore } = useTimelineProvider();
+  const { visibleMoments, hasMore, sentinelRef } = useFeedScroll(moments);
 
   if (isLoading) return <MomentsSkeleton />;
   if (moments.length === 0) return <NoMomentsFound />;
 
   return (
     <div className="grid w-full grow grid-cols-1 gap-3 pt-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-      {moments.map((m: TimelineMoment) => (
+      {visibleMoments.map((m: TimelineMoment) => (
         <MomentItem m={m} key={m.id} />
       ))}
+      {hasMore ? (
+        <div ref={sentinelRef} className="col-span-full h-px" />
+      ) : (
+        hasNextPage && <FetchMore fetchMore={fetchMore} />
+      )}
     </div>
   );
 };

--- a/hooks/useCollectionManageTabs.ts
+++ b/hooks/useCollectionManageTabs.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { COLLECTION_MANAGE_TABS } from "@/components/CollectionManagePage/Tabs";
+
+const useCollectionManageTabs = () => {
+  const [selectedTab, setSelectedTab] = useState<number>(COLLECTION_MANAGE_TABS.MEDIA);
+  const [hasVisitedMoments, setHasVisitedMoments] = useState(
+    () => selectedTab === COLLECTION_MANAGE_TABS.MOMENTS
+  );
+  const params = useParams();
+  const collection = params.collection as string;
+
+  const handleChangeTab = (value: number) => {
+    setSelectedTab(value);
+    if (value === COLLECTION_MANAGE_TABS.MOMENTS) setHasVisitedMoments(true);
+  };
+
+  return {
+    selectedTab,
+    hasVisitedMoments,
+    handleChangeTab,
+    collection,
+  };
+};
+
+export default useCollectionManageTabs;


### PR DESCRIPTION
## Summary
- `Moments.tsx` rendered every fetched moment (up to 100, no virtualization) in one shot and never called the timeline's `fetchMore()`, so collections with more than 100 moments silently capped there. Now mirrors the Home page feed pattern (`useFeedScroll` + `FetchMore`): reveals 10 at a time as the user scrolls, then auto-fetches the next server page via an intersection-observer sentinel once the current batch is exhausted — no load-more button, same as Home. This is the shared grid component, so `/manage/moments`, mutual-moments, and Timeline all get the same fix.
- Fixes the Collection Manage page's Moments tab losing its scroll-reveal position on every tab switch — it was conditionally rendered like Media/Admins, so switching away unmounted it and reset `useFeedScroll`'s local `visibleCount`. Once visited, it now stays mounted (hidden via CSS) instead of unmounting on tab switch, while Media/Admins keep their original mount-on-select behavior (no wasted upfront fetches there).
- Extracted the tab-switching logic (`selectedTab`, `hasVisitedMoments`, `handleChangeTab`, `collection`) into `useCollectionManageTabs` so `CollectionManagePage.tsx` stays JSX-only per the repo's component convention.

## Test plan
- [x] `tsc --noEmit` — no new type errors
- [x] `pnpm dev` — `/manage/[collection]` route compiles and responds 200
- [ ] Manually verify: scrolling the Moments tab reveals more items 10 at a time, then auto-fetches further pages near the bottom with no button
- [ ] Manually verify: scroll partway down Moments, switch to Admins, switch back — scroll position/revealed count is preserved instead of resetting

🤖 Generated with [Claude Code](https://claude.com/claude-code)