### PR TITLE
Show collection name and view-collection link on mobile feed cards

### DIFF
--- a/components/HomePage/MomentFeedCard.tsx
+++ b/components/HomePage/MomentFeedCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TimelineMoment } from "@/types/moment";
-import { Link as ChainLinkIcon, MessageCircle } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 import Link from "next/link";
 import ContentRenderer from "@/components/Renderers";
 import { useMomentFeedCard } from "@/hooks/useMomentFeedCard";
@@ -23,28 +23,56 @@ const MomentFeedCard = ({ moment }: MomentFeedCardProps) => {
     handleMomentClick,
     commentCount,
     showComments,
+    collectionName,
+    collectionHref,
   } = useMomentFeedCard(moment);
   const creatorName = moment.creator.username ?? `${moment.creator.address.slice(0, 6)}...`;
   const timeStr = new Date(moment.created_at).toLocaleString();
 
   return (
-    <div className="mb-2 overflow-hidden rounded-[6px] border border-grey-moss-100 bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)]">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleMomentClick}
+      onKeyDown={(e) => e.key === "Enter" && handleMomentClick()}
+      className="mb-2 cursor-pointer overflow-hidden rounded-[6px] border border-grey-moss-100 bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)]"
+    >
       <div className="relative isolate z-0 w-full overflow-hidden">
         <ContentRenderer metadata={metadata} variant="natural" />
       </div>
       <div className="px-[15px] pb-[15px] pt-[13px]">
-        <div className="mb-[5px] flex items-center gap-[9px]">
-          <Link
-            href={`/${moment.creator.address.toLowerCase()}`}
-            onClick={(e) => e.stopPropagation()}
-            className="font-archivo-medium text-base text-grey-moss-900 active:opacity-70"
-          >
-            {creatorName}
-          </Link>
-          <span className="ml-auto font-archivo text-xs text-tan-gold">{timeStr}</span>
+        <div className="mb-[5px] flex flex-col gap-[2px]">
+          <div className="flex items-center justify-between gap-[9px]">
+            <Link
+              href={`/${moment.creator.address.toLowerCase()}`}
+              onClick={(e) => e.stopPropagation()}
+              className="block min-w-0 truncate font-archivo-medium text-base text-grey-moss-900 active:opacity-70"
+            >
+              {creatorName}
+            </Link>
+            <span className="shrink-0 font-archivo text-xs text-tan-gold">{timeStr}</span>
+          </div>
+          {collectionHref && (
+            <div className="flex items-center justify-between gap-[9px]">
+              <Link
+                href={collectionHref}
+                onClick={(e) => e.stopPropagation()}
+                className="block min-w-0 truncate font-archivo text-xs text-grey-moss-300 active:opacity-70"
+              >
+                {collectionName}
+              </Link>
+              <Link
+                href={collectionHref}
+                onClick={(e) => e.stopPropagation()}
+                className="shrink-0 font-archivo text-xs text-tan-gold underline underline-offset-2 active:opacity-70"
+              >
+                {`[ View collection ]`}
+              </Link>
+            </div>
+          )}
         </div>
 
-        <p className="mb-3 line-clamp-2 font-spectral-italic text-lg leading-snug text-grey-moss-900">
+        <p className="my-2 line-clamp-2 font-spectral-italic text-lg leading-snug text-grey-moss-900">
           {metadata?.name ?? "—"}
         </p>
 
@@ -73,35 +101,22 @@ const MomentFeedCard = ({ moment }: MomentFeedCardProps) => {
             )}
           </div>
 
-          <div className="flex min-w-0 items-center gap-3">
-            {showComments && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCommentClick();
-                }}
-                className={actionButtonClass}
-                aria-label={`${commentCount} comments`}
-              >
-                <MessageCircle className="h-[17px] w-[17px]" strokeWidth={1.75} />
-                <span className="font-archivo text-sm tabular-nums">
-                  {commentCount.toLocaleString()}
-                </span>
-              </button>
-            )}
+          {showComments && (
             <button
               type="button"
               onClick={(e) => {
                 e.stopPropagation();
-                handleMomentClick();
+                onCommentClick();
               }}
               className={actionButtonClass}
-              aria-label="Open moment link"
+              aria-label={`${commentCount} comments`}
             >
-              <ChainLinkIcon className="h-[17px] w-[17px]" strokeWidth={1.75} />
+              <MessageCircle className="h-[17px] w-[17px]" strokeWidth={1.75} />
+              <span className="font-archivo text-sm tabular-nums">
+                {commentCount.toLocaleString()}
+              </span>
             </button>
-          </div>
+          )}
         </div>
       </div>
     </div>

--- a/hooks/useMomentFeedCard.ts
+++ b/hooks/useMomentFeedCard.ts
@@ -5,6 +5,8 @@ import { formatSalePriceLabel } from "@/lib/moment/formatSalePriceLabel";
 import { isSaleEnded } from "@/lib/moment/isSaleEnded";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
 import { useMomentClick } from "@/hooks/useMomentClick";
+import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
+import truncateAddress from "@/lib/truncateAddress";
 
 export const useMomentFeedCard = (moment: TimelineMoment) => {
   const { openCollect, openComment } = useMobileDrawersProvider();
@@ -13,6 +15,9 @@ export const useMomentFeedCard = (moment: TimelineMoment) => {
   const isSoldOut = isSaleEnded(sale);
   const commentCount = moment.comments ?? 0;
   const showComments = moment.protocol === Protocol.InProcess;
+  const shortName = getShortNameFromChainId(moment.chain_id);
+  const collectionName = moment.collection?.name?.trim() || truncateAddress(moment.address);
+  const collectionHref = shortName ? `/collection/${shortName}:${moment.address}` : undefined;
 
   const onCollect = () => {
     openCollect(moment);
@@ -31,5 +36,7 @@ export const useMomentFeedCard = (moment: TimelineMoment) => {
     handleMomentClick,
     commentCount,
     showComments,
+    collectionName,
+    collectionHref,
   };
 };


### PR DESCRIPTION
## Summary
- Show the collection name under the artist name, and a "[ View collection ]" link under the timestamp, on the HomePage moment feed card — both link to the collection timeline page (`/collection/{shortName}:{address}`)
- Remove the redundant link icon; clicking the general card body now opens the moment page instead
- Artist name / collection name / view-collection links stop event propagation so they don't trigger the card's own moment-page navigation

## Test plan
- [ ] Verify long artist names truncate to one line instead of wrapping
- [ ] Verify creator name/timestamp and collection name/view-collection rows stay vertically centered
- [ ] Click artist name, collection name, "[ View collection ]", Collect, and comment count — confirm none of them navigate to the moment page
- [ ] Click elsewhere on the card body — confirm it navigates to the moment page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moment cards are now fully clickable and support keyboard activation.
  * Added a “View collection” link when collection information is available.
  * Improved collection details with readable names and shortened addresses.

* **Bug Fixes**
  * Updated comment interactions to prevent accidental moment navigation when commenting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->