### PR TITLE
Desktop header: add Create button and restyle account/sign-in

### DIFF
--- a/components/Header/HeaderActions.tsx
+++ b/components/Header/HeaderActions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import LoginButton from "../LoginButton";
+import HeaderCreateButton from "./HeaderCreateButton";
 import { DropdownMenu } from "./DropdownMenu";
 import { useLayoutProvider } from "@/providers/LayoutProvider";
 import NotificationButton from "@/components/NotificationButton";
@@ -11,25 +12,28 @@ const HeaderActions = () => {
   const { isOpenNavbar, toggleNavbar, isExpandedSearchInput } = useLayoutProvider();
 
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex items-center gap-3">
       {primaryWallet && <NotificationButton />}
-      <div className="flex items-center gap-1 md:relative md:gap-2">
-        {!isExpandedSearchInput && <LoginButton />}
-        {primaryWallet && (
-          <button
-            onClick={toggleNavbar}
-            type="button"
-            className="flex flex-col rounded-md bg-grey-moss-400 px-2 py-1.5 md:hidden"
-            aria-label="Toggle navigation"
-            aria-expanded={isOpenNavbar}
-          >
-            <div className="size-2 rounded-full bg-grey-moss-100" />
-            <div className="size-2 rounded-full bg-grey-moss-100" />
-            <div className="size-2 rounded-full bg-grey-moss-100" />
-          </button>
-        )}
-        {isOpenNavbar && primaryWallet && <DropdownMenu />}
-      </div>
+      {!isExpandedSearchInput && (
+        <div className="flex items-center gap-2.5 md:relative">
+          <HeaderCreateButton />
+          <LoginButton />
+          {primaryWallet && (
+            <button
+              onClick={toggleNavbar}
+              type="button"
+              className="flex flex-col rounded-md bg-grey-moss-400 px-2 py-1.5 md:hidden"
+              aria-label="Toggle navigation"
+              aria-expanded={isOpenNavbar}
+            >
+              <div className="size-2 rounded-full bg-grey-moss-100" />
+              <div className="size-2 rounded-full bg-grey-moss-100" />
+              <div className="size-2 rounded-full bg-grey-moss-100" />
+            </button>
+          )}
+          {isOpenNavbar && primaryWallet && <DropdownMenu />}
+        </div>
+      )}
     </div>
   );
 };

--- a/components/Header/HeaderCreateButton.tsx
+++ b/components/Header/HeaderCreateButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { CircleDot } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+const HeaderCreateButton = () => {
+  const { push } = useRouter();
+
+  return (
+    <button
+      type="button"
+      aria-label="Create"
+      onClick={() => push("/create")}
+      className="hidden items-center gap-1.5 rounded-[10px] bg-grey-moss-900 py-[9px] pl-[13px] pr-4 font-archivo-medium text-[13.5px] text-white transition-colors hover:bg-black md:inline-flex"
+    >
+      <CircleDot className="size-4" strokeWidth={2} />
+      create
+    </button>
+  );
+};
+
+export default HeaderCreateButton;

--- a/components/LoginButton/PrivyButton.tsx
+++ b/components/LoginButton/PrivyButton.tsx
@@ -34,27 +34,32 @@ export function PrivyButton({ className = "" }: PrivyButtonProps) {
       type="button"
       onClick={handleClick}
       className={cn(
-        "flex items-center rounded-lg md:rounded-[10px] font-archivo-medium text-sm text-white md:bg-black md:text-[13px] md:hover:bg-[#34332F]",
+        "flex items-center gap-2 rounded-md bg-grey-moss-400 px-4 py-2 font-archivo-medium text-sm text-white",
+        "md:h-[38px] md:gap-2 md:rounded-[10px] md:border md:border-solid md:border-[#E4E0D7] md:bg-[#F1EEE8] md:py-[9px] md:pl-[13px] md:pr-4 md:text-[13.5px] md:text-grey-moss-900 md:hover:border-[#C4BDAE] md:hover:bg-[#EAE6DD]",
         className
       )}
     >
-      <div className="flex items-center gap-2 rounded-md bg-grey-moss-400 px-2 py-2 md:gap-1.5 md:bg-transparent px-4">
-        <div
-          className={`h-[7px] w-[7px] rounded-full ${privyWallet ? "bg-[#7FD58A]" : "border border-grey-moss-100"}`}
-        />
-        {privyWallet ? (
-          <>
-            <p className="min-w-20 text-left md:min-w-0">
-              {truncated(username || "", 9) || truncateAddress(privyWallet.address as string)}
-            </p>
-            <ChevronDown
-              className={`ml-4 hidden size-3.5 text-white/65 transition-transform duration-200 md:block ${isOpenNavbar ? "rotate-180" : ""}`}
-            />
-          </>
-        ) : (
-          "sign in"
+      <div
+        className={cn(
+          "h-2 w-2 shrink-0 rounded-full",
+          privyWallet ? "bg-[#7FD58A]" : "border border-grey-moss-100 md:border-[#A8A296]"
         )}
-      </div>
+      />
+      {privyWallet ? (
+        <>
+          <span className="min-w-20 text-left md:min-w-0">
+            {truncated(username || "", 9) || truncateAddress(privyWallet.address as string)}
+          </span>
+          <ChevronDown
+            className={cn(
+              "ml-4 hidden size-4 transition-transform duration-200 md:ml-0 md:block md:text-[#A8A296]",
+              isOpenNavbar && "rotate-180"
+            )}
+          />
+        </>
+      ) : (
+        "sign in"
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Add a desktop-only Create button (circle-dot + `create`) that navigates to `/create`
- Restyle the Privy sign-in/account chip to the light design treatment with a readable hover border
- Match create and sign-in/account height, padding, and type size

## Test plan
- [ ] Desktop header shows create (dark) then sign-in/account (light chip)
- [ ] Create navigates to `/create`
- [ ] Signed-out: sign in chip matches create height/padding
- [ ] Signed-in: green status dot, name/address, chevron; menu still opens
- [ ] Hover keeps a visible chip border
- [ ] Create is hidden on mobile; mobile login styling unchanged


Made with [Cursor](https://cursor.com)