### PR TITLE
Navigate to Manifesto/FAQ in-tab from mobile header menu

### DIFF
--- a/components/Header/MobileHeaderMenu.tsx
+++ b/components/Header/MobileHeaderMenu.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/navigation";
 import HeaderSocialIcons from "./HeaderSocialIcons";
 
 interface MobileHeaderMenuProps {
@@ -7,34 +8,38 @@ interface MobileHeaderMenuProps {
 const NAV_ITEM_CLASS =
   "rounded-lg px-1.5 py-1 text-left font-archivo-medium text-[13.5px] text-[#4E4E4E] transition-colors hover:bg-grey-moss-50";
 
-const MobileHeaderMenu = ({ onNavigate }: MobileHeaderMenuProps) => (
-  <div className="absolute right-4 top-12 w-36 rounded-md border border-[#E4E0D7] bg-white p-2 shadow-lg">
-    <div className="flex flex-col gap-0.5">
-      <button
-        type="button"
-        className={NAV_ITEM_CLASS}
-        onClick={() => {
-          onNavigate();
-          window.open("/manifesto", "_blank");
-        }}
-      >
-        Manifesto
-      </button>
-      <button
-        type="button"
-        className={NAV_ITEM_CLASS}
-        onClick={() => {
-          onNavigate();
-          window.open("/faq", "_blank");
-        }}
-      >
-        FAQ
-      </button>
+const MobileHeaderMenu = ({ onNavigate }: MobileHeaderMenuProps) => {
+  const { push } = useRouter();
+
+  return (
+    <div className="absolute right-4 top-12 w-36 rounded-md border border-[#E4E0D7] bg-white p-2 shadow-lg">
+      <div className="flex flex-col gap-0.5">
+        <button
+          type="button"
+          className={NAV_ITEM_CLASS}
+          onClick={() => {
+            onNavigate();
+            push("/manifesto");
+          }}
+        >
+          Manifesto
+        </button>
+        <button
+          type="button"
+          className={NAV_ITEM_CLASS}
+          onClick={() => {
+            onNavigate();
+            push("/faq");
+          }}
+        >
+          FAQ
+        </button>
+      </div>
+      <div className="border-t border-[#EDEAE2] py-2 pl-1">
+        <HeaderSocialIcons />
+      </div>
     </div>
-    <div className="border-t border-[#EDEAE2] py-2 pl-1">
-      <HeaderSocialIcons />
-    </div>
-  </div>
-);
+  );
+};
 
 export default MobileHeaderMenu;


### PR DESCRIPTION
## Summary
- The mobile header menu (hamburger icon) opened Manifesto and FAQ in a new tab via `window.open(url, "_blank")`, which is unexpected on mobile and breaks in-app navigation flow
- Switched to `router.push()` so both links navigate in the same tab, like normal app navigation
- Left the social icons (X, Farcaster) and the desktop `HeaderNavLinks` behavior untouched — external links should still open in a new tab, and desktop wasn't in scope for this change

## Test plan
- [ ] On mobile, open the header menu (hamburger icon), tap Manifesto — confirm it navigates in the same tab (no new tab)
- [ ] Tap FAQ — confirm same-tab navigation
- [ ] Confirm the social icons (X, Farcaster) still open in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)