### PR TITLE
Update PermissionErrorModal copy to reflect legacy-moment permission gap

### DIFF
--- a/components/PermissionErrorModal.tsx
+++ b/components/PermissionErrorModal.tsx
@@ -30,10 +30,10 @@ const PermissionErrorModal = ({ open, onClose, contractAddress }: PermissionErro
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Permission Required</DialogTitle>
+          <DialogTitle>Legacy Moment Permission Missing</DialogTitle>
           <DialogDescription>
-            The In·Process smart wallet does not have permission. Use your external wallet to
-            directly add permission onchain.
+            This is a legacy moment, so the In·Process smart wallet was never granted permission for
+            it. Use your external wallet to add permission onchain directly.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>


### PR DESCRIPTION
## Summary
- `PermissionErrorModal` title/description were generic ("Permission Required" / "The In·Process smart wallet does not have permission...") and didn't explain that this only happens for legacy moments whose collection never granted the smart wallet admin permission.
- Title changed to "Legacy Moment Permission Missing"; description now states this is a legacy moment before pointing the artist to their external wallet to grant permission onchain.

## Test plan
- [x] `git diff` reviewed — only the title/description strings changed in `components/PermissionErrorModal.tsx`
- [ ] Manually trigger the modal (add admin / save media / set sale on a moment where only the external wallet is an admin) and confirm the new copy renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)