### PR TITLE
fix: keep moment page media fully visible in frame

### DIFF
--- a/components/MomentPage/MomentMediaFrame.tsx
+++ b/components/MomentPage/MomentMediaFrame.tsx
@@ -10,7 +10,7 @@ const MomentMediaFrame = () => {
 
   return (
     <div className="relative w-full max-w-none overflow-hidden rounded-[12px] border border-[#E4E0D7] bg-[repeating-linear-gradient(45deg,#F1EEE8_0_12px,#EAE6DD_12px_24px)] shadow-[0_8px_26px_-12px_rgba(27,21,4,.3)] md:max-w-[520px] md:shadow-[0_10px_34px_-14px_rgba(27,21,4,.32)]">
-      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral md:max-h-[calc(100vh-260px)] [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain">
+      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral [&_iframe]:aspect-video [&_iframe]:h-auto [&_iframe]:max-h-[calc(100vh-260px)] [&_iframe]:w-full [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain [&_video]:h-auto [&_video]:max-h-[calc(100vh-260px)] [&_video]:w-full [&_video]:object-contain [&_.pdf-viewer-root]:!h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!max-h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!min-h-0">
         <ContentRenderer
           metadata={metadata}
           variant="natural"

--- a/components/Renderers/PdfViewer.tsx
+++ b/components/Renderers/PdfViewer.tsx
@@ -10,7 +10,7 @@ interface PdfViewerProps {
 const PdfViewer = ({ fileUrl }: PdfViewerProps) => {
   const defaultLayoutPluginInstance = defaultLayoutPlugin();
   return (
-    <div className="size-full min-h-[200px] min-w-[300px]">
+    <div className="pdf-viewer-root size-full min-h-[200px] min-w-[300px]">
       <Worker workerUrl={`https://unpkg.com/pdfjs-dist@${PDFJS_DIST_VERSION}/build/pdf.worker.js`}>
         <Viewer fileUrl={fileUrl} plugins={[defaultLayoutPluginInstance]} />
       </Worker>

--- a/components/VideoPlayer/VideoPlayer.tsx
+++ b/components/VideoPlayer/VideoPlayer.tsx
@@ -34,8 +34,10 @@ const VideoPlayer = ({ url, thumbnail, variant = "fill", onError }: VideoPlayerP
     );
   }
 
+  const isNatural = variant === "natural";
+
   return (
-    <div className="flex size-full justify-center">
+    <div className={`flex justify-center ${isNatural ? "max-h-full w-full" : "size-full"}`}>
       {!isLoaded && (
         <VideoPreview
           thumbnail={thumbnail}
@@ -49,7 +51,9 @@ const VideoPlayer = ({ url, thumbnail, variant = "fill", onError }: VideoPlayerP
       <video
         ref={videoRef}
         controls
-        className={`w-full rounded-md bg-grey-moss-900 ${!isLoaded ? "absolute inset-0 opacity-0" : ""}`}
+        className={`rounded-md bg-grey-moss-900 ${
+          isNatural ? "h-auto max-h-full w-full object-contain" : "w-full"
+        } ${!isLoaded ? "absolute inset-0 opacity-0" : ""}`}
         onClick={stopPropagation}
         onMouseDown={stopPropagation}
         onPointerDown={stopPropagation}


### PR DESCRIPTION
## Summary
- Extend `MomentMediaFrame` contain rules beyond images to video, iframe, and PDF
- For `natural` videos, use `object-contain` so playback controls stay inside the frame
- Tag `PdfViewer` root so the moment frame can cap its height

## Test plan
- [ ] Moment page: play a tall/portrait video — full frame + controls visible
- [ ] Moment page: image still fits with contain
- [ ] Moment page: PDF stays within the media frame
- [ ] Moment page: YouTube embed fits width/aspect without overflow crop
- [ ] Home feed card: media still renders at natural size (no unintended shrink)


Made with [Cursor](https://cursor.com)