### PR TITLE
Ensure Process collection via POST /collections/default

### DIFF
--- a/hooks/useCollections.ts
+++ b/hooks/useCollections.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams, useSearchParams } from "next/navigation";
 import { fetchCollections } from "@/lib/collections/fetchCollections";
@@ -6,6 +6,7 @@ import { createDefaultCollection } from "@/lib/collections/createDefaultCollecti
 import { useWalletsProvider } from "@/providers/WalletsProvider";
 import { useAuthorizationProvider } from "@/providers/AuthorizationProvider";
 import { parseCollectionAddress } from "@/lib/timeline/parseCollectionAddress";
+import type { CollectionItem } from "@/types/collections";
 
 export function useCollections() {
   const { primaryWallet } = useWalletsProvider();
@@ -21,6 +22,7 @@ export function useCollections() {
   const selectedCollectionRef = useRef(selectedCollection);
   selectedCollectionRef.current = selectedCollection;
 
+  const [defaultCollection, setDefaultCollection] = useState<CollectionItem | null>(null);
   const ensuredProcessForWalletRef = useRef<string | null>(null);
 
   const query = useQuery({
@@ -32,6 +34,7 @@ export function useCollections() {
 
   useEffect(() => {
     if (!initialAddress) setSelectedCollection(undefined);
+    setDefaultCollection(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [primaryWallet]);
 
@@ -47,8 +50,9 @@ export function useCollections() {
 
     void (async () => {
       try {
-        await createDefaultCollection(await getAuthHeaders());
+        const collection = await createDefaultCollection(await getAuthHeaders());
         if (cancelled) return;
+        setDefaultCollection(collection);
         await queryClient.invalidateQueries({
           queryKey: ["collections", primaryWallet],
         });
@@ -69,15 +73,19 @@ export function useCollections() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [primaryWallet, queryClient]);
 
-  const collections = query.data?.collections ?? [];
+  const collections = useMemo(() => {
+    const loaded = query.data?.collections ?? [];
+    if (!defaultCollection) return loaded;
+    const defaultAddress = defaultCollection.address.toLowerCase();
+    const rest = loaded.filter((collection) => collection.address.toLowerCase() !== defaultAddress);
+    return [defaultCollection, ...rest];
+  }, [query.data?.collections, defaultCollection]);
 
   useEffect(() => {
     if (selectedCollectionRef.current) return;
-    const loadedCollections = query.data?.collections;
-    if (!loadedCollections?.length) return;
-    setSelectedCollection(loadedCollections[0].address.toLowerCase());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query.data?.collections]);
+    if (!collections.length) return;
+    setSelectedCollection(collections[0].address.toLowerCase());
+  }, [collections]);
 
   return {
     collections,

--- a/hooks/useCollections.ts
+++ b/hooks/useCollections.ts
@@ -1,12 +1,16 @@
 import { useEffect, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams, useSearchParams } from "next/navigation";
 import { fetchCollections } from "@/lib/collections/fetchCollections";
+import { createDefaultCollection } from "@/lib/collections/createDefaultCollection";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
+import { useAuthorizationProvider } from "@/providers/AuthorizationProvider";
 import { parseCollectionAddress } from "@/lib/timeline/parseCollectionAddress";
 
 export function useCollections() {
   const { primaryWallet } = useWalletsProvider();
+  const { getAuthHeaders } = useAuthorizationProvider();
+  const queryClient = useQueryClient();
   const params = useParams();
   const searchParams = useSearchParams();
 
@@ -16,6 +20,8 @@ export function useCollections() {
   const [selectedCollection, setSelectedCollection] = useState<string | undefined>(initialAddress);
   const selectedCollectionRef = useRef(selectedCollection);
   selectedCollectionRef.current = selectedCollection;
+
+  const ensuredProcessForWalletRef = useRef<string | null>(null);
 
   const query = useQuery({
     queryKey: ["collections", primaryWallet],
@@ -28,6 +34,40 @@ export function useCollections() {
     if (!initialAddress) setSelectedCollection(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [primaryWallet]);
+
+  useEffect(() => {
+    if (!primaryWallet) {
+      ensuredProcessForWalletRef.current = null;
+      return;
+    }
+    if (ensuredProcessForWalletRef.current === primaryWallet) return;
+
+    let cancelled = false;
+    ensuredProcessForWalletRef.current = primaryWallet;
+
+    void (async () => {
+      try {
+        await createDefaultCollection(await getAuthHeaders());
+        if (cancelled) return;
+        await queryClient.invalidateQueries({
+          queryKey: ["collections", primaryWallet],
+        });
+      } catch (error) {
+        if (cancelled) return;
+        ensuredProcessForWalletRef.current = null;
+        console.error("Failed to ensure Process collection", error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (ensuredProcessForWalletRef.current === primaryWallet) {
+        ensuredProcessForWalletRef.current = null;
+      }
+    };
+    // Intentionally omit getAuthHeaders: new identity each render would cancel in-flight ensures.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [primaryWallet, queryClient]);
 
   const collections = query.data?.collections ?? [];
 

--- a/lib/collections/createDefaultCollection.ts
+++ b/lib/collections/createDefaultCollection.ts
@@ -1,0 +1,20 @@
+import { IN_PROCESS_API } from "@/lib/consts";
+import type { CreateCollectionResult } from "@/types/collections";
+
+export type CreateDefaultCollectionResult = CreateCollectionResult | { message: string };
+
+export async function createDefaultCollection(
+  authHeaders: HeadersInit
+): Promise<CreateDefaultCollectionResult> {
+  const response = await fetch(`${IN_PROCESS_API}/collections/default`, {
+    method: "POST",
+    headers: {
+      ...authHeaders,
+    },
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.message || "Failed to create default collection");
+  }
+  return data;
+}

--- a/lib/collections/createDefaultCollection.ts
+++ b/lib/collections/createDefaultCollection.ts
@@ -1,13 +1,9 @@
 import { IN_PROCESS_API } from "@/lib/consts";
-import type { CreateCollectionResult } from "@/types/collections";
+import type { CollectionItem } from "@/types/collections";
 
-export type CreateDefaultCollectionResult = CreateCollectionResult | { message: string };
-
-export async function createDefaultCollection(
-  authHeaders: HeadersInit
-): Promise<CreateDefaultCollectionResult> {
+export async function createDefaultCollection(authHeaders: HeadersInit): Promise<CollectionItem> {
   const response = await fetch(`${IN_PROCESS_API}/collections/default`, {
-    method: "POST",
+    method: "GET",
     headers: {
       ...authHeaders,
     },

--- a/types/collections.ts
+++ b/types/collections.ts
@@ -10,10 +10,10 @@ export interface CollectionsResponse {
     uri: string;
     name: string;
     created_at: string;
-    creator: {
-      username: string | null;
-      address: string;
-    };
+    protocol: string;
+    creator: string;
+    creator_username: string | null;
+    admins: { artist_address: string; token_id: number }[];
   }>;
   pagination: {
     page: number;


### PR DESCRIPTION
## Summary
- Call `POST /collections/default` when an authenticated artist’s `useCollections` session starts
- Let the API decide whether Process already exists (do not infer from paginated list page 1)
- Invalidate collections after a successful ensure so new/existing artists both get Process

## Test plan
- [ ] New artist with 0 collections: opening `/create` creates Process and refreshes the list
- [ ] Existing artist with many collections and no Process: Process is created without relying on page-1 URI checks
- [ ] Artist who already has Process: request succeeds idempotently (`200 already created`)
- [ ] Failed auth / API error does not break collection dropdown selection


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically creates a default Process collection when a wallet becomes available.
  * Refreshes the collection list after the default collection is created.
  * Displays appropriate error handling when collection creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->