### PR TITLE
Add USD balance topup item to mobile drawer and desktop dropdown

### DIFF
--- a/components/Balances/TopupMenuItem.tsx
+++ b/components/Balances/TopupMenuItem.tsx
@@ -1,0 +1,29 @@
+import { DollarSign } from "lucide-react";
+import { useSmartAccountProvider } from "@/providers/SmartWalletAccountProvider";
+import formatBalanceAmount from "@/lib/balance/formatBalanceAmount";
+
+interface TopupMenuItemProps {
+  className: string;
+  iconClassName: string;
+  onClick: () => void;
+}
+
+const TopupMenuItem = ({ className, iconClassName, onClick }: TopupMenuItemProps) => {
+  const { balance, isLoading } = useSmartAccountProvider();
+
+  return (
+    <button type="button" onClick={onClick} className={`${className} justify-between`}>
+      <span className="flex items-center gap-3">
+        <DollarSign className={iconClassName} strokeWidth={1.5} />
+        Topup
+      </span>
+      {isLoading ? (
+        <span className="h-3 w-14 animate-pulse rounded bg-white/20" />
+      ) : (
+        <span className="text-white/40">${formatBalanceAmount(balance)}</span>
+      )}
+    </button>
+  );
+};
+
+export default TopupMenuItem;

--- a/components/Footer/UserDrawer.tsx
+++ b/components/Footer/UserDrawer.tsx
@@ -7,7 +7,7 @@ import { useMobileUserDrawer } from "@/hooks/useMobileUserDrawer";
 import UserDrawerPanel from "./UserDrawerPanel";
 
 const UserDrawer = () => {
-  const { isOpen, toggle, close, onTimeline, onManage, onLogout, isMiniApp, displayName } =
+  const { isOpen, toggle, close, onTimeline, onManage, onTopup, onLogout, isMiniApp, displayName } =
     useMobileUserDrawer();
 
   const [mounted, setMounted] = useState(false);
@@ -30,6 +30,7 @@ const UserDrawer = () => {
             onClose={close}
             onTimeline={onTimeline}
             onManage={onManage}
+            onTopup={onTopup}
             onLogout={onLogout}
             isMiniApp={isMiniApp}
             displayName={displayName}

--- a/components/Footer/UserDrawerPanel.tsx
+++ b/components/Footer/UserDrawerPanel.tsx
@@ -1,4 +1,5 @@
 import { Clock, Settings, LogOut, User } from "lucide-react";
+import TopupMenuItem from "../Balances/TopupMenuItem";
 
 const ITEM_CLASS =
   "flex w-full items-center gap-4 px-7 py-[16px] text-left font-archivo text-[17px] text-white active:bg-[#333333]";
@@ -10,6 +11,7 @@ interface UserDrawerPanelProps {
   onClose: () => void;
   onTimeline: () => void;
   onManage: () => void;
+  onTopup: () => void;
   onLogout: () => void;
   isMiniApp: boolean;
   displayName: string | null;
@@ -20,6 +22,7 @@ const UserDrawerPanel = ({
   onClose,
   onTimeline,
   onManage,
+  onTopup,
   onLogout,
   isMiniApp,
   displayName,
@@ -40,6 +43,12 @@ const UserDrawerPanel = ({
         <Settings className="h-[18px] w-[18px] opacity-60" strokeWidth={1.5} />
         Manage
       </button>
+      <Divider />
+      <TopupMenuItem
+        className={ITEM_CLASS}
+        iconClassName="h-[18px] w-[18px] opacity-60"
+        onClick={onTopup}
+      />
       {isMiniApp ? (
         displayName && (
           <>

--- a/components/Header/DropdownMenu.tsx
+++ b/components/Header/DropdownMenu.tsx
@@ -5,6 +5,7 @@ import { useLayoutProvider } from "@/providers/LayoutProvider";
 import { usePrivy } from "@privy-io/react-auth";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import { Clock, Settings, LogOut } from "lucide-react";
+import TopupMenuItem from "../Balances/TopupMenuItem";
 
 const ITEM_CLASS =
   "flex w-full items-center gap-3 whitespace-nowrap px-3 py-2 text-left text-sm text-white transition-colors hover:bg-[#333333]";
@@ -39,6 +40,15 @@ export function DropdownMenu() {
         <Settings className="size-4 shrink-0 opacity-60" strokeWidth={1.5} />
         Manage
       </button>
+      <Divider />
+      <TopupMenuItem
+        className={ITEM_CLASS}
+        iconClassName="size-4 shrink-0 opacity-60"
+        onClick={() => {
+          toggleNavbar();
+          push("/topup");
+        }}
+      />
       {!isMiniApp && (
         <>
           <Divider />

--- a/hooks/useMobileUserDrawer.ts
+++ b/hooks/useMobileUserDrawer.ts
@@ -41,6 +41,11 @@ export const useMobileUserDrawer = () => {
     push("/manage");
   };
 
+  const onTopup = () => {
+    close();
+    push("/topup");
+  };
+
   const onLogout = () => {
     close();
     logout();
@@ -52,6 +57,7 @@ export const useMobileUserDrawer = () => {
     close,
     onTimeline,
     onManage,
+    onTopup,
     onLogout,
     isMiniApp,
     displayName,

--- a/lib/balance/formatBalanceAmount.ts
+++ b/lib/balance/formatBalanceAmount.ts
@@ -1,0 +1,11 @@
+const formatBalanceAmount = (amount: string): string => {
+  const n = Number(amount);
+  if (!Number.isFinite(n)) return amount;
+
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 3,
+    minimumFractionDigits: 0,
+  }).format(n);
+};
+
+export default formatBalanceAmount;


### PR DESCRIPTION
## Summary
- Add a "Topup" menu item below Manage in the mobile user drawer (opened via the user icon) and the desktop header dropdown (opened via the user name button)
- Row shows the current USDC balance (formatted to a maximum of 3 decimal places) and navigates to `/topup` on click
- New `TopupMenuItem` component reads balance directly from `useSmartAccountProvider`, avoiding prop tunneling through parent components

## Test plan
- [ ] On mobile, tap the user icon in the footer to open the drawer, confirm the Topup row appears below Manage and shows the current balance
- [ ] Tap Topup and confirm it navigates to `/topup` and closes the drawer
- [ ] On desktop, click the user name button in the top header, confirm the Topup row appears below Manage in the dropdown
- [ ] Click Topup and confirm it navigates to `/topup` and closes the dropdown
- [ ] Confirm balance shows while loading (skeleton) and updates once the smart wallet balance query resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Top Up option to the header dropdown and mobile user drawer.
  * Added a balance display with loading state and formatted amounts.
  * Top Up actions now navigate directly to the Top Up page.
* **Improvements**
  * Balance values are displayed with up to three decimal places for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->