### PR TITLE
Add right-click "Open in new tab" menu on logo and moment cards

### DIFF
--- a/components/HomePage/MomentFeedCard.tsx
+++ b/components/HomePage/MomentFeedCard.tsx
@@ -5,6 +5,7 @@ import { MessageCircle } from "lucide-react";
 import Link from "next/link";
 import ContentRenderer from "@/components/Renderers";
 import { useMomentFeedCard } from "@/hooks/useMomentFeedCard";
+import OpenInNewTabMenu from "@/components/OpenInNewTabMenu";
 import { cn } from "@/lib/utils";
 
 interface MomentFeedCardProps {
@@ -21,6 +22,7 @@ const MomentFeedCard = ({ moment }: MomentFeedCardProps) => {
     onCollect,
     onCommentClick,
     handleMomentClick,
+    momentHref,
     commentCount,
     showComments,
     collectionName,
@@ -30,96 +32,98 @@ const MomentFeedCard = ({ moment }: MomentFeedCardProps) => {
   const timeStr = new Date(moment.created_at).toLocaleString();
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={handleMomentClick}
-      onKeyDown={(e) => e.key === "Enter" && handleMomentClick()}
-      className="mb-2 cursor-pointer overflow-hidden rounded-[6px] border border-grey-moss-100 bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)]"
-    >
-      <div className="relative isolate z-0 w-full overflow-hidden">
-        <ContentRenderer metadata={metadata} variant="natural" />
-      </div>
-      <div className="px-[15px] pb-[15px] pt-[13px]">
-        <div className="mb-[5px] flex flex-col gap-[2px]">
-          <div className="flex items-center justify-between gap-[9px]">
-            <Link
-              href={`/${moment.creator.address.toLowerCase()}`}
-              onClick={(e) => e.stopPropagation()}
-              className="block min-w-0 truncate font-archivo-medium text-base text-grey-moss-900 active:opacity-70"
-            >
-              {creatorName}
-            </Link>
-            <span className="shrink-0 font-archivo text-xs text-tan-gold">{timeStr}</span>
-          </div>
-          {collectionHref && (
+    <OpenInNewTabMenu href={momentHref}>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={handleMomentClick}
+        onKeyDown={(e) => e.key === "Enter" && handleMomentClick()}
+        className="mb-2 cursor-pointer overflow-hidden rounded-[6px] border border-grey-moss-100 bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)]"
+      >
+        <div className="relative isolate z-0 w-full overflow-hidden">
+          <ContentRenderer metadata={metadata} variant="natural" />
+        </div>
+        <div className="px-[15px] pb-[15px] pt-[13px]">
+          <div className="mb-[5px] flex flex-col gap-[2px]">
             <div className="flex items-center justify-between gap-[9px]">
               <Link
-                href={collectionHref}
+                href={`/${moment.creator.address.toLowerCase()}`}
                 onClick={(e) => e.stopPropagation()}
-                className="block min-w-0 truncate font-archivo text-xs text-grey-moss-300 active:opacity-70"
+                className="block min-w-0 truncate font-archivo-medium text-base text-grey-moss-900 active:opacity-70"
               >
-                {collectionName}
+                {creatorName}
               </Link>
-              <Link
-                href={collectionHref}
-                onClick={(e) => e.stopPropagation()}
-                className="shrink-0 font-archivo text-xs text-tan-gold underline underline-offset-2 active:opacity-70"
-              >
-                {`[ View collection ]`}
-              </Link>
+              <span className="shrink-0 font-archivo text-xs text-tan-gold">{timeStr}</span>
             </div>
-          )}
-        </div>
-
-        <p className="my-2 line-clamp-2 font-spectral-italic text-lg leading-snug text-grey-moss-900">
-          {metadata?.name ?? "—"}
-        </p>
-
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex shrink-0 items-center gap-2">
-            <button
-              type="button"
-              disabled={isSoldOut}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (!isSoldOut) onCollect();
-              }}
-              className={cn(
-                "rounded-[22px] px-4 py-2 font-archivo-medium text-sm",
-                isSoldOut
-                  ? "cursor-not-allowed bg-grey-moss-300 text-white"
-                  : "bg-grey-moss-900 text-white active:opacity-80"
-              )}
-            >
-              {isSoldOut ? "Sold Out" : "Collect"}
-            </button>
-            {priceLabel && (
-              <span className="font-archivo-bold text-xs uppercase text-tan-gold">
-                {priceLabel}
-              </span>
+            {collectionHref && (
+              <div className="flex items-center justify-between gap-[9px]">
+                <Link
+                  href={collectionHref}
+                  onClick={(e) => e.stopPropagation()}
+                  className="block min-w-0 truncate font-archivo text-xs text-grey-moss-300 active:opacity-70"
+                >
+                  {collectionName}
+                </Link>
+                <Link
+                  href={collectionHref}
+                  onClick={(e) => e.stopPropagation()}
+                  className="shrink-0 font-archivo text-xs text-tan-gold underline underline-offset-2 active:opacity-70"
+                >
+                  {`[ View collection ]`}
+                </Link>
+              </div>
             )}
           </div>
 
-          {showComments && (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onCommentClick();
-              }}
-              className={actionButtonClass}
-              aria-label={`${commentCount} comments`}
-            >
-              <MessageCircle className="h-[17px] w-[17px]" strokeWidth={1.75} />
-              <span className="font-archivo text-sm tabular-nums">
-                {commentCount.toLocaleString()}
-              </span>
-            </button>
-          )}
+          <p className="my-2 line-clamp-2 font-spectral-italic text-lg leading-snug text-grey-moss-900">
+            {metadata?.name ?? "—"}
+          </p>
+
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                disabled={isSoldOut}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!isSoldOut) onCollect();
+                }}
+                className={cn(
+                  "rounded-[22px] px-4 py-2 font-archivo-medium text-sm",
+                  isSoldOut
+                    ? "cursor-not-allowed bg-grey-moss-300 text-white"
+                    : "bg-grey-moss-900 text-white active:opacity-80"
+                )}
+              >
+                {isSoldOut ? "Sold Out" : "Collect"}
+              </button>
+              {priceLabel && (
+                <span className="font-archivo-bold text-xs uppercase text-tan-gold">
+                  {priceLabel}
+                </span>
+              )}
+            </div>
+
+            {showComments && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCommentClick();
+                }}
+                className={actionButtonClass}
+                aria-label={`${commentCount} comments`}
+              >
+                <MessageCircle className="h-[17px] w-[17px]" strokeWidth={1.75} />
+                <span className="font-archivo text-sm tabular-nums">
+                  {commentCount.toLocaleString()}
+                </span>
+              </button>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+    </OpenInNewTabMenu>
   );
 };
 

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -4,6 +4,7 @@ import useIsMobile from "@/hooks/useIsMobile";
 import { useLayoutProvider } from "@/providers/LayoutProvider";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import OpenInNewTabMenu from "@/components/OpenInNewTabMenu";
 
 interface LogoProps {
   className?: string;
@@ -14,17 +15,19 @@ const Logo = ({ className = "" }: LogoProps) => {
   const { isOpenNavbar } = useLayoutProvider();
 
   return (
-    <button
-      className={`relative h-[18px] w-[80px] md:h-[29px] md:w-[128px] ${className}`}
-      type="button"
-      onClick={() => push("/")}
-    >
-      {isOpenNavbar && isMobile ? (
-        <Image src="/white_logo.svg" blurDataURL="/white_logo.png" alt="not found logo" fill />
-      ) : (
-        <Image src="/logo.svg" blurDataURL="/logo.png" alt="not found logo" fill />
-      )}
-    </button>
+    <OpenInNewTabMenu href="/">
+      <button
+        className={`relative h-[18px] w-[80px] md:h-[29px] md:w-[128px] ${className}`}
+        type="button"
+        onClick={() => push("/")}
+      >
+        {isOpenNavbar && isMobile ? (
+          <Image src="/white_logo.svg" blurDataURL="/white_logo.png" alt="not found logo" fill />
+        ) : (
+          <Image src="/logo.svg" blurDataURL="/logo.png" alt="not found logo" fill />
+        )}
+      </button>
+    </OpenInNewTabMenu>
   );
 };
 

--- a/components/MomentsGrid/MomentItem.tsx
+++ b/components/MomentsGrid/MomentItem.tsx
@@ -6,6 +6,7 @@ import { type TimelineMoment } from "@/types/moment";
 import { ArrowUpRight } from "lucide-react";
 import Preview from "./Preview";
 import useCanHideMoment from "@/hooks/useCanHideMoment";
+import OpenInNewTabMenu from "@/components/OpenInNewTabMenu";
 
 import ProtocolBadge from "./ProtocolBadge";
 import ChainLogo from "./ChainLogo";
@@ -23,75 +24,80 @@ const MomentItem = ({ m }: MomentItemProps) => {
   const pathname = usePathname();
   const isManagePage = pathname.includes("/manage");
 
+  const shortName = getShortNameFromChainId(m.chain_id);
+  const momentHref = shortName
+    ? `/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}/${m.token_id}`
+    : undefined;
+
   const handleClick = () => {
-    const shortName = getShortNameFromChainId(m.chain_id);
-    if (!shortName) return;
-    push(`/${isManagePage ? "manage" : "collect"}/${shortName}:${m.address}/${m.token_id}`);
+    if (!momentHref) return;
+    push(momentHref);
   };
 
   const handleViewCollection = (e: React.MouseEvent) => {
     e.stopPropagation();
-    const shortName = getShortNameFromChainId(m.chain_id);
     if (!shortName) return;
     const base = isManagePage ? "manage" : "collection";
     push(`/${base}/${shortName}:${m.address}`);
   };
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      className="group relative col-span-1 h-fit w-full cursor-pointer rounded-[10px] border border-[#E4E0D7] bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,0.12)] transition-shadow duration-150 hover:z-10 hover:shadow-[0_10px_24px_-8px_rgba(27,21,4,0.22)]"
-      onClick={handleClick}
-      onKeyDown={(e) => e.key === "Enter" && handleClick()}
-    >
-      <div className="relative aspect-square w-full overflow-hidden rounded-t-[9px] bg-grey-moss-50 will-change-transform">
-        <div className="absolute left-2 top-2 z-20">
-          <ProtocolBadge protocol={m.protocol} />
-        </div>
-        {canHideMoment && (
-          <div className="absolute right-2 top-2 z-20">
-            <HideButton moment={m} />
+    <OpenInNewTabMenu href={momentHref}>
+      <div
+        role="button"
+        tabIndex={0}
+        className="group relative col-span-1 h-fit w-full cursor-pointer rounded-[10px] border border-[#E4E0D7] bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,0.12)] transition-shadow duration-150 hover:z-10 hover:shadow-[0_10px_24px_-8px_rgba(27,21,4,0.22)]"
+        onClick={handleClick}
+        onKeyDown={(e) => e.key === "Enter" && handleClick()}
+      >
+        <div className="relative aspect-square w-full overflow-hidden rounded-t-[9px] bg-grey-moss-50 will-change-transform">
+          <div className="absolute left-2 top-2 z-20">
+            <ProtocolBadge protocol={m.protocol} />
           </div>
-        )}
-        {data ? (
-          <Preview data={data} />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <p className="font-archivo text-sm text-grey-moss-200">No Preview</p>
-          </div>
-        )}
-      </div>
-      <div className="px-[13px] pb-[13px] pt-3">
-        <div className="flex items-baseline justify-between gap-2">
-          <p
-            className={`truncate font-spectral text-[14.5px] leading-[1.3] transition-colors ${hasName ? "text-grey-moss-900 hover:text-tan-gold" : "text-grey-moss-200"}`}
-          >
-            {data ? (hasName ? truncated(data.name ?? "", 20) : "------") : "Unknown"}
-          </p>
-          <span className="shrink-0 whitespace-nowrap font-archivo text-[10.5px] text-tan-gold">
-            {new Date(m.created_at).toLocaleDateString("en-US")}
-          </span>
+          {canHideMoment && (
+            <div className="absolute right-2 top-2 z-20">
+              <HideButton moment={m} />
+            </div>
+          )}
+          {data ? (
+            <Preview data={data} />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <p className="font-archivo text-sm text-grey-moss-200">No Preview</p>
+            </div>
+          )}
         </div>
-        <button
-          type="button"
-          onClick={handleViewCollection}
-          className="group/link relative mt-[7px] flex w-full items-center justify-between gap-1.5 text-left"
-        >
-          <ChainLogo chainId={m.chain_id} />
-          <span className="min-w-0 truncate text-right font-spectral-italic text-xs text-grey-moss-200">
-            <span className="font-archivo text-[11px] text-grey-moss-300">#{m.token_id}</span> in{" "}
-            <span className="text-sm text-tan-gold underline decoration-tan-gold underline-offset-[3px] transition-colors group-hover/link:text-grey-moss-900">
-              {m.collection?.name?.trim() || truncateAddress(m.address)}
+        <div className="px-[13px] pb-[13px] pt-3">
+          <div className="flex items-baseline justify-between gap-2">
+            <p
+              className={`truncate font-spectral text-[14.5px] leading-[1.3] transition-colors ${hasName ? "text-grey-moss-900 hover:text-tan-gold" : "text-grey-moss-200"}`}
+            >
+              {data ? (hasName ? truncated(data.name ?? "", 20) : "------") : "Unknown"}
+            </p>
+            <span className="shrink-0 whitespace-nowrap font-archivo text-[10.5px] text-tan-gold">
+              {new Date(m.created_at).toLocaleDateString("en-US")}
             </span>
-          </span>
-          <span className="uppercase pointer-events-none absolute right-0 top-full z-10 mt-1.5 hidden items-center gap-1 whitespace-nowrap rounded-lg bg-grey-moss-900 px-2.5 py-1.5 font-archivo text-[10.5px] text-white shadow-lg group-hover/link:flex">
-            {isManagePage ? "manage collection" : "open collection timeline"}
-            <ArrowUpRight className="size-3" />
-          </span>
-        </button>
+          </div>
+          <button
+            type="button"
+            onClick={handleViewCollection}
+            className="group/link relative mt-[7px] flex w-full items-center justify-between gap-1.5 text-left"
+          >
+            <ChainLogo chainId={m.chain_id} />
+            <span className="min-w-0 truncate text-right font-spectral-italic text-xs text-grey-moss-200">
+              <span className="font-archivo text-[11px] text-grey-moss-300">#{m.token_id}</span> in{" "}
+              <span className="text-sm text-tan-gold underline decoration-tan-gold underline-offset-[3px] transition-colors group-hover/link:text-grey-moss-900">
+                {m.collection?.name?.trim() || truncateAddress(m.address)}
+              </span>
+            </span>
+            <span className="uppercase pointer-events-none absolute right-0 top-full z-10 mt-1.5 hidden items-center gap-1 whitespace-nowrap rounded-lg bg-grey-moss-900 px-2.5 py-1.5 font-archivo text-[10.5px] text-white shadow-lg group-hover/link:flex">
+              {isManagePage ? "manage collection" : "open collection timeline"}
+              <ArrowUpRight className="size-3" />
+            </span>
+          </button>
+        </div>
       </div>
-    </div>
+    </OpenInNewTabMenu>
   );
 };
 

--- a/components/OpenInNewTabMenu.tsx
+++ b/components/OpenInNewTabMenu.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+
+interface OpenInNewTabMenuProps {
+  href: string | undefined;
+  children: React.ReactNode;
+}
+
+const OpenInNewTabMenu = ({ href, children }: OpenInNewTabMenuProps) => {
+  if (!href) return children;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem
+          onSelect={() => window.open(href, "_blank", "noopener,noreferrer")}
+          className="font-archivo"
+        >
+          Open in new tab
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+};
+
+export default OpenInNewTabMenu;

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+
+import { cn } from "@/lib/utils";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[180px] overflow-hidden rounded-md border border-neutral-200 bg-white p-1 text-neutral-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2.5 py-2 text-sm outline-none data-[highlighted]:bg-neutral-100",
+      className
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+export { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem };

--- a/hooks/useMomentClick.ts
+++ b/hooks/useMomentClick.ts
@@ -1,9 +1,6 @@
 import { useRouter } from "next/navigation";
 import { TimelineMoment } from "@/types/moment";
-import { validateUrl } from "@/lib/url/validateUrl";
-import { isYoutubeUrl } from "@/lib/url/isYoutubeUrl";
-import { isDeprecatedUrl } from "@/lib/url/isDeprecatedUrl";
-import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
+import { getMomentUrl } from "@/lib/moment/getMomentUrl";
 
 export const useMomentClick = (moment: TimelineMoment | undefined) => {
   const { push } = useRouter();
@@ -11,21 +8,13 @@ export const useMomentClick = (moment: TimelineMoment | undefined) => {
 
   const handleMomentClick = () => {
     if (!moment) return;
-    const { chain_id, address, token_id } = moment;
-    if (
-      data?.external_url &&
-      !isDeprecatedUrl(data.external_url) &&
-      !isYoutubeUrl(data.external_url)
-    ) {
-      // Validate URL before opening to prevent phishing
-      if (validateUrl(data.external_url)) {
-        window.open(data.external_url, "_blank", "noopener,noreferrer");
-      }
+    const momentUrl = getMomentUrl(moment);
+    if (!momentUrl) return;
+    if (momentUrl.isExternal) {
+      window.open(momentUrl.href, "_blank", "noopener,noreferrer");
       return;
     }
-    const shortName = getShortNameFromChainId(chain_id);
-    if (!shortName) return;
-    push(`/collect/${shortName}:${address}/${token_id}`);
+    push(momentUrl.href);
   };
 
   return { handleMomentClick, data };

--- a/hooks/useMomentFeedCard.ts
+++ b/hooks/useMomentFeedCard.ts
@@ -5,6 +5,7 @@ import { formatSalePriceLabel } from "@/lib/moment/formatSalePriceLabel";
 import { isSaleEnded } from "@/lib/moment/isSaleEnded";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
 import { useMomentClick } from "@/hooks/useMomentClick";
+import { getMomentUrl } from "@/lib/moment/getMomentUrl";
 import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
 import truncateAddress from "@/lib/truncateAddress";
 
@@ -18,6 +19,7 @@ export const useMomentFeedCard = (moment: TimelineMoment) => {
   const shortName = getShortNameFromChainId(moment.chain_id);
   const collectionName = moment.collection?.name?.trim() || truncateAddress(moment.address);
   const collectionHref = shortName ? `/collection/${shortName}:${moment.address}` : undefined;
+  const momentHref = getMomentUrl(moment)?.href;
 
   const onCollect = () => {
     openCollect(moment);
@@ -34,6 +36,7 @@ export const useMomentFeedCard = (moment: TimelineMoment) => {
     onCollect,
     onCommentClick,
     handleMomentClick,
+    momentHref,
     commentCount,
     showComments,
     collectionName,

--- a/lib/moment/getMomentUrl.ts
+++ b/lib/moment/getMomentUrl.ts
@@ -1,0 +1,23 @@
+import { TimelineMoment } from "@/types/moment";
+import { validateUrl } from "@/lib/url/validateUrl";
+import { isYoutubeUrl } from "@/lib/url/isYoutubeUrl";
+import { isDeprecatedUrl } from "@/lib/url/isDeprecatedUrl";
+import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
+
+export interface MomentUrl {
+  href: string;
+  isExternal: boolean;
+}
+
+export const getMomentUrl = (moment: TimelineMoment): MomentUrl | undefined => {
+  const { chain_id, address, token_id, metadata } = moment;
+  const externalUrl = metadata?.external_url;
+  if (externalUrl && !isDeprecatedUrl(externalUrl) && !isYoutubeUrl(externalUrl)) {
+    const validatedUrl = validateUrl(externalUrl);
+    if (validatedUrl) return { href: validatedUrl, isExternal: true };
+  }
+
+  const shortName = getShortNameFromChainId(chain_id);
+  if (!shortName) return undefined;
+  return { href: `/collect/${shortName}:${address}/${token_id}`, isExternal: false };
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mux/upchunk": "^3.5.0",
     "@privy-io/react-auth": "^3.12.0",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-context-menu": "^2.3.4",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       "@radix-ui/react-accordion":
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-context-menu":
+        specifier: ^2.3.4
+        version: 2.3.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@radix-ui/react-dialog":
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -2067,10 +2070,32 @@ packages:
         integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==,
       }
 
+  "@radix-ui/primitive@1.1.6":
+    resolution:
+      {
+        integrity: sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==,
+      }
+
   "@radix-ui/react-accordion@1.2.12":
     resolution:
       {
         integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-arrow@1.1.12":
+    resolution:
+      {
+        integrity: sha512-ltXCE0glRomMZ9+u10d9o1Go+edqa1aLxufH59JRNNM3Yz1uvaeNWSaS1HeVh1X64agtdBG5JA1W1I6ySqWiwA==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2115,6 +2140,22 @@ packages:
       "@types/react-dom":
         optional: true
 
+  "@radix-ui/react-collection@1.1.12":
+    resolution:
+      {
+        integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-collection@1.1.7":
     resolution:
       {
@@ -2143,10 +2184,50 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-compose-refs@1.1.3":
+    resolution:
+      {
+        integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-context-menu@2.3.4":
+    resolution:
+      {
+        integrity: sha512-eO9tkvHvo4dNwb+lytEcKWjy8c8To+ttLwNt0f9XzzsVFIaspqt3i1/c0JaaksxBB5G//zPo9CCgn39huWQyBA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-context@1.1.2":
     resolution:
       {
         integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-context@1.2.0":
+    resolution:
+      {
+        integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2183,10 +2264,38 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-direction@1.1.2":
+    resolution:
+      {
+        integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-dismissable-layer@1.1.11":
     resolution:
       {
         integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-dismissable-layer@1.1.16":
+    resolution:
+      {
+        integrity: sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2209,6 +2318,34 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       "@types/react":
+        optional: true
+
+  "@radix-ui/react-focus-guards@1.1.4":
+    resolution:
+      {
+        integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-focus-scope@1.1.13":
+    resolution:
+      {
+        integrity: sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
         optional: true
 
   "@radix-ui/react-focus-scope@1.1.7":
@@ -2247,10 +2384,38 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-id@1.1.2":
+    resolution:
+      {
+        integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-label@2.1.8":
     resolution:
       {
         integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-menu@2.1.21":
+    resolution:
+      {
+        integrity: sha512-2BHtaJHvvoWTECyrja1mOjN6z2dWdpeHL6b8PxqZYgex8J8xakT2KAchpZIaMwNPauIRHH/VlPJYhSSKe8lz2g==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2295,6 +2460,38 @@ packages:
       "@types/react-dom":
         optional: true
 
+  "@radix-ui/react-popper@1.3.4":
+    resolution:
+      {
+        integrity: sha512-PXnCa3XgTQk0FegMctxgqJXtFLZe4IFJdbUkB7jKSCKEpb6utEO4S9Vog/pkyCfEPdzM331gvE4xpztmBAfMng==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-portal@1.1.14":
+    resolution:
+      {
+        integrity: sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-portal@1.1.9":
     resolution:
       {
@@ -2327,6 +2524,22 @@ packages:
       "@types/react-dom":
         optional: true
 
+  "@radix-ui/react-presence@1.1.8":
+    resolution:
+      {
+        integrity: sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-primitive@2.1.3":
     resolution:
       {
@@ -2347,6 +2560,38 @@ packages:
     resolution:
       {
         integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-primitive@2.1.7":
+    resolution:
+      {
+        integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-roving-focus@1.1.16":
+    resolution:
+      {
+        integrity: sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2447,6 +2692,18 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-slot@1.3.0":
+    resolution:
+      {
+        integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-tooltip@1.2.8":
     resolution:
       {
@@ -2475,10 +2732,34 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-use-callback-ref@1.1.2":
+    resolution:
+      {
+        integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-use-controllable-state@1.2.2":
     resolution:
       {
         integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-controllable-state@1.2.4":
+    resolution:
+      {
+        integrity: sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2499,6 +2780,18 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-use-effect-event@0.0.3":
+    resolution:
+      {
+        integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-use-escape-keydown@1.1.1":
     resolution:
       {
@@ -2511,10 +2804,34 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-use-is-hydrated@0.1.1":
+    resolution:
+      {
+        integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-use-layout-effect@1.1.1":
     resolution:
       {
         integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-layout-effect@1.1.2":
+    resolution:
+      {
+        integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2547,10 +2864,34 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-use-rect@1.1.2":
+    resolution:
+      {
+        integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-use-size@1.1.1":
     resolution:
       {
         integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-size@1.1.2":
+    resolution:
+      {
+        integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -2595,6 +2936,12 @@ packages:
     resolution:
       {
         integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==,
+      }
+
+  "@radix-ui/rect@1.1.2":
+    resolution:
+      {
+        integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==,
       }
 
   "@randlabs/communication-bridge@1.0.1":
@@ -12876,6 +13223,8 @@ snapshots:
 
   "@radix-ui/primitive@1.1.3": {}
 
+  "@radix-ui/primitive@1.1.6": {}
+
   "@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/primitive": 1.1.3
@@ -12887,6 +13236,15 @@ snapshots:
       "@radix-ui/react-id": 1.1.1(@types/react@19.2.7)(react@19.2.1)
       "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-arrow@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:
@@ -12918,6 +13276,18 @@ snapshots:
       "@types/react": 19.2.7
       "@types/react-dom": 19.2.3(@types/react@19.2.7)
 
+  "@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-context": 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-slot": 1.3.0(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
   "@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/react-compose-refs": 1.1.2(@types/react@19.2.7)(react@19.2.1)
@@ -12936,7 +13306,32 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-context-menu@2.3.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.6
+      "@radix-ui/react-context": 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-menu": 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-use-controllable-state": 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
   "@radix-ui/react-context@1.1.2(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-context@1.2.0(@types/react@19.2.7)(react@19.2.1)":
     dependencies:
       react: 19.2.1
     optionalDependencies:
@@ -12970,6 +13365,12 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-direction@1.1.2(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/primitive": 1.1.3
@@ -12983,11 +13384,41 @@ snapshots:
       "@types/react": 19.2.7
       "@types/react-dom": 19.2.3(@types/react@19.2.7)
 
+  "@radix-ui/react-dismissable-layer@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.6
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-effect-event": 0.0.3(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
   "@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.7)(react@19.2.1)":
     dependencies:
       react: 19.2.1
     optionalDependencies:
       "@types/react": 19.2.7
+
+  "@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-focus-scope@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
 
   "@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
@@ -13011,11 +13442,44 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-id@1.1.2(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/react-primitive": 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-menu@2.1.21(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.6
+      "@radix-ui/react-collection": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-context": 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-dismissable-layer": 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-focus-guards": 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-focus-scope": 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-popper": 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-portal": 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-presence": 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-roving-focus": 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-slot": 1.3.0(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      aria-hidden: 1.2.6
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
     optionalDependencies:
       "@types/react": 19.2.7
       "@types/react-dom": 19.2.3(@types/react@19.2.7)
@@ -13061,6 +13525,34 @@ snapshots:
       "@types/react": 19.2.7
       "@types/react-dom": 19.2.3(@types/react@19.2.7)
 
+  "@radix-ui/react-popper@1.3.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@floating-ui/react-dom": 2.1.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-arrow": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-context": 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-rect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-size": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/rect": 1.1.2
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-portal@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
   "@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -13081,6 +13573,15 @@ snapshots:
       "@types/react": 19.2.7
       "@types/react-dom": 19.2.3(@types/react@19.2.7)
 
+  "@radix-ui/react-presence@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
   "@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/react-slot": 1.2.3(@types/react@19.2.7)(react@19.2.1)
@@ -13093,6 +13594,34 @@ snapshots:
   "@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/react-slot": 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-slot": 1.3.0(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-roving-focus@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.6
+      "@radix-ui/react-collection": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-context": 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-primitive": 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-controllable-state": 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-is-hydrated": 0.1.1(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:
@@ -13187,6 +13716,13 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-slot@1.3.0(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@radix-ui/primitive": 1.1.3
@@ -13213,10 +13749,25 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.7)(react@19.2.1)":
     dependencies:
       "@radix-ui/react-use-effect-event": 0.0.2(@types/react@19.2.7)(react@19.2.1)
       "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-use-controllable-state@1.2.4(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.6
+      "@radix-ui/react-use-effect-event": 0.0.3(@types/react@19.2.7)(react@19.2.1)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
     optionalDependencies:
       "@types/react": 19.2.7
@@ -13228,6 +13779,13 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.7)(react@19.2.1)":
     dependencies:
       "@radix-ui/react-use-callback-ref": 1.1.1(@types/react@19.2.7)(react@19.2.1)
@@ -13235,7 +13793,19 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.7)(react@19.2.1)":
     dependencies:
       react: 19.2.1
     optionalDependencies:
@@ -13254,9 +13824,23 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.7
 
+  "@radix-ui/react-use-rect@1.1.2(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      "@radix-ui/rect": 1.1.2
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
   "@radix-ui/react-use-size@1.1.1(@types/react@19.2.7)(react@19.2.1)":
     dependencies:
       "@radix-ui/react-use-layout-effect": 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      "@types/react": 19.2.7
+
+  "@radix-ui/react-use-size@1.1.2(@types/react@19.2.7)(react@19.2.1)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
     optionalDependencies:
       "@types/react": 19.2.7
@@ -13280,6 +13864,8 @@ snapshots:
       "@types/react-dom": 19.2.3(@types/react@19.2.7)
 
   "@radix-ui/rect@1.1.1": {}
+
+  "@radix-ui/rect@1.1.2": {}
 
   "@randlabs/communication-bridge@1.0.1":
     optional: true


### PR DESCRIPTION
## Summary
- Right-clicking the top-left InProcess logo now shows a context menu with "Open in new tab" that opens the home page
- Right-clicking anywhere on a HomePage moment feed card or a timeline/collection grid moment card shows the same menu, opening the moment page (or its external URL, matching existing click behavior) in a new tab
- Adds a reusable `OpenInNewTabMenu` component built on `@radix-ui/react-context-menu` (new dependency) plus a generic `components/ui/context-menu.tsx` primitive wrapper
- Extracts the moment URL resolution (external link vs internal `/collect` page) shared by `useMomentClick` and `useMomentFeedCard` into `lib/moment/getMomentUrl.ts` to avoid duplicating that logic

## Test plan
- [ ] Right-click the top-left logo — confirm "Open in new tab" appears and opens the home page in a new tab
- [ ] Right-click anywhere on a HomePage moment feed card — confirm the menu appears and opens the moment page in a new tab
- [ ] Right-click a timeline/collection grid moment card — confirm the same behavior
- [ ] Confirm left-click behavior on all three (logo, feed card, grid card) is unchanged
- [ ] Confirm nested links/buttons (artist name, collection name, Collect, comment) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)