### PR TITLE
Add comment option to home page collect modal via collapsible advanced section

### DIFF
--- a/components/HomePage/CollectAdvanced.tsx
+++ b/components/HomePage/CollectAdvanced.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import { useMomentCommentsProvider } from "@/providers/MomentCommentsProvider";
+
+const CollectAdvanced = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { comment, setComment } = useMomentCommentsProvider();
+
+  return (
+    <div className="mt-3 flex w-full flex-col gap-2">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between border-b border-grey-moss-300 pb-1 font-archivo text-sm text-grey-moss-400"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        Advanced
+        <ChevronDown
+          className={`h-4 w-4 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+      {isOpen && (
+        <textarea
+          className="w-full !border-none bg-grey-moss-50 p-3 font-spectral text-sm !outline-none !ring-0"
+          rows={4}
+          placeholder="leave a comment"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default CollectAdvanced;

--- a/components/HomePage/CollectModalContents.tsx
+++ b/components/HomePage/CollectModalContents.tsx
@@ -5,11 +5,12 @@ import useCollectAvailability from "@/hooks/useCollectAvailability";
 import getPrice from "@/lib/getPrice";
 import getPriceUnit from "@/lib/getPriceUnit";
 import { useMomentProvider } from "@/providers/MomentProvider";
-import { MomentType } from "@/types/moment";
+import { MomentType, Protocol } from "@/types/moment";
 import CommentButton from "@/components/CommentButton/CommentButton";
+import CollectAdvanced from "@/components/HomePage/CollectAdvanced";
 
 const CollectModalContents = () => {
-  const { isLoading, metadata, saleConfig } = useMomentProvider();
+  const { isLoading, metadata, saleConfig, protocol } = useMomentProvider();
   const { isCollectDisabled, collectCtaLabel } = useCollectAvailability();
 
   if (isLoading || !metadata) {
@@ -33,6 +34,7 @@ const CollectModalContents = () => {
           {priceLabel}
         </p>
       </div>
+      {protocol === Protocol.InProcess && !isCollectDisabled && <CollectAdvanced />}
       <div className="pt-3 w-full">
         <CommentButton disabled={isCollectDisabled} label={collectCtaLabel} />
       </div>


### PR DESCRIPTION
## Summary
- Home page collects go through a confirm modal (not one-click), but the modal had no way to leave a comment, unlike the moment page collect flow.
- Adds a collapsible "advanced" section below the price in `CollectModalContents` — expanding it reveals a comment textarea, following the same collapse pattern already used in `MomentPage/Advanced.tsx` and `CreateForm/Advanced.tsx`.
- Reuses the existing `comment`/`setComment` state from `MomentCommentsProvider`, which `useMomentCollect`'s `collectWithComment` already sends to the API — only the input UI was missing.
- Section is gated to `Protocol.InProcess` and non-disabled collects, matching the moment page's condition for showing the comment field.

## Test plan
- [ ] On home page, click collect on a moment feed card → confirm modal opens
- [ ] Verify "advanced" section is collapsed by default, below the price
- [ ] Expand it → textarea appears, chevron rotates
- [ ] Type a comment, collect → verify comment is submitted with the collect
- [ ] Verify section does not appear for Sound.xyz/Catalog moments or when collect is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable **Advanced** section to the collection modal.
  * Users can enter optional comments when collection is in progress and enabled.
  * The section includes a visual indicator showing whether it is expanded or collapsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->