### PR TITLE
Update web clients to use top-level /comments API

### DIFF
--- a/lib/moment/createCommentApi.ts
+++ b/lib/moment/createCommentApi.ts
@@ -24,7 +24,7 @@ export const createCommentApi = async ({
   headers,
 }: CreateCommentInput): Promise<string> => {
   try {
-    const path = `${IN_PROCESS_API}/moment/comments/eip155:${moment.chainId}/erc1155:${moment.collectionAddress}`;
+    const path = `${IN_PROCESS_API}/comments/eip155:${moment.chainId}/erc1155:${moment.collectionAddress}`;
     const response = await fetch(path, {
       method: "POST",
       headers: buildHeaders(headers),

--- a/lib/moment/fetchComments.ts
+++ b/lib/moment/fetchComments.ts
@@ -11,7 +11,7 @@ async function fetchComments({ moment, offset }: MomentCommentsInput): Promise<C
       offset: offset?.toString() || "0",
     });
 
-    const response = await fetch(`${IN_PROCESS_API}/moment/comments?${queryString}`);
+    const response = await fetch(`${IN_PROCESS_API}/comments?${queryString}`);
 
     if (!response.ok) {
       throw new Error("Failed to fetch comments.");

--- a/lib/moment/fetchReplies.ts
+++ b/lib/moment/fetchReplies.ts
@@ -20,7 +20,7 @@ async function fetchReplies({
       replyToId,
     });
 
-    const response = await fetch(`${IN_PROCESS_API}/moment/comments?${queryString}`);
+    const response = await fetch(`${IN_PROCESS_API}/comments?${queryString}`);
 
     if (!response.ok) {
       throw new Error("Failed to fetch replies.");


### PR DESCRIPTION
## Summary
- Point `fetchComments`, `fetchReplies`, and `createCommentApi` at `/comments` instead of `/moment/comments`

Pairs with:
- API: https://github.com/sweetmantech/in_process_api/pull/423
- Docs: https://github.com/sweetmantech/in_process_docs/pull/130

## Test plan
- [ ] Load moment comments list
- [ ] Expand / paginate replies
- [ ] Create a top-level comment
- [ ] Create a reply
- [ ] No remaining `/moment/comments` references in web


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated comment and reply requests to use the current API endpoint.
  * Improved compatibility for creating ERC1155 comments and retrieving comment threads without changing existing response or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->