### PR TITLE
Adapt moment page mobile layout with floating collect bar

### DIFF
--- a/components/MomentPage/BackToTimeline.tsx
+++ b/components/MomentPage/BackToTimeline.tsx
@@ -15,7 +15,7 @@ const BackToTimeline = () => {
 
   if (isLoading) {
     return (
-      <div className="mb-[18px]">
+      <div className="mb-3">
         <Skeleton className="h-5 w-48" />
       </div>
     );
@@ -24,10 +24,10 @@ const BackToTimeline = () => {
   const displayName = artistProfile?.username || truncateAddress(owner);
 
   return (
-    <div className="mb-[18px]">
+    <div className="mb-3">
       <Link
         href={`/${owner.toLowerCase()}`}
-        className="inline-flex items-center gap-1.5 font-archivo-medium text-[12.5px] font-archivo-medium tracking-wide text-[#6B6456] transition-colors hover:text-grey-moss-900"
+        className="inline-flex items-center gap-1.5 font-archivo-medium text-[12.5px] tracking-wide text-[#6B6456] transition-colors hover:text-grey-moss-900"
       >
         <ChevronLeft className="size-[15px]" strokeWidth={1.75} />
         BACK TO {displayName}&#39;S TIMELINE

--- a/components/MomentPage/Comment.tsx
+++ b/components/MomentPage/Comment.tsx
@@ -4,6 +4,7 @@ import truncateAddress from "@/lib/utils/truncateAddress";
 import { MintComment } from "@/types/moment";
 import Link from "next/link";
 import { Address } from "viem";
+import { Sparkles } from "lucide-react";
 
 export const Comment = (comment: MintComment) => {
   const { sender, username, timestamp, comment: commentText } = comment;
@@ -12,6 +13,7 @@ export const Comment = (comment: MintComment) => {
   const displayName = username || data?.username || truncatedAddress;
   const initial = displayName.charAt(0).toLowerCase();
   const timelineHref = `/${(sender as Address).toLowerCase()}`;
+  const hasText = Boolean(commentText?.trim());
 
   return (
     <div className="flex gap-3 border-t border-[#EDEAE2] py-[13px] first:border-t-0">
@@ -25,10 +27,15 @@ export const Comment = (comment: MintComment) => {
         {initial}
       </Link>
       <div className="min-w-0 flex-1">
-        {commentText && (
+        {hasText ? (
           <p className="mb-1 font-spectral text-[14.5px] leading-snug text-grey-moss-900">
             {commentText}
           </p>
+        ) : (
+          <div className="mb-1 inline-flex items-center gap-1.5 font-archivo text-[11.5px] text-[#8B8474]">
+            <Sparkles className="size-3 text-tan-gold" strokeWidth={1.75} />
+            collected
+          </div>
         )}
         <div className="flex flex-wrap items-baseline gap-2.5">
           <Link

--- a/components/MomentPage/CommentsContainer.tsx
+++ b/components/MomentPage/CommentsContainer.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 const CommentsContainer = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="no-scrollbar flex max-h-[360px] flex-col overflow-y-auto px-[18px] pb-3.5 pt-1">
+    <div className="no-scrollbar flex flex-col overflow-y-auto px-[18px] pb-3.5 pt-1 md:max-h-[360px]">
       {children}
     </div>
   );

--- a/components/MomentPage/Description.tsx
+++ b/components/MomentPage/Description.tsx
@@ -13,7 +13,7 @@ const Description = () => {
   return (
     <div className="mt-2.5 max-w-[560px]">
       <p
-        className={`font-spectral text-[15px] leading-normal text-grey-moss-400 ${
+        className={`font-spectral text-[13.5px] leading-normal text-grey-moss-400 md:text-[15px] ${
           !isExpanded && shouldTruncate ? "line-clamp-2" : ""
         }`}
       >

--- a/components/MomentPage/MomentActionCard.tsx
+++ b/components/MomentPage/MomentActionCard.tsx
@@ -3,9 +3,6 @@
 import { CircleDot, Link2, Share2, Download, Send } from "lucide-react";
 import Link from "next/link";
 import { Address } from "viem";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import CollectModalContents from "@/components/MomentPage/CollectModalContents";
 import AirdropProvider from "@/providers/AirdropProvider";
 import AddressChipInput from "@/components/SMSMomentPage/AddressChipInput";
 import RecentRecipientsRow from "@/components/SMSMomentPage/RecentRecipientsRow";
@@ -21,8 +18,6 @@ const MomentActionCard = () => {
     mode,
     setMode,
     copied,
-    isOpenCommentModal,
-    setIsOpenCommentModal,
     isLoading,
     metadata,
     owner,
@@ -41,117 +36,101 @@ const MomentActionCard = () => {
   if (isLoading || !metadata) return null;
 
   return (
-    <>
-      <div className={CARD_CLASS}>
-        {owner && (
-          <div className="mb-4 flex items-center gap-1.5">
-            <span className="font-archivo text-[12px] text-[#6B6456]">Created by</span>
-            <Link
-              href={`/${(owner as Address).toLowerCase()}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-archivo-medium text-[13px] text-grey-moss-900 hover:text-tan-gold"
-            >
-              {creatorName}
-            </Link>
-          </div>
-        )}
-
-        {canAirdrop && (
-          <div className="mb-4 flex gap-1 rounded-[11px] bg-[#F1EEE8] p-0.5">
-            {(
-              [
-                { key: "collect", label: "Collect", icon: CircleDot },
-                { key: "airdrop", label: "Airdrop", icon: Send },
-              ] as const
-            ).map(({ key, label, icon: Icon }) => {
-              const active = mode === key;
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  onClick={() => setMode(key)}
-                  className={cn(
-                    "flex flex-1 items-center justify-center gap-1.5 rounded-lg px-2 py-2 font-archivo-medium text-[12.5px] transition-colors",
-                    active
-                      ? "bg-white text-grey-moss-900 shadow-[0_1px_3px_rgba(27,21,4,.14)]"
-                      : "bg-transparent text-[#8B8474]"
-                  )}
-                >
-                  <Icon className="size-3.5" strokeWidth={1.75} />
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-        )}
-
-        {(!canAirdrop || mode === "collect") && (
-          <>
-            {priceLabel && (
-              <div className="mt-0.5 flex items-baseline gap-1.5">
-                <span className="font-['Archivo-Bold'] text-[42px] uppercase leading-none tracking-tight text-tan-gold">
-                  {priceLabel}
-                </span>
-                {priceUnit && (
-                  <span className="font-archivo-medium text-base uppercase text-tan-gold">
-                    {priceUnit}
-                  </span>
-                )}
-              </div>
-            )}
-            <button
-              type="button"
-              onClick={handleCollect}
-              disabled={isCollectDisabled}
-              className="mt-4 flex w-full items-center justify-center gap-2 rounded-full bg-grey-moss-900 py-3.5 font-archivo-medium text-base text-white shadow-[0_6px_16px_-8px_rgba(27,21,4,.28)] transition-all hover:bg-black hover:shadow-[0_8px_18px_-8px_rgba(27,21,4,.32)] active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-[#C7C1B4] disabled:text-[#F1EEE8] disabled:shadow-none disabled:active:scale-100"
-            >
-              <CircleDot className="size-[18px]" strokeWidth={1.75} />
-              {collectCtaLabel}
-            </button>
-          </>
-        )}
-
-        {canAirdrop && mode === "airdrop" && (
-          <AirdropProvider>
-            <AddressChipInput />
-            <RecentRecipientsRow />
-            <AirdropSubmitButton />
-            <RecipientSearchSheet />
-          </AirdropProvider>
-        )}
-
-        <div className="mt-5 flex gap-2">
-          <button type="button" onClick={handleCopyLink} className={PILL_BTN_CLASS}>
-            <Link2 className="size-[13px]" strokeWidth={1.75} />
-            {copied ? "Copied" : "Copy link"}
-          </button>
-          <button type="button" onClick={handleShare} className={PILL_BTN_CLASS}>
-            <Share2 className="size-[13px]" strokeWidth={1.75} />
-            Share
-          </button>
-          {balanceOf > 0 && (
-            <button
-              type="button"
-              onClick={download}
-              className={PILL_BTN_CLASS}
-              aria-label="Download"
-            >
-              <Download className="size-[13px]" strokeWidth={1.75} />
-            </button>
-          )}
+    <div className={CARD_CLASS}>
+      {owner && (
+        <div className="mb-4 flex items-center gap-1.5">
+          <span className="font-archivo text-[12px] text-[#6B6456]">Created by</span>
+          <Link
+            href={`/${(owner as Address).toLowerCase()}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-archivo-medium text-[13px] text-grey-moss-900 hover:text-tan-gold"
+          >
+            {creatorName}
+          </Link>
         </div>
-      </div>
+      )}
 
-      <Dialog open={isOpenCommentModal} onOpenChange={setIsOpenCommentModal}>
-        <DialogContent className="flex max-w-xl flex-col items-center !gap-0 overflow-hidden !rounded-3xl border-none !bg-white bg-transparent px-8 py-10 shadow-lg">
-          <VisuallyHidden>
-            <DialogTitle>Collect</DialogTitle>
-          </VisuallyHidden>
-          <CollectModalContents />
-        </DialogContent>
-      </Dialog>
-    </>
+      {canAirdrop && (
+        <div className="mb-4 flex gap-1 rounded-[11px] bg-[#F1EEE8] p-0.5">
+          {(
+            [
+              { key: "collect", label: "Collect", icon: CircleDot },
+              { key: "airdrop", label: "Airdrop", icon: Send },
+            ] as const
+          ).map(({ key, label, icon: Icon }) => {
+            const active = mode === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setMode(key)}
+                className={cn(
+                  "flex flex-1 items-center justify-center gap-1.5 rounded-lg px-2 py-2 font-archivo-medium text-[12.5px] transition-colors",
+                  active
+                    ? "bg-white text-grey-moss-900 shadow-[0_1px_3px_rgba(27,21,4,.14)]"
+                    : "bg-transparent text-[#8B8474]"
+                )}
+              >
+                <Icon className="size-3.5" strokeWidth={1.75} />
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {(!canAirdrop || mode === "collect") && (
+        <>
+          {priceLabel && (
+            <div className="mt-0.5 flex items-baseline gap-1.5">
+              <span className="font-['Archivo-Bold'] text-[42px] uppercase leading-none tracking-tight text-tan-gold">
+                {priceLabel}
+              </span>
+              {priceUnit && (
+                <span className="font-archivo-medium text-base uppercase text-tan-gold">
+                  {priceUnit}
+                </span>
+              )}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={handleCollect}
+            disabled={isCollectDisabled}
+            className="mt-4 flex w-full items-center justify-center gap-2 rounded-full bg-grey-moss-900 py-3.5 font-archivo-medium text-base text-white shadow-[0_6px_16px_-8px_rgba(27,21,4,.28)] transition-all hover:bg-black hover:shadow-[0_8px_18px_-8px_rgba(27,21,4,.32)] active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-[#C7C1B4] disabled:text-[#F1EEE8] disabled:shadow-none disabled:active:scale-100"
+          >
+            <CircleDot className="size-[18px]" strokeWidth={1.75} />
+            {collectCtaLabel}
+          </button>
+        </>
+      )}
+
+      {canAirdrop && mode === "airdrop" && (
+        <AirdropProvider>
+          <AddressChipInput />
+          <RecentRecipientsRow />
+          <AirdropSubmitButton />
+          <RecipientSearchSheet />
+        </AirdropProvider>
+      )}
+
+      <div className="mt-5 flex gap-2">
+        <button type="button" onClick={handleCopyLink} className={PILL_BTN_CLASS}>
+          <Link2 className="size-[13px]" strokeWidth={1.75} />
+          {copied ? "Copied" : "Copy link"}
+        </button>
+        <button type="button" onClick={handleShare} className={PILL_BTN_CLASS}>
+          <Share2 className="size-[13px]" strokeWidth={1.75} />
+          Share
+        </button>
+        {balanceOf > 0 && (
+          <button type="button" onClick={download} className={PILL_BTN_CLASS} aria-label="Download">
+            <Download className="size-[13px]" strokeWidth={1.75} />
+          </button>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/components/MomentPage/MomentActivityCard.tsx
+++ b/components/MomentPage/MomentActivityCard.tsx
@@ -28,7 +28,12 @@ const MomentActivityCard = () => {
   ];
 
   return (
-    <div className="overflow-hidden rounded-[10px] border border-[#E4E0D7] bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)]">
+    <div
+      className={cn(
+        "overflow-hidden bg-white",
+        "md:rounded-[10px] md:border md:border-[#E4E0D7] md:shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)]"
+      )}
+    >
       <div className="flex items-center gap-1 border-b border-[#DDD8CC] px-2">
         {tabs.map(({ key, label }) => {
           const active = activeTab === key;
@@ -38,7 +43,7 @@ const MomentActivityCard = () => {
               type="button"
               onClick={() => setTab(key)}
               className={cn(
-                "-mb-px border-b-2 px-3 pb-[13px] pt-3.5 font-archivo text-xs uppercase tracking-[0.06em] transition-colors hover:text-grey-moss-900",
+                "-mb-px border-b-2 px-3 pb-3 pt-[11px] font-archivo text-xs uppercase tracking-[0.06em] transition-colors hover:text-grey-moss-900 md:pb-[13px] md:pt-3.5",
                 active
                   ? "border-grey-moss-900 font-archivo-bold text-grey-moss-900"
                   : "border-transparent font-archivo-medium text-[#6B6456]"
@@ -53,7 +58,7 @@ const MomentActivityCard = () => {
       {activeTab === "comments" && showComments && <Comments />}
 
       {activeTab === "collectors" && (
-        <div className="flex max-h-[360px] flex-col overflow-y-auto px-3 py-1.5">
+        <div className="flex flex-col overflow-y-auto px-3 py-1.5 md:max-h-[360px]">
           {isLoading || transfers.length === 0 ? (
             <p className="px-2 py-6 font-archivo text-sm text-[#8B8474]">no collectors yet</p>
           ) : (

--- a/components/MomentPage/MomentAirdropAccordion.tsx
+++ b/components/MomentPage/MomentAirdropAccordion.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import AirdropProvider from "@/providers/AirdropProvider";
+import AddressChipInput from "@/components/SMSMomentPage/AddressChipInput";
+import RecentRecipientsRow from "@/components/SMSMomentPage/RecentRecipientsRow";
+import RecipientSearchSheet from "@/components/SMSMomentPage/RecipientSearchSheet";
+import AirdropSubmitButton from "@/components/SMSMomentPage/AirdropSubmitButton";
+import useCanAirdropMoment from "@/hooks/useCanAirdropMoment";
+import { cn } from "@/lib/utils";
+
+const MomentAirdropAccordion = () => {
+  const canAirdrop = useCanAirdropMoment();
+  const [open, setOpen] = useState(false);
+
+  if (!canAirdrop) return null;
+
+  return (
+    <div className="mt-4 overflow-hidden rounded-[12px] border border-[#E4E0D7] bg-white shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)] md:hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-2.5 bg-transparent px-4 py-3.5 text-grey-moss-900"
+      >
+        <span className="inline-flex items-center gap-2">
+          <span className="size-1.5 rounded-full bg-[#887bff] shadow-[0_0_8px_rgba(136,123,255,.7)]" />
+          <span className="font-archivo text-[10.5px] uppercase tracking-[0.1em] text-[#6B6456]">
+            airdrop
+          </span>
+        </span>
+        <ChevronDown
+          className={cn(
+            "size-4 text-[#8B8474] transition-transform duration-[180ms] ease-out",
+            open && "rotate-180"
+          )}
+          strokeWidth={1.75}
+        />
+      </button>
+      {open && (
+        <div className="px-4 pb-4">
+          <AirdropProvider>
+            <AddressChipInput />
+            <RecentRecipientsRow />
+            <AirdropSubmitButton />
+            <RecipientSearchSheet />
+          </AirdropProvider>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MomentAirdropAccordion;

--- a/components/MomentPage/MomentCollectBar.tsx
+++ b/components/MomentPage/MomentCollectBar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { CircleDot } from "lucide-react";
+import useMomentActionCard from "@/hooks/useMomentActionCard";
+
+const MomentCollectBar = () => {
+  const {
+    isLoading,
+    metadata,
+    priceLabel,
+    priceUnit,
+    isCollectDisabled,
+    collectCtaLabel,
+    handleCollect,
+  } = useMomentActionCard();
+
+  if (isLoading || !metadata) return null;
+
+  return (
+    <div className="fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 z-[55] flex items-center gap-3 border-t border-[#E4E0D7] bg-white px-[18px] py-2.5 md:hidden">
+      {priceLabel && (
+        <div className="flex min-w-[4.5rem] shrink-0 flex-col justify-center">
+          <div className="flex items-baseline gap-1">
+            <span className="font-['Archivo-Bold'] text-[24px] uppercase leading-none tracking-tight text-tan-gold">
+              {priceLabel}
+            </span>
+            {priceUnit && (
+              <span className="font-archivo-medium text-xs uppercase text-tan-gold">
+                {priceUnit}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={handleCollect}
+        disabled={isCollectDisabled}
+        className="flex flex-1 items-center justify-center gap-1.5 rounded-[11px] bg-grey-moss-900 px-3 py-3 font-archivo-medium text-sm text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:bg-[#C7C1B4] disabled:text-[#F1EEE8]"
+      >
+        <CircleDot className="size-4" strokeWidth={1.75} />
+        {collectCtaLabel}
+      </button>
+    </div>
+  );
+};
+
+export default MomentCollectBar;

--- a/components/MomentPage/MomentCollectDialog.tsx
+++ b/components/MomentPage/MomentCollectDialog.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import CollectModalContents from "@/components/MomentPage/CollectModalContents";
+import { useMomentCommentsProvider } from "@/providers/MomentCommentsProvider";
+
+const MomentCollectDialog = () => {
+  const { isOpenCommentModal, setIsOpenCommentModal } = useMomentCommentsProvider();
+
+  return (
+    <Dialog open={isOpenCommentModal} onOpenChange={setIsOpenCommentModal}>
+      <DialogContent className="flex max-w-xl flex-col items-center !gap-0 overflow-hidden !rounded-3xl border-none !bg-white bg-transparent px-8 py-10 shadow-lg">
+        <VisuallyHidden>
+          <DialogTitle>Collect</DialogTitle>
+        </VisuallyHidden>
+        <CollectModalContents />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MomentCollectDialog;

--- a/components/MomentPage/MomentLayout.tsx
+++ b/components/MomentPage/MomentLayout.tsx
@@ -5,21 +5,39 @@ import MomentMeta from "./MomentMeta";
 import MomentMediaFrame from "./MomentMediaFrame";
 import MomentActionCard from "./MomentActionCard";
 import MomentActivityCard from "./MomentActivityCard";
+import MomentCollectBar from "./MomentCollectBar";
+import MomentAirdropAccordion from "./MomentAirdropAccordion";
+import MomentCollectDialog from "./MomentCollectDialog";
 
 const MomentLayout = () => {
   return (
-    <div className="mx-auto w-full max-w-[1080px] px-3 pb-20 pt-2 md:px-10">
+    <div className="mx-auto w-full max-w-[1080px] px-[18px] pb-[88px] pt-2 md:px-10 md:pb-20">
       <BackToTimeline />
-      <div className="flex flex-col gap-10 md:flex-row md:items-start">
-        <div className="flex min-w-0 flex-1 flex-col gap-4">
-          <MomentMeta />
-          <MomentMediaFrame />
+
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-10">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex flex-col md:gap-4">
+            <div className="order-2 md:order-1">
+              <MomentMeta />
+            </div>
+            <div className="order-1 md:order-2">
+              <MomentMediaFrame />
+            </div>
+          </div>
+          <MomentAirdropAccordion />
+          <div className="order-3 mt-[18px] md:hidden">
+            <MomentActivityCard />
+          </div>
         </div>
-        <div className="flex w-full shrink-0 flex-col gap-4 md:sticky md:top-24 md:w-[340px]">
+
+        <div className="hidden w-full shrink-0 flex-col gap-4 md:sticky md:top-24 md:flex md:w-[340px]">
           <MomentActionCard />
           <MomentActivityCard />
         </div>
       </div>
+
+      <MomentCollectBar />
+      <MomentCollectDialog />
     </div>
   );
 };

--- a/components/MomentPage/MomentMediaFrame.tsx
+++ b/components/MomentPage/MomentMediaFrame.tsx
@@ -9,8 +9,8 @@ const MomentMediaFrame = () => {
   if (!metadata) return null;
 
   return (
-    <div className="relative w-full max-w-[520px] overflow-hidden rounded-[12px] border border-[#E4E0D7] bg-[repeating-linear-gradient(45deg,#F1EEE8_0_12px,#EAE6DD_12px_24px)] shadow-[0_10px_34px_-14px_rgba(27,21,4,.32)]">
-      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain">
+    <div className="relative w-full max-w-none overflow-hidden rounded-[12px] border border-[#E4E0D7] bg-[repeating-linear-gradient(45deg,#F1EEE8_0_12px,#EAE6DD_12px_24px)] shadow-[0_8px_26px_-12px_rgba(27,21,4,.3)] md:max-w-[520px] md:shadow-[0_10px_34px_-14px_rgba(27,21,4,.32)]">
+      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral md:max-h-[calc(100vh-260px)] [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain">
         <ContentRenderer
           metadata={metadata}
           variant="natural"

--- a/components/MomentPage/MomentMeta.tsx
+++ b/components/MomentPage/MomentMeta.tsx
@@ -5,7 +5,7 @@ import Title from "./Title";
 
 const MomentMeta = () => {
   return (
-    <div>
+    <div className="mt-4 md:mt-0">
       <Title />
       <Description />
     </div>

--- a/components/MomentPage/MomentPage.tsx
+++ b/components/MomentPage/MomentPage.tsx
@@ -22,7 +22,7 @@ const MomentPage = () => {
 
   return (
     <main className="flex w-screen grow">
-      <div className="flex w-full flex-col pt-12 md:pt-14">
+      <div className="flex w-full flex-col pt-6 md:pt-8">
         <MomentProvider
           moment={{
             collectionAddress: address as Address,

--- a/components/MomentPage/Title.tsx
+++ b/components/MomentPage/Title.tsx
@@ -6,7 +6,7 @@ const Title = () => {
   if (!metadata) return null;
 
   return (
-    <h1 className="line-clamp-2 font-spectral text-[26px] leading-[1.15] tracking-tight text-grey-moss-900">
+    <h1 className="line-clamp-2 font-spectral text-[24px] leading-[1.15] tracking-tight text-grey-moss-900 md:text-[26px]">
       {truncated(metadata.name, 100)}
     </h1>
   );


### PR DESCRIPTION
## Summary
- Restructures the moment page for mobile into a single-column scroll with media, meta, optional airdrop accordion, and activity tabs
- Adds a fixed white collect bar above the footer (price + Collect CTA) and shares one collect dialog across mobile/desktop
- Keeps the desktop two-column action/activity cards; softens mobile activity chrome while preserving white backgrounds and padding

## Test plan
- [ ] Mobile: back link shows `BACK TO … TIMELINE` without extra bottom margin; share icon is absent
- [ ] Mobile: media appears above title/description; comments/collectors sit on white with horizontal padding
- [ ] Mobile: collect bar is white, price ~24px, Collect button height feels balanced with price
- [ ] Mobile admin: airdrop accordion expands and submits
- [ ] Desktop: two-column layout, action card, and collect flow unchanged
- [ ] Collect success still shows toast + confetti without swapping the action UI


Made with [Cursor](https://cursor.com)