### PR TITLE
Add Collected link to account dropdown

### DIFF
--- a/components/Header/DropdownMenu.tsx
+++ b/components/Header/DropdownMenu.tsx
@@ -4,7 +4,7 @@ import Divider from "./Divider";
 import { useLayoutProvider } from "@/providers/LayoutProvider";
 import { usePrivy } from "@privy-io/react-auth";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
-import { Clock, Settings, LogOut } from "lucide-react";
+import { CircleDot, Clock, Settings, LogOut } from "lucide-react";
 import TopupMenuItem from "../Balances/TopupMenuItem";
 
 const ITEM_CLASS =
@@ -28,6 +28,17 @@ export function DropdownMenu() {
       >
         <Clock className="size-4 shrink-0 opacity-60" strokeWidth={1.5} />
         Timeline
+      </button>
+      <Divider />
+      <button
+        onClick={() => {
+          toggleNavbar();
+          push(`/${primaryWallet}/collected`);
+        }}
+        className={ITEM_CLASS}
+      >
+        <CircleDot className="size-4 shrink-0 opacity-60" strokeWidth={1.5} />
+        Collected
       </button>
       <Divider />
       <button


### PR DESCRIPTION
## Summary
- Add a Collected menu item to the signed-in account dropdown (next to Timeline)
- Navigates to `/{wallet}/collected` so users can open their collected page from the header

## Test plan
- [ ] Sign in and open the account dropdown
- [ ] Confirm Timeline and Collected both appear
- [ ] Click Collected and verify navigation to `/{address}/collected`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Collected** option to the navigation menu.
  * Selecting it opens the Collected page and closes the menu automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->