### PR TITLE
Feed comment icon: open free comment modal (not collect)

### DIFF
--- a/components/HomePage/CommentDrawer.tsx
+++ b/components/HomePage/CommentDrawer.tsx
@@ -11,15 +11,16 @@ import { getMomentSeed } from "@/lib/moment/getMomentSeed";
 import { MomentCommentsProvider } from "@/providers/MomentCommentsProvider";
 import { MomentProvider } from "@/providers/MomentProvider";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
+import { useTimelineProvider } from "@/providers/TimelineProvider";
 import { cn } from "@/lib/utils";
 
 const headerClass =
   "flex shrink-0 items-center justify-between gap-3 border-b border-[#DDD8CC] px-[18px] pb-3 pt-4";
-const titleClass =
-  "font-archivo-bold text-xs uppercase tracking-[0.06em] text-grey-moss-900";
+const titleClass = "font-archivo-bold text-xs uppercase tracking-[0.06em] text-grey-moss-900";
 
 const CommentDrawer = () => {
   const { isDrawerOpen, commentMoment, closeDrawer } = useMobileDrawersProvider();
+  const { moments } = useTimelineProvider();
   const isOpen = isDrawerOpen("comment");
   const isMobile = useIsMobile();
   const [mounted, setMounted] = useState(false);
@@ -29,7 +30,8 @@ const CommentDrawer = () => {
   if (!commentMoment) return null;
 
   const moment = getMomentKey(commentMoment);
-  const commentCount = commentMoment.comments ?? 0;
+  const commentCount =
+    moments.find((entry) => entry.id === commentMoment.id)?.comments ?? commentMoment.comments ?? 0;
   const title = commentCount > 0 ? `comments (${commentCount.toLocaleString()})` : "comments";
 
   const closeButton = (

--- a/components/HomePage/CommentDrawer.tsx
+++ b/components/HomePage/CommentDrawer.tsx
@@ -1,44 +1,76 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import CommentComposer from "@/components/MomentPage/CommentComposer";
+import Comments from "@/components/MomentPage/Comments";
+import useIsMobile from "@/hooks/useIsMobile";
 import { getMomentKey } from "@/lib/moment/getMomentKey";
 import { getMomentSeed } from "@/lib/moment/getMomentSeed";
 import { MomentCommentsProvider } from "@/providers/MomentCommentsProvider";
 import { MomentProvider } from "@/providers/MomentProvider";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { cn } from "@/lib/utils";
 
 const CommentDrawer = () => {
   const { isDrawerOpen, commentMoment, closeDrawer } = useMobileDrawersProvider();
   const isOpen = isDrawerOpen("comment");
+  const isMobile = useIsMobile();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
 
   if (!commentMoment) return null;
 
   const moment = getMomentKey(commentMoment);
+  const commentCount = commentMoment.comments ?? 0;
+  const title = commentCount > 0 ? `comments (${commentCount.toLocaleString()})` : "comments";
 
-  return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && closeDrawer()}>
-      <DialogContent className="flex w-[calc(100%-2rem)] max-w-sm flex-col !gap-0 overflow-hidden !rounded-lg border-none !bg-white px-5 py-5 shadow-lg">
-        <VisuallyHidden>
-          <DialogTitle>Comment</DialogTitle>
-        </VisuallyHidden>
-        <MomentProvider
-          key={commentMoment.id}
-          moment={moment}
-          initialData={getMomentSeed(commentMoment)}
-        >
-          <MomentCommentsProvider>
-            <CommentComposer
-              placeholder="add a comment…"
-              submitLabel="add comment"
-              autoFocus
-              onSuccess={closeDrawer}
-            />
-          </MomentCommentsProvider>
-        </MomentProvider>
-      </DialogContent>
-    </Dialog>
+  const body = (
+    <MomentProvider
+      key={commentMoment.id}
+      moment={moment}
+      initialData={getMomentSeed(commentMoment)}
+    >
+      <MomentCommentsProvider>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <Comments />
+        </div>
+      </MomentCommentsProvider>
+    </MomentProvider>
+  );
+
+  if (!isMobile) {
+    return (
+      <Dialog open={isOpen} onOpenChange={(open) => !open && closeDrawer()}>
+        <DialogContent className="flex h-[min(85vh,640px)] w-[calc(100%-2rem)] max-w-md flex-col !gap-0 overflow-hidden !rounded-lg border-none !bg-white p-0 shadow-lg">
+          <DialogTitle className="shrink-0 border-b border-[#DDD8CC] px-[18px] pb-3 pt-4 text-left font-archivo-bold text-xs uppercase tracking-[0.06em] text-grey-moss-900">
+            {title}
+          </DialogTitle>
+          {body}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className={cn(
+        "fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 top-0 z-50 flex flex-col overflow-hidden bg-white transition-transform duration-300 ease-out will-change-transform",
+        isOpen ? "translate-y-0" : "pointer-events-none translate-y-[2000px]"
+      )}
+    >
+      <h2 className="shrink-0 border-b border-[#DDD8CC] px-[18px] pb-3 pt-4 font-archivo-bold text-xs uppercase tracking-[0.06em] text-grey-moss-900">
+        {title}
+      </h2>
+      {body}
+    </div>,
+    document.body
   );
 };
 

--- a/components/HomePage/CommentDrawer.tsx
+++ b/components/HomePage/CommentDrawer.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import CollectModalContents from "@/components/MomentPage/CollectModalContents";
+import CommentComposer from "@/components/MomentPage/CommentComposer";
 import { getMomentKey } from "@/lib/moment/getMomentKey";
 import { getMomentSeed } from "@/lib/moment/getMomentSeed";
-import { MomentCollectProvider } from "@/providers/MomentCollectProvider";
 import { MomentCommentsProvider } from "@/providers/MomentCommentsProvider";
 import { MomentProvider } from "@/providers/MomentProvider";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
@@ -20,9 +19,9 @@ const CommentDrawer = () => {
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && closeDrawer()}>
-      <DialogContent className="flex max-w-xl flex-col items-center !gap-0 overflow-hidden !rounded-lg border-none !bg-white bg-transparent px-8 py-10 shadow-lg">
+      <DialogContent className="flex w-[calc(100%-2rem)] max-w-sm flex-col !gap-0 overflow-hidden !rounded-lg border-none !bg-white px-5 py-5 shadow-lg">
         <VisuallyHidden>
-          <DialogTitle>Collect</DialogTitle>
+          <DialogTitle>Comment</DialogTitle>
         </VisuallyHidden>
         <MomentProvider
           key={commentMoment.id}
@@ -30,9 +29,12 @@ const CommentDrawer = () => {
           initialData={getMomentSeed(commentMoment)}
         >
           <MomentCommentsProvider>
-            <MomentCollectProvider>
-              <CollectModalContents />
-            </MomentCollectProvider>
+            <CommentComposer
+              placeholder="add a comment…"
+              submitLabel="add comment"
+              autoFocus
+              onSuccess={closeDrawer}
+            />
           </MomentCommentsProvider>
         </MomentProvider>
       </DialogContent>

--- a/components/HomePage/CommentDrawer.tsx
+++ b/components/HomePage/CommentDrawer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { X } from "lucide-react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import Comments from "@/components/MomentPage/Comments";
 import useIsMobile from "@/hooks/useIsMobile";
@@ -11,6 +12,11 @@ import { MomentCommentsProvider } from "@/providers/MomentCommentsProvider";
 import { MomentProvider } from "@/providers/MomentProvider";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
 import { cn } from "@/lib/utils";
+
+const headerClass =
+  "flex shrink-0 items-center justify-between gap-3 border-b border-[#DDD8CC] px-[18px] pb-3 pt-4";
+const titleClass =
+  "font-archivo-bold text-xs uppercase tracking-[0.06em] text-grey-moss-900";
 
 const CommentDrawer = () => {
   const { isDrawerOpen, commentMoment, closeDrawer } = useMobileDrawersProvider();
@@ -25,6 +31,17 @@ const CommentDrawer = () => {
   const moment = getMomentKey(commentMoment);
   const commentCount = commentMoment.comments ?? 0;
   const title = commentCount > 0 ? `comments (${commentCount.toLocaleString()})` : "comments";
+
+  const closeButton = (
+    <button
+      type="button"
+      onClick={closeDrawer}
+      aria-label="Close comments"
+      className="flex shrink-0 items-center text-grey-moss-400 active:opacity-70"
+    >
+      <X className="size-5" strokeWidth={1.5} />
+    </button>
+  );
 
   const body = (
     <MomentProvider
@@ -44,9 +61,10 @@ const CommentDrawer = () => {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && closeDrawer()}>
         <DialogContent className="flex h-[min(85vh,640px)] w-[calc(100%-2rem)] max-w-md flex-col !gap-0 overflow-hidden !rounded-lg border-none !bg-white p-0 shadow-lg">
-          <DialogTitle className="shrink-0 border-b border-[#DDD8CC] px-[18px] pb-3 pt-4 text-left font-archivo-bold text-xs uppercase tracking-[0.06em] text-grey-moss-900">
-            {title}
-          </DialogTitle>
+          <div className={headerClass}>
+            <DialogTitle className={cn(titleClass, "text-left")}>{title}</DialogTitle>
+            {closeButton}
+          </div>
           {body}
         </DialogContent>
       </Dialog>
@@ -65,9 +83,10 @@ const CommentDrawer = () => {
         isOpen ? "translate-y-0" : "pointer-events-none translate-y-[2000px]"
       )}
     >
-      <h2 className="shrink-0 border-b border-[#DDD8CC] px-[18px] pb-3 pt-4 font-archivo-bold text-xs uppercase tracking-[0.06em] text-grey-moss-900">
-        {title}
-      </h2>
+      <div className={headerClass}>
+        <h2 className={titleClass}>{title}</h2>
+        {closeButton}
+      </div>
       {body}
     </div>,
     document.body

--- a/hooks/useCreateMomentComment.ts
+++ b/hooks/useCreateMomentComment.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 import { Address } from "viem";
 import { toast } from "sonner";
 import { useAuthorizationProvider } from "@/providers/AuthorizationProvider";
@@ -7,7 +8,9 @@ import { useUserProvider } from "@/providers/UserProvider";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import isCommentHolderError from "@/lib/errors/isCommentHolderError";
 import { createCommentApi, CreateCommentReplyTo } from "@/lib/moment/createCommentApi";
+import { bumpTimelineCommentCount } from "@/lib/timeline/bumpTimelineCommentCount";
 import { MintComment } from "@/types/moment";
+import { TimelineResponse } from "@/types/timeline";
 
 export type SubmitCommentArgs = {
   text: string;
@@ -26,6 +29,7 @@ const useCreateMomentComment = ({ addComment, addReply }: UseCreateMomentComment
   const { getAuthHeaders } = useAuthorizationProvider();
   const { isPrepared, username } = useUserProvider();
   const { primaryWallet } = useWalletsProvider();
+  const queryClient = useQueryClient();
 
   const submitComment = useCallback(
     async ({ text, parent }: SubmitCommentArgs): Promise<boolean> => {
@@ -84,6 +88,10 @@ const useCreateMomentComment = ({ addComment, addReply }: UseCreateMomentComment
           addComment(optimistic);
         }
 
+        queryClient.setQueriesData<InfiniteData<TimelineResponse>>(
+          { queryKey: ["timeline"] },
+          (data) => bumpTimelineCommentCount(data, moment)
+        );
         toast.success(parent ? "reply posted" : "comment posted");
         return true;
       } catch (error: unknown) {
@@ -97,7 +105,7 @@ const useCreateMomentComment = ({ addComment, addReply }: UseCreateMomentComment
         setIsSubmitting(false);
       }
     },
-    [addComment, addReply, getAuthHeaders, isPrepared, moment, primaryWallet, username]
+    [addComment, addReply, getAuthHeaders, isPrepared, moment, primaryWallet, queryClient, username]
   );
 
   return { submitComment, isSubmitting };

--- a/lib/timeline/bumpTimelineCommentCount.ts
+++ b/lib/timeline/bumpTimelineCommentCount.ts
@@ -1,0 +1,27 @@
+import { InfiniteData } from "@tanstack/react-query";
+import { Moment } from "@/types/moment";
+import { TimelineResponse } from "@/types/timeline";
+
+/** Optimistic +1 for feed comment counts — indexer lag means invalidate alone is too early. */
+export const bumpTimelineCommentCount = (
+  data: InfiniteData<TimelineResponse> | undefined,
+  moment: Moment
+): InfiniteData<TimelineResponse> | undefined => {
+  if (!data) return data;
+
+  const address = moment.collectionAddress.toLowerCase();
+
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      moments: page.moments.map((entry) =>
+        entry.address.toLowerCase() === address &&
+        entry.token_id === moment.tokenId &&
+        entry.chain_id === moment.chainId
+          ? { ...entry, comments: (entry.comments ?? 0) + 1 }
+          : entry
+      ),
+    })),
+  };
+};


### PR DESCRIPTION
## Summary
- Replace feed `CommentDrawer` collect UI with a simple free-comment composer (`CommentComposer`)
- Post comments via the existing comments API; close the modal on success
- Leave collect button / collect drawer unchanged

## Test plan
- [ ] On home feed, tap comment icon on an In Process moment → comment modal (textarea + add comment), not collect
- [ ] Submit a comment while holding the moment → success toast and modal closes
- [ ] Submit without holding → holder error toast; collect flow still available from Collect button
- [ ] Collect button still opens collect confirmation modal


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the comment drawer to render comments instead of the prior collect flow, with a comment-count header and close controls.
  * Improved responsiveness: desktop uses a dialog, while mobile uses an overlay with hydration-safe mounting and smooth open/close behavior.
* **Improvements**
  * Enhanced comment posting/replying with React Query cache updates to optimistically bump the timeline comment count for affected moments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->