### PR TITLE
Grant permission to the operational smart wallet, not the fund-management one

### DIFF
--- a/hooks/useInProcessGrantPermission.ts
+++ b/hooks/useInProcessGrantPermission.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { ConnectedWallet, useConnectWallet } from "@privy-io/react-auth";
 import useConnectedWallet from "./useConnectedWallet";
-import { useSmartAccountProvider } from "@/providers/SmartWalletAccountProvider";
+import useOperationalSmartWallet from "./useOperationalSmartWallet";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import { createWalletClient, custom, Address } from "viem";
 import { CHAIN_ID, PERMISSION_BIT_ADMIN } from "@/lib/consts";
@@ -20,7 +20,7 @@ const useInProcessGrantPermission = (
   { onGranted }: UseInProcessGrantPermissionOptions = {}
 ) => {
   const { primaryWallet } = useWalletsProvider();
-  const { smartWallet } = useSmartAccountProvider();
+  const { operationalSmartWallet } = useOperationalSmartWallet();
   const { externalWallet } = useConnectedWallet();
   const [isGranting, setIsGranting] = useState(false);
 
@@ -32,7 +32,7 @@ const useInProcessGrantPermission = (
       return;
     }
 
-    if (!smartWallet) {
+    if (!operationalSmartWallet) {
       toast.error("Smart wallet not available");
       return;
     }
@@ -55,7 +55,7 @@ const useInProcessGrantPermission = (
         address: contractAddress,
         abi: zoraCreator1155ImplABI,
         functionName: "addPermission",
-        args: [BigInt(0), smartWallet as Address, BigInt(PERMISSION_BIT_ADMIN)],
+        args: [BigInt(0), operationalSmartWallet, BigInt(PERMISSION_BIT_ADMIN)],
       });
 
       const publicClient = getPublicClient(CHAIN_ID);

--- a/hooks/useOperationalSmartWallet.ts
+++ b/hooks/useOperationalSmartWallet.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { Address } from "viem";
+import { useWalletsProvider } from "@/providers/WalletsProvider";
+import fetchOperationalSmartWallet from "@/lib/smartwallets/fetchOperationalSmartWallet";
+
+const useOperationalSmartWallet = () => {
+  const { primaryWallet } = useWalletsProvider();
+
+  const query = useQuery({
+    queryKey: ["operational_smart_wallet", primaryWallet],
+    queryFn: () => fetchOperationalSmartWallet(primaryWallet as Address),
+    enabled: Boolean(primaryWallet),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  return {
+    operationalSmartWallet: query.data,
+    isLoading: query.isLoading,
+  };
+};
+
+export default useOperationalSmartWallet;

--- a/lib/smartwallets/fetchOperationalSmartWallet.ts
+++ b/lib/smartwallets/fetchOperationalSmartWallet.ts
@@ -1,0 +1,19 @@
+import { Address } from "viem";
+import { IN_PROCESS_API } from "@/lib/consts";
+
+const fetchOperationalSmartWallet = async (walletAddress: Address): Promise<Address> => {
+  const params = new URLSearchParams({ walletAddress });
+  const res = await fetch(`${IN_PROCESS_API}/smartwallet?${params.toString()}`);
+
+  if (!res.ok) {
+    const err = await res
+      .json()
+      .catch(() => ({ message: "Failed to fetch operational smart wallet" }));
+    throw new Error(err.message ?? "Failed to fetch operational smart wallet");
+  }
+
+  const data = await res.json();
+  return data.address as Address;
+};
+
+export default fetchOperationalSmartWallet;


### PR DESCRIPTION
## Summary
- `useInProcessGrantPermission` was granting admin to `getArtistSmartAccount` (artist-level smart wallet, used only for fund management like Arweave), but the backend's actual write path (`getOperationalSmartWallet`, used by `updateMomentURI`, `addPermission`, `setSale`, etc.) checks admin permission on `getWalletSmartAccount` — a different address keyed by wallet address, not artist ID.
- Because these are different addresses, granting permission via the modal never actually authorized the wallet the backend checks, so `"No authorized smart wallet found"` would keep recurring even after a successful grant transaction.
- Added `lib/smartwallets/fetchOperationalSmartWallet.ts`, which calls the existing (previously unused by the frontend) `GET /smartwallet?walletAddress=` endpoint — already backed by `getWalletSmartAccount` on the API side.
- Added `hooks/useOperationalSmartWallet.ts`, a React Query wrapper keyed on `primaryWallet`.
- Updated `hooks/useInProcessGrantPermission.ts` to grant permission to this operational smart wallet address instead.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors in the changed files
- [ ] Manually trigger the permission modal on a legacy moment, grant permission, and confirm the subsequent save/add-admin/set-sale action succeeds without the error recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the operational smart wallet associated with a connected wallet.
  * Permission grants now use the operational smart wallet address for contract transactions.
  * Added loading and error handling when the operational smart wallet cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->