### PR TITLE
Mobile footer: replace Home with centered Create (+)

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { House } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
 import NotificationButton from "@/components/NotificationButton";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
@@ -8,33 +8,46 @@ import { useWalletsProvider } from "@/providers/WalletsProvider";
 import UserDrawer from "@/components/Footer/UserDrawer";
 import FeedbackDrawer from "@/components/Footer/FeedbackDrawer";
 import SearchDrawer from "@/components/ArtistSearch/SearchDrawer";
+import { cn } from "@/lib/utils";
 
 const Footer = () => {
   const { push } = useRouter();
   const pathname = usePathname();
   const { closeDrawer } = useMobileDrawersProvider();
   const { primaryWallet } = useWalletsProvider();
+  const isCreatePage = pathname.startsWith("/create");
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-[60] border-t border-[#EDEAE2] bg-white pb-[env(safe-area-inset-bottom,0px)]">
-      <div className="flex h-[74px] items-center justify-around px-[30px]">
+      <div className="relative flex h-[74px] items-center px-5">
+        <div className="flex flex-1 items-center justify-evenly">
+          <SearchDrawer />
+          {primaryWallet ? (
+            <NotificationButton onClick={closeDrawer} />
+          ) : (
+            <span className="inline-block h-[23px] w-[23px]" aria-hidden />
+          )}
+        </div>
+
         <button
           type="button"
+          aria-label="Create"
           onClick={() => {
             closeDrawer();
-            push("/");
+            push("/create");
           }}
+          className={cn(
+            "absolute left-1/2 top-0 z-10 flex h-14 w-14 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full shadow-[0_4px_14px_-4px_rgba(27,21,4,.35)] transition-opacity active:opacity-80",
+            isCreatePage ? "bg-tan-gold text-white" : "bg-grey-moss-900 text-white"
+          )}
         >
-          <House
-            className="h-[23px] w-[23px]"
-            strokeWidth={1.75}
-            color={pathname === "/" ? "#1B1504" : "#B6B2A8"}
-          />
+          <Plus className="h-7 w-7" strokeWidth={2.25} />
         </button>
-        <SearchDrawer />
-        {primaryWallet && <NotificationButton onClick={closeDrawer} />}
-        <FeedbackDrawer />
-        <UserDrawer />
+
+        <div className="flex flex-1 items-center justify-evenly">
+          <FeedbackDrawer />
+          <UserDrawer />
+        </div>
       </div>
     </div>
   );

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { House, Plus } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
 import NotificationButton from "@/components/NotificationButton";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
@@ -16,18 +16,37 @@ const Footer = () => {
   const { closeDrawer } = useMobileDrawersProvider();
   const { primaryWallet } = useWalletsProvider();
   const isCreatePage = pathname.startsWith("/create");
+  const isHomePage = pathname === "/";
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-[60] border-t border-[#EDEAE2] bg-white pb-[env(safe-area-inset-bottom,0px)]">
-      <div className="relative flex h-[74px] items-center px-5">
-        <div className="flex flex-1 items-center justify-evenly">
-          <SearchDrawer />
-          {primaryWallet ? (
+      <div className="relative flex h-[74px] items-center justify-between px-8">
+        {primaryWallet ? (
+          <>
+            <SearchDrawer />
             <NotificationButton onClick={closeDrawer} />
-          ) : (
-            <span className="inline-block h-[23px] w-[23px]" aria-hidden />
-          )}
-        </div>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              aria-label="Home"
+              onClick={() => {
+                closeDrawer();
+                push("/");
+              }}
+            >
+              <House
+                className="h-[23px] w-[23px]"
+                strokeWidth={1.75}
+                color={isHomePage ? "#1B1504" : "#B6B2A8"}
+              />
+            </button>
+            <SearchDrawer />
+          </>
+        )}
+
+        <span className="w-20 shrink-0" aria-hidden />
 
         <button
           type="button"
@@ -37,17 +56,15 @@ const Footer = () => {
             push("/create");
           }}
           className={cn(
-            "absolute left-1/2 top-0 z-10 flex h-14 w-14 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full shadow-[0_4px_14px_-4px_rgba(27,21,4,.35)] transition-opacity active:opacity-80",
+            "absolute left-1/2 top-0 z-10 flex h-20 w-20 -translate-x-1/2 -translate-y-[26%] items-center justify-center rounded-full border-4 border-white shadow-[0_4px_14px_-4px_rgba(27,21,4,.35)] transition-opacity active:opacity-80",
             isCreatePage ? "bg-tan-gold text-white" : "bg-grey-moss-900 text-white"
           )}
         >
-          <Plus className="h-7 w-7" strokeWidth={2.25} />
+          <Plus className="h-9 w-9" strokeWidth={2} />
         </button>
 
-        <div className="flex flex-1 items-center justify-evenly">
-          <FeedbackDrawer />
-          <UserDrawer />
-        </div>
+        <FeedbackDrawer />
+        <UserDrawer />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove the Home icon from the mobile footer
- Split remaining actions into left (Search, Notifications) and right (Feedback, User)
- Add a protruding circular Create (+) control that navigates to `/create`

## Test plan
- [ ] Mobile footer shows 2 icons left, Create in center, 2 icons right
- [ ] Home icon is gone
- [ ] Tapping Create closes any open drawer and opens `/create`
- [ ] Create button protrudes above the footer bar
- [ ] Logged out: layout stays balanced without Notifications
- [ ] Search, Notifications, Feedback, and User still work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centered Create button to the bottom navigation.
  * Updated navigation controls to provide context-sensitive Home and Create states.
  * Added notification access for users with a connected wallet.
  * Improved bottom navigation layout and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->