### PR TITLE
Fix mobile Create FAB tap not navigating to /create

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { House, Plus } from "lucide-react";
+import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 import NotificationButton from "@/components/NotificationButton";
 import { useMobileDrawersProvider } from "@/providers/MobileDrawersProvider";
@@ -46,25 +47,22 @@ const Footer = () => {
           </>
         )}
 
-        <span className="w-20 shrink-0" aria-hidden />
-
-        <button
-          type="button"
-          aria-label="Create"
-          onClick={() => {
-            closeDrawer();
-            push("/create");
-          }}
-          className={cn(
-            "absolute left-1/2 top-0 z-10 flex h-20 w-20 -translate-x-1/2 -translate-y-[26%] items-center justify-center rounded-full border-4 border-white shadow-[0_4px_14px_-4px_rgba(27,21,4,.35)] transition-opacity active:opacity-80",
-            isCreatePage ? "bg-tan-gold text-white" : "bg-grey-moss-900 text-white"
-          )}
-        >
-          <Plus className="h-9 w-9" strokeWidth={2} />
-        </button>
+        <span className="pointer-events-none w-20 shrink-0" aria-hidden />
 
         <FeedbackDrawer />
         <UserDrawer />
+
+        <Link
+          href="/create"
+          aria-label="Create"
+          onClick={closeDrawer}
+          className={cn(
+            "absolute left-1/2 top-0 z-50 flex h-20 w-20 -translate-x-1/2 -translate-y-[26%] touch-manipulation items-center justify-center rounded-full border-4 border-white shadow-[0_4px_14px_-4px_rgba(27,21,4,.35)] transition-opacity active:opacity-80",
+            isCreatePage ? "bg-tan-gold text-white" : "bg-grey-moss-900 text-white"
+          )}
+        >
+          <Plus className="pointer-events-none h-9 w-9" strokeWidth={2} />
+        </Link>
       </div>
     </div>
   );

--- a/components/MomentPage/MomentCollectBar.tsx
+++ b/components/MomentPage/MomentCollectBar.tsx
@@ -17,7 +17,7 @@ const MomentCollectBar = () => {
   if (isLoading || !metadata) return null;
 
   return (
-    <div className="fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 z-[55] flex items-center justify-between gap-3 border-t border-[#E4E0D7] bg-white px-[18px] py-2.5 md:hidden">
+    <div className="pointer-events-none fixed bottom-[calc(74px+env(safe-area-inset-bottom,0px))] left-0 right-0 z-[55] flex items-center justify-between gap-3 border-t border-[#E4E0D7] bg-white px-[18px] py-2.5 md:hidden">
       {priceLabel && (
         <div className="flex min-w-[4.5rem] max-w-[calc(50%-2.75rem)] shrink-0 flex-col justify-center">
           <div className="flex min-w-0 items-baseline gap-1">
@@ -36,7 +36,7 @@ const MomentCollectBar = () => {
         type="button"
         onClick={handleCollect}
         disabled={isCollectDisabled}
-        className="flex w-[calc(50%-2.75rem)] shrink-0 items-center justify-center gap-1.5 rounded-[11px] bg-grey-moss-900 px-3 py-3 font-archivo-medium text-sm text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:bg-[#C7C1B4] disabled:text-[#F1EEE8]"
+        className="pointer-events-auto flex w-[calc(50%-2.75rem)] shrink-0 items-center justify-center gap-1.5 rounded-[11px] bg-grey-moss-900 px-3 py-3 font-archivo-medium text-sm text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:bg-[#C7C1B4] disabled:text-[#F1EEE8]"
       >
         <CircleDot className="size-4 shrink-0" strokeWidth={1.75} />
         <span className="truncate">{collectCtaLabel}</span>


### PR DESCRIPTION
## Summary
- On real mobile devices, tapping the centered Create (`+`) FAB could flash without navigating to `/create`, especially on moment pages where the Collect bar overlaps the FAB protrusion.
- Switch Create to a `Link` with `touch-manipulation`, and set the Collect bar to `pointer-events-none` with `pointer-events-auto` only on the Collect button.

## Test plan
- [ ] On a physical phone, from home feed, tap Create (`+`) → `/create`
- [ ] On a moment page with Collect bar, tap Create (`+`) → `/create`
- [ ] Confirm Collect button still works
- [ ] Confirm other footer icons (search, notifications, feedback, user) still work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation for the footer’s Create action while preserving route highlighting and drawer behavior.
  - Fixed mobile collect bar interactions so the collect button remains fully usable.
- **UI Improvements**
  - Refined layering and pointer interactions for footer controls and the mobile collect bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->