### PR TITLE
Redesign Moment Manage Admins tab to match Collection Manage

### DIFF
--- a/components/MomentManagePage/AddAdmin.tsx
+++ b/components/MomentManagePage/AddAdmin.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import useAddMomentAdmin from "@/hooks/useAddMomentAdmin";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import PermissionErrorModal from "@/components/PermissionErrorModal";
+
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
 
 const AddAdmin = () => {
   const {
@@ -17,26 +18,36 @@ const AddAdmin = () => {
   } = useAddMomentAdmin();
   const { isOwner, moment } = useMomentProvider();
 
+  const isDisabled = isAdding || !isOwner;
+  const hasValue = Boolean(newAdminAddress.trim());
+
   return (
-    <div className="flex flex-col gap-2 border-t border-grey-secondary pt-4">
-      <h3 className="font-archivo-medium text-lg">Add New Admin</h3>
-      <div className="flex gap-2">
+    <div>
+      <div className="mb-3 flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-[#887bff]" />
+        <span className={FIELD_LABEL_CLASS}>add new admin</span>
+      </div>
+      <div className="flex gap-2.5">
         <Input
           type="text"
-          placeholder="Enter admin address or ENS name (0x... or name.eth)"
+          placeholder="Admin address or ENS name (0x… or name.eth)"
           value={newAdminAddress}
           onChange={(e) => setNewAdminAddress(e.target.value)}
-          disabled={isAdding || !isOwner}
-          className="flex-1"
+          disabled={isDisabled}
+          className="min-w-0 flex-1 rounded-md border-grey-moss-100 bg-white font-archivo text-[13.5px] text-grey-moss-900 placeholder:text-grey-moss-200"
         />
-        <Button
+        <button
           type="button"
           onClick={handleAddAdmin}
-          disabled={!newAdminAddress.trim() || isAdding || !isOwner}
-          className="w-fit rounded-md bg-black px-8 py-2 text-grey-eggshell disabled:opacity-50"
+          disabled={!hasValue || isDisabled}
+          className={`shrink-0 rounded-full border px-[18px] py-2 font-archivo-medium text-xs transition-colors disabled:opacity-50 ${
+            hasValue
+              ? "border-grey-moss-900 bg-grey-moss-900 text-white hover:bg-black"
+              : "border-grey-moss-100 bg-grey-moss-50 text-grey-moss-300"
+          }`}
         >
           {isAdding ? "Adding..." : "Add"}
-        </Button>
+        </button>
       </div>
       <PermissionErrorModal
         open={showPermissionModal}

--- a/components/MomentManagePage/Admins.tsx
+++ b/components/MomentManagePage/Admins.tsx
@@ -5,29 +5,39 @@ import AddAdmin from "./AddAdmin";
 import MomentAdmin from "./MomentAdmin";
 import { Address } from "viem";
 
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+
 const Admins = () => {
   const { momentAdmins } = useMomentProvider();
 
-  if (!momentAdmins) return <div>Loading...</div>;
+  if (!momentAdmins) {
+    return (
+      <div className="rounded-lg border border-grey-moss-100 bg-white p-4 shadow-sm md:p-6">
+        <p className="font-spectral-italic text-sm text-grey-moss-300">Loading...</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="w-full font-archivo">
-      <div className="mt-4 flex w-full max-w-md flex-col gap-4 rounded-2xl bg-white p-4 pt-4">
-        <div className="flex flex-col gap-2">
-          <h3 className="font-archivo-medium text-lg">Current Admins</h3>
-          {momentAdmins.length === 0 ? (
-            <p className="font-spectral-italic text-sm text-grey-secondary">No admins added yet.</p>
-          ) : (
-            <div className="space-y-2">
-              {momentAdmins.map((address: Address) => (
-                <MomentAdmin key={address} address={address} />
-              ))}
-            </div>
-          )}
-        </div>
-
-        <AddAdmin />
+    <div className="rounded-lg border border-grey-moss-100 bg-white p-4 shadow-sm md:p-6">
+      <div className="mb-4 flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-[#7FD58A]" />
+        <span className={FIELD_LABEL_CLASS}>current admins</span>
       </div>
+
+      {momentAdmins.length === 0 ? (
+        <p className="font-spectral-italic text-sm text-grey-moss-300">No admins added yet.</p>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {momentAdmins.map((address: Address) => (
+            <MomentAdmin key={address} address={address} />
+          ))}
+        </div>
+      )}
+
+      <div className="my-5 border-t border-grey-moss-50" />
+
+      <AddAdmin />
     </div>
   );
 };

--- a/components/MomentManagePage/MomentAdmin.tsx
+++ b/components/MomentManagePage/MomentAdmin.tsx
@@ -1,43 +1,49 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import truncateAddress from "@/lib/truncateAddress";
 import { Address } from "viem";
 import useRemoveMomentAdmin from "@/hooks/useRemoveMomentAdmin";
 import { useArtistProfile } from "@/hooks/useArtistProfile";
-import { useSmartAccountProvider } from "@/providers/SmartWalletAccountProvider";
-import { useWalletsProvider } from "@/providers/WalletsProvider";
+import { useIsNotOwnWallet } from "@/hooks/useIsNotOwnWallet";
+import { useMomentProvider } from "@/providers/MomentProvider";
 
 const MomentAdmin = ({ address }: { address: Address }) => {
   const { handleRemoveAdmin, isRemoving } = useRemoveMomentAdmin();
-  const { data: artistProfile } = useArtistProfile(address);
-  const { smartWallet } = useSmartAccountProvider();
-  const { primaryWallet } = useWalletsProvider();
+  const { data: artistProfile, isLoading } = useArtistProfile(address);
+  const isNotOwnWallet = useIsNotOwnWallet(address);
+  const { isOwner } = useMomentProvider();
 
-  const isRemovable =
-    address.toLowerCase() !== primaryWallet?.toLowerCase() &&
-    address.toLowerCase() !== smartWallet.toLowerCase();
+  const label = artistProfile?.username || truncateAddress(address);
+  const initial = artistProfile?.username ? artistProfile.username.charAt(0).toUpperCase() : "0x";
 
   return (
-    <div className="flex items-center justify-between rounded-lg border border-grey-secondary bg-grey-eggshell p-3">
-      {artistProfile ? (
-        <p className="font-archivo text-sm text-grey-moss-600">
-          {artistProfile.username || truncateAddress(address)}
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-grey-moss-100 bg-grey-moss-50/60 px-3.5 py-2.5">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-grey-moss-300 font-archivo-bold text-[11px] text-white">
+          {initial}
+        </span>
+        <p className="truncate font-archivo text-[13.5px] text-grey-moss-900">
+          {isLoading ? "Loading..." : label}
         </p>
+      </div>
+      {!isNotOwnWallet ? (
+        <span className="shrink-0 rounded-full bg-grey-moss-50 px-2.5 py-1 font-archivo-medium text-[10px] uppercase tracking-wider text-grey-moss-300">
+          you
+        </span>
       ) : (
-        <p className="font-archivo text-sm text-grey-moss-600">Loading...</p>
+        isOwner && (
+          <button
+            type="button"
+            onClick={() => handleRemoveAdmin(address)}
+            disabled={isRemoving}
+            aria-label="Remove admin"
+            className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-red-200 text-red-500 transition-colors hover:bg-red-50 disabled:opacity-50"
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+        )
       )}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => handleRemoveAdmin(address)}
-        disabled={isRemoving || !isRemovable}
-        className="border-red-300 text-red-600 hover:bg-red-50"
-      >
-        <Trash2 className="h-4 w-4" />
-      </Button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Restyle Moment Manage Admins to Collection Manage card chrome (section dots, avatar rows, you badge / trash remove, pill Add CTA).
- Keep moment-specific add/remove admin hooks, owner checks, and permission modal.

## Test plan
- [ ] Open Moment Manage → Admins; card matches Collection Manage Admins layout
- [ ] Own wallet shows `you` badge; other admins show remove for owners
- [ ] Add admin via address/ENS; permission modal still works on failure
- [ ] Non-owners cannot add or remove admins


Made with [Cursor](https://cursor.com)