### PR TITLE
Restyle Moment Manage Sale tab to match updated manage UI

### DIFF
--- a/components/MomentManagePage/Sale.tsx
+++ b/components/MomentManagePage/Sale.tsx
@@ -8,6 +8,8 @@ import SaleEndPicker from "./SaleEndPicker";
 import SalePriceInput from "./SalePriceInput";
 import PermissionErrorModal from "@/components/PermissionErrorModal";
 
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+
 const Sale = () => {
   const {
     saleStart,
@@ -26,40 +28,56 @@ const Sale = () => {
 
   if (!saleConfig) return <SaleSkeleton />;
 
+  const isSaleInactive = BigInt(saleConfig.saleEnd) === BigInt(0);
+
   return (
-    <div className="w-full font-archivo">
-      <div className="mt-4 flex w-full max-w-md flex-col gap-2 rounded-2xl bg-white p-4 pt-4">
-        {BigInt(saleConfig.saleEnd) === BigInt(0) ? (
-          <div>sale is not yet activated.</div>
-        ) : (
-          <>
+    <div className="rounded-lg border border-grey-moss-100 bg-white p-4 shadow-sm md:p-6">
+      <div className="mb-4 flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-[#03c7f6]" />
+        <span className={FIELD_LABEL_CLASS}>sale</span>
+      </div>
+
+      {isSaleInactive ? (
+        <p className="font-spectral-italic text-sm text-grey-moss-300">
+          Sale is not yet activated.
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-col gap-4">
             <SaleStartPicker
               saleStart={saleStart}
               currentSaleStart={saleConfig.saleStart}
               setSaleStart={setSaleStart}
+              disabled={isLoading || !isOwner}
             />
             <SaleEndPicker
               saleEnd={saleEnd}
               currentSaleEnd={saleConfig.saleEnd}
               setSaleEnd={setSaleEnd}
               saleStart={saleStart}
+              disabled={isLoading || !isOwner}
             />
             <SalePriceInput
               priceInput={priceInput}
               priceUnit={priceUnit}
-              disabled={isLoading}
+              disabled={isLoading || !isOwner}
               setPriceInput={setPriceInput}
             />
+          </div>
+
+          <div className="mt-[18px] flex items-center justify-end gap-3 border-t border-grey-moss-50 pt-4">
             <button
-              className="w-fit rounded-md bg-black px-8 py-2 text-grey-eggshell disabled:opacity-50"
+              type="button"
               onClick={setSale}
               disabled={isLoading || !isOwner}
+              className="rounded-full border border-grey-moss-900 bg-grey-moss-900 px-[18px] py-2 font-archivo-medium text-xs text-white transition-colors hover:bg-black disabled:opacity-50"
             >
-              {isLoading ? "setting..." : "set sale"}
+              {isLoading ? "Saving..." : "Save Changes"}
             </button>
-          </>
-        )}
-      </div>
+          </div>
+        </>
+      )}
+
       <PermissionErrorModal
         open={showPermissionModal}
         onClose={closePermissionModal}

--- a/components/MomentManagePage/SaleEndPicker.tsx
+++ b/components/MomentManagePage/SaleEndPicker.tsx
@@ -1,22 +1,45 @@
 import { DateTimePicker } from "@/components/ui/date-time-picker";
 import { isOpenEndedSale } from "@/lib/moment/isOpenEndedSale";
 
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+const PICKER_CLASS =
+  "!rounded-md !border-grey-moss-100 !font-archivo text-[15px] text-grey-moss-900 hover:!bg-white";
+
 interface SaleEndPickerProps {
   saleEnd: Date | undefined;
   currentSaleEnd: number | string;
   setSaleEnd: (date: Date) => void;
   saleStart: Date;
+  disabled?: boolean;
 }
 
-const SaleEndPicker = ({ saleEnd, currentSaleEnd, setSaleEnd, saleStart }: SaleEndPickerProps) => {
+const SaleEndPicker = ({
+  saleEnd,
+  currentSaleEnd,
+  setSaleEnd,
+  saleStart,
+  disabled = false,
+}: SaleEndPickerProps) => {
   const isOpenEnded = isOpenEndedSale(currentSaleEnd);
+  const currentLabel = isOpenEnded
+    ? "Open"
+    : new Date(Number(currentSaleEnd) * 1000).toLocaleDateString();
+
   return (
-    <div>
-      <p className="pb-2">
-        sale end:{" "}
-        {isOpenEnded ? "Open" : new Date(Number(currentSaleEnd) * 1000).toLocaleDateString()}
-      </p>
-      <DateTimePicker date={saleEnd} setDate={setSaleEnd} minDate={saleStart} />
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between gap-2">
+        <label className={FIELD_LABEL_CLASS}>sale end</label>
+        <span className="font-archivo text-[10.5px] text-grey-moss-200">
+          current · {currentLabel}
+        </span>
+      </div>
+      <DateTimePicker
+        date={saleEnd}
+        setDate={setSaleEnd}
+        minDate={saleStart}
+        disabled={disabled}
+        className={PICKER_CLASS}
+      />
     </div>
   );
 };

--- a/components/MomentManagePage/SalePriceInput.tsx
+++ b/components/MomentManagePage/SalePriceInput.tsx
@@ -1,5 +1,7 @@
 import { Input } from "@/components/ui/input";
 
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+
 interface SalePriceInputProps {
   priceInput: string;
   priceUnit: string;
@@ -13,10 +15,13 @@ const SalePriceInput = ({
   disabled,
   setPriceInput,
 }: SalePriceInputProps) => (
-  <div className="w-full pt-2">
-    <p className="pb-1 font-archivo text-md">price</p>
-    <div className="flex overflow-hidden border border-grey-secondary">
+  <div className="flex flex-col gap-1">
+    <label htmlFor="sale-price" className={FIELD_LABEL_CLASS}>
+      price
+    </label>
+    <div className="flex overflow-hidden rounded-md border border-grey-moss-100">
       <Input
+        id="sale-price"
         type="number"
         inputMode="decimal"
         min="0"
@@ -27,13 +32,15 @@ const SalePriceInput = ({
           if (/^\d*\.?\d*$/.test(val)) setPriceInput(val);
         }}
         onWheel={(e) => e.currentTarget.blur()}
-        className="flex-grow !rounded-[0px] !border-none bg-white !font-spectral [appearance:textfield] focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        className="flex-grow !rounded-none !border-none bg-white !font-archivo text-[15px] text-grey-moss-900 [appearance:textfield] focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         disabled={disabled}
       />
-      <div className="bg-white">
-        <div className="my-2 h-6 w-[1px] bg-grey-secondary" />
+      <div className="flex items-center bg-white">
+        <div className="my-2 h-6 w-px bg-grey-moss-100" />
       </div>
-      <div className="flex items-center bg-white px-3 font-archivo text-sm">{priceUnit}</div>
+      <div className="flex items-center bg-white px-3 font-archivo text-[13.5px] text-grey-moss-300">
+        {priceUnit}
+      </div>
     </div>
   </div>
 );

--- a/components/MomentManagePage/SaleSkeleton.tsx
+++ b/components/MomentManagePage/SaleSkeleton.tsx
@@ -1,11 +1,26 @@
 import { Skeleton } from "../ui/skeleton";
 
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+
 const SaleSkeleton = () => (
-  <div className="w-full font-archivo">
-    <div className="mt-4 flex w-full max-w-md flex-col gap-2 rounded-2xl bg-white p-4 pt-4">
-      <Skeleton className="h-4 w-48" />
-      <Skeleton className="h-10 w-full rounded-md" />
-      <Skeleton className="h-10 w-24 rounded-md" />
+  <div className="rounded-lg border border-grey-moss-100 bg-white p-4 shadow-sm md:p-6">
+    <div className="mb-4 flex items-center gap-1.5">
+      <span className="size-1.5 rounded-full bg-[#03c7f6]" />
+      <span className={FIELD_LABEL_CLASS}>sale</span>
+    </div>
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-10 w-full rounded-md" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-10 w-full rounded-md" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-10 w-full rounded-md" />
+      </div>
     </div>
   </div>
 );

--- a/components/MomentManagePage/SaleStartPicker.tsx
+++ b/components/MomentManagePage/SaleStartPicker.tsx
@@ -1,22 +1,42 @@
 import { DateTimePicker } from "@/components/ui/date-time-picker";
 
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+const PICKER_CLASS =
+  "!rounded-md !border-grey-moss-100 !font-archivo text-[15px] text-grey-moss-900 hover:!bg-white";
+
 interface SaleStartPickerProps {
   saleStart: Date;
   currentSaleStart: number | string;
   setSaleStart: (date: Date) => void;
+  disabled?: boolean;
 }
 
-const SaleStartPicker = ({ saleStart, currentSaleStart, setSaleStart }: SaleStartPickerProps) => {
+const SaleStartPicker = ({
+  saleStart,
+  currentSaleStart,
+  setSaleStart,
+  disabled = false,
+}: SaleStartPickerProps) => {
   const normalized = BigInt(String(Math.floor(Number(currentSaleStart))));
+  const currentLabel =
+    normalized === BigInt(0)
+      ? "Open"
+      : new Date(Number(normalized) * 1000).toLocaleDateString();
+
   return (
-    <div>
-      <p className="pb-2">
-        sale start:{" "}
-        {normalized === BigInt(0)
-          ? "Open"
-          : new Date(Number(normalized) * 1000).toLocaleDateString()}
-      </p>
-      <DateTimePicker date={saleStart} setDate={setSaleStart} />
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between gap-2">
+        <label className={FIELD_LABEL_CLASS}>sale start</label>
+        <span className="font-archivo text-[10.5px] text-grey-moss-200">
+          current · {currentLabel}
+        </span>
+      </div>
+      <DateTimePicker
+        date={saleStart}
+        setDate={setSaleStart}
+        disabled={disabled}
+        className={PICKER_CLASS}
+      />
     </div>
   );
 };

--- a/components/ui/date-time-picker.tsx
+++ b/components/ui/date-time-picker.tsx
@@ -16,9 +16,17 @@ interface DatetimePickerProps {
   setDate: (_value: Date) => void;
   /** Dates on or before this day are not selectable. */
   minDate?: Date;
+  className?: string;
+  disabled?: boolean;
 }
 
-export function DateTimePicker({ date, setDate, minDate }: DatetimePickerProps) {
+export function DateTimePicker({
+  date,
+  setDate,
+  minDate,
+  className,
+  disabled = false,
+}: DatetimePickerProps) {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const disabledBefore = React.useMemo(() => {
@@ -53,9 +61,11 @@ export function DateTimePicker({ date, setDate, minDate }: DatetimePickerProps) 
       <PopoverTrigger asChild>
         <Button
           variant="outline"
+          disabled={disabled}
           className={cn(
             "w-full justify-start !rounded-[0px] !border-grey !bg-white text-left !font-spectral font-normal",
-            !date && "text-muted-foreground"
+            !date && "text-muted-foreground",
+            className
           )}
         >
           <CalendarIcon className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- Restyle the Moment Manage **Sale** tab to the shared manage card UI (bordered card, section dot/label, uppercase field labels, rounded inputs, pill Save Changes).
- Keep current on-chain sale values visible (`current · …`) and preserve inactive-sale empty state + permission modal behavior.
- Extend `DateTimePicker` with optional `className` / `disabled` so Sale pickers can match the new form styling without changing Create-form defaults.
- Includes earlier Moment Manage redesign commits already on this branch (Media, overview/tabs, Admins, Airdrop).

## Test plan
- [ ] Open Moment Manage → Sale tab and confirm card chrome matches Media/Admins/Airdrop
- [ ] Edit sale start, sale end, and price; Save Changes updates successfully
- [ ] Confirm current values still show above each date field
- [ ] Non-owner / loading states disable inputs and button
- [ ] Inactive sale (`saleEnd === 0`) shows muted empty message
- [ ] Permission error still opens the permission modal
- [ ] Create-form date picker still uses its previous squared style


Made with [Cursor](https://cursor.com)