### PR TITLE
Fix broken emoji rendering in moment comments

### DIFF
--- a/components/MomentPage/Comment.tsx
+++ b/components/MomentPage/Comment.tsx
@@ -28,7 +28,7 @@ export const Comment = (comment: MintComment) => {
       </Link>
       <div className="min-w-0 flex-1">
         {hasText ? (
-          <p className="mb-1 font-spectral text-[14.5px] leading-snug text-grey-moss-900">
+          <p className="mb-1 font-spectral text-[14.5px] leading-snug text-grey-moss-900 [font-variant-emoji:emoji]">
             {commentText}
           </p>
         ) : (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 
+// Color emoji fonts must sit after the brand face so ZWJ sequences (e.g. 🙂‍↔️)
+// fall back instead of rendering as .notdef tofu from Spectral/Archivo/sans-serif.
+const emojiFallback = ["Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Android Emoji"];
+
 module.exports = {
   darkMode: ["class"],
   content: [
@@ -60,15 +64,15 @@ module.exports = {
         },
       },
       fontFamily: {
-        nounish: ["LondrinaSolid-Regular", "sans-serif"],
-        archivo: ["Archivo-Regular", "sans-serif"],
-        "archivo-medium": ["Archivo-Medium", "sans-serif"],
-        "archivo-bold": ["Archivo-Medium", "sans-serif"],
-        "spectral-italic": ["Spectral-Italic", "sans-serif"],
-        spectral: ["Spectral-Regular", "sans-serif"],
-        "spectral-medium": ["Spectral-Medium", "sans-serif"],
-        "spectral-bold": ["Spectral-Bold", "sans-serif"],
-        "spectral-medium-italic": ["Spectral-MediumItalic", "sans-serif"],
+        nounish: ["LondrinaSolid-Regular", ...emojiFallback, "sans-serif"],
+        archivo: ["Archivo-Regular", ...emojiFallback, "sans-serif"],
+        "archivo-medium": ["Archivo-Medium", ...emojiFallback, "sans-serif"],
+        "archivo-bold": ["Archivo-Medium", ...emojiFallback, "sans-serif"],
+        "spectral-italic": ["Spectral-Italic", ...emojiFallback, "sans-serif"],
+        spectral: ["Spectral-Regular", ...emojiFallback, "sans-serif"],
+        "spectral-medium": ["Spectral-Medium", ...emojiFallback, "sans-serif"],
+        "spectral-bold": ["Spectral-Bold", ...emojiFallback, "sans-serif"],
+        "spectral-medium-italic": ["Spectral-MediumItalic", ...emojiFallback, "sans-serif"],
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- Adds color emoji font fallbacks (`Apple Color Emoji`, `Segoe UI Emoji`, `Noto Color Emoji`, `Android Emoji`) to brand font stacks so ZWJ sequences like `🙂‍↔️` no longer render as tofu
- Forces emoji presentation on comment body text via `font-variant-emoji: emoji`

## Test plan
- [ ] Open a moment with a comment containing `🙂‍↔️` and confirm it renders (not □)
- [ ] Spot-check simple emojis (🙂 ❤️) in comments
- [ ] Confirm Spectral/Archivo typography for non-emoji text is unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji rendering and appearance in comments.
  * Added consistent emoji font fallbacks across the application’s typography styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->