### PR TITLE
Adapt web comments fetch to nested GET /moment/comments

### DIFF
--- a/hooks/useComments.ts
+++ b/hooks/useComments.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from "react";
 import { useInfiniteQuery, useQueryClient, InfiniteData } from "@tanstack/react-query";
-import { MintComment } from "@/types/moment";
+import { CommentsPage, MintComment } from "@/types/moment";
 import fetchComments from "@/lib/moment/fetchComments";
+import withCommentDefaults from "@/lib/moment/withCommentDefaults";
 import { useMomentProvider } from "@/providers/MomentProvider";
 
 const COMMENTS_PER_PAGE = 20;
@@ -22,38 +23,42 @@ export function useComments() {
     staleTime: 1000 * 60 * 5, // 5 minutes
     retry: (failureCount) => failureCount < 3,
     getNextPageParam: (lastPage, allPages) => {
-      // If we got fewer than COMMENTS_PER_PAGE, there are no more comments
-      // Note: Supabase range(offset, offset + 20) is inclusive, so it may return 21 items
-      // We treat 20+ as a full page and continue pagination
-      if (lastPage.length < COMMENTS_PER_PAGE) {
+      // Pagination is by top-level comments only (API page size 20).
+      // Flattened length must not drive hasNextPage — replies inflate the list.
+      if (lastPage.topLevelCount < COMMENTS_PER_PAGE) {
         return undefined;
       }
-      // Otherwise, return the next offset (each page fetches COMMENTS_PER_PAGE items)
       return allPages.length * COMMENTS_PER_PAGE;
     },
     initialPageParam: 0,
   });
 
   const comments = useMemo(
-    () => query.data?.pages.flatMap((page) => page) ?? [],
+    () => query.data?.pages.flatMap((page) => page.comments) ?? [],
     [query.data?.pages]
   );
 
   const addComment = useCallback(
     (comment: MintComment) => {
-      // Optimistically update the query cache
-      queryClient.setQueryData<InfiniteData<MintComment[], number>>(
+      const next = withCommentDefaults(comment);
+      queryClient.setQueryData<InfiniteData<CommentsPage, number>>(
         ["comments", collectionAddress, tokenId, chainId],
         (oldData) => {
           if (!oldData) {
             return {
-              pages: [[comment]],
+              pages: [{ comments: [next], topLevelCount: 1 }],
               pageParams: [0],
             };
           }
-          // Add comment to the beginning of the first page
+          const [first, ...rest] = oldData.pages;
           return {
-            pages: [[comment, ...oldData.pages[0]], ...oldData.pages.slice(1)],
+            pages: [
+              {
+                comments: [next, ...first.comments],
+                topLevelCount: first.topLevelCount + 1,
+              },
+              ...rest,
+            ],
             pageParams: oldData.pageParams,
           };
         }

--- a/lib/moment/fetchComments.ts
+++ b/lib/moment/fetchComments.ts
@@ -1,7 +1,8 @@
-import { MintComment, MomentCommentsInput, MomentCommentsResult } from "@/types/moment";
+import { CommentsPage, MomentCommentsInput, MomentCommentsResult } from "@/types/moment";
 import { IN_PROCESS_API } from "@/lib/consts";
+import flattenComments from "@/lib/moment/flattenComments";
 
-async function fetchComments({ moment, offset }: MomentCommentsInput): Promise<MintComment[]> {
+async function fetchComments({ moment, offset }: MomentCommentsInput): Promise<CommentsPage> {
   try {
     const queryString = new URLSearchParams({
       collectionAddress: moment.collectionAddress,
@@ -16,10 +17,15 @@ async function fetchComments({ moment, offset }: MomentCommentsInput): Promise<M
       throw new Error("Failed to fetch comments.");
     }
     const data: MomentCommentsResult = await response.json();
-    return data.comments;
+    const topLevel = data.comments ?? [];
+
+    return {
+      comments: flattenComments(topLevel),
+      topLevelCount: topLevel.length,
+    };
   } catch (error) {
     console.error(error);
-    return [];
+    return { comments: [], topLevelCount: 0 };
   }
 }
 

--- a/lib/moment/flattenComments.ts
+++ b/lib/moment/flattenComments.ts
@@ -1,0 +1,16 @@
+import { MintComment } from "@/types/moment";
+
+/**
+ * Nested replies are ignored by the UI for now. Flatten top-level + preview
+ * replies into one list (newest first) so existing comments still appear.
+ */
+function flattenComments(comments: MintComment[]): MintComment[] {
+  const flat = comments.flatMap((comment) => {
+    const nested = comment.replies ?? [];
+    return [{ ...comment, replies: [] }, ...nested.map((reply) => ({ ...reply, replies: [] }))];
+  });
+
+  return flat.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+export default flattenComments;

--- a/lib/moment/withCommentDefaults.ts
+++ b/lib/moment/withCommentDefaults.ts
@@ -1,0 +1,14 @@
+import { MintComment } from "@/types/moment";
+
+function withCommentDefaults(comment: MintComment): MintComment {
+  return {
+    ...comment,
+    commentId: comment.commentId ?? null,
+    replyToId: comment.replyToId ?? null,
+    nonce: comment.nonce ?? null,
+    replyCount: comment.replyCount ?? 0,
+    replies: comment.replies ?? [],
+  };
+}
+
+export default withCommentDefaults;

--- a/types/moment.ts
+++ b/types/moment.ts
@@ -21,12 +21,23 @@ export interface MomentCommentsResult {
   comments: MintComment[];
 }
 
+/** One infinite-query page: flattened for the current flat UI, with top-level count for pagination. */
+export interface CommentsPage {
+  comments: MintComment[];
+  topLevelCount: number;
+}
+
 export interface MintComment {
   id: string;
   username: string;
   sender: string;
   comment: string;
   timestamp: number;
+  commentId: string | null;
+  replyToId: string | null;
+  nonce: string | null;
+  replyCount: number;
+  replies: MintComment[];
 }
 
 export interface MomentMetadata {


### PR DESCRIPTION
## Summary
- Extend `MintComment` for nested protocol fields (`commentId`, `replyToId`, `nonce`, `replyCount`, `replies`)
- Flatten top-level + preview replies for the existing flat comments UI (no reply/thread UI)
- Paginate by top-level count so nested replies do not break infinite scroll / optimistic `addComment`

## Test plan
- [ ] Open an In Process moment comments section and confirm comments still load
- [ ] Scroll / Fetch more and confirm pagination still works when replies are present
- [ ] Collect with a comment and confirm optimistic prepend still works
- [ ] Confirm reply comments from the API still appear in the flat list without thread chrome


Made with [Cursor](https://cursor.com)