### PR TITLE
Redesign create page desktop new-moment studio

### DIFF
--- a/app/create/layout.tsx
+++ b/app/create/layout.tsx
@@ -12,8 +12,8 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
     <CreateCollectionModalTriggerProvider>
       <CollectionsProvider>
         <MomentCreateProviderWrapper>
-          <main className="w-screen grow">
-            <div className="relative mt-12 grid w-full grid-cols-1 gap-6 px-6 md:mt-24 md:grid-cols-3 md:px-10">
+          <main className="flex w-screen grow flex-col md:min-h-0 md:overflow-hidden">
+            <div className="relative mt-12 grid w-full flex-1 grid-cols-1 gap-6 px-6 md:mx-auto md:mt-0 md:flex md:min-h-0 md:max-w-[1680px] md:gap-0 md:px-0">
               {children}
             </div>
           </main>

--- a/components/BulkUpload/BulkCenterGrid.tsx
+++ b/components/BulkUpload/BulkCenterGrid.tsx
@@ -2,13 +2,14 @@
 
 import useBulkCenterGrid from "@/hooks/useBulkCenterGrid";
 import BulkFileCard from "./BulkFileCard";
+import { Plus } from "lucide-react";
 
 const BulkCenterGrid = () => {
   const { bulkItems, removeFile, setItemName, isCreating, inputRef, onChange } =
     useBulkCenterGrid();
 
   return (
-    <div className="md:min-h-auto relative min-h-[400px] w-full overflow-y-auto bg-[url('/grid.svg')] bg-contain p-3 md:aspect-[571/692]">
+    <div className="relative min-h-[400px] w-full flex-1 overflow-y-auto md:min-h-0">
       <input
         ref={inputRef}
         type="file"
@@ -17,7 +18,7 @@ const BulkCenterGrid = () => {
         className="hidden"
         onChange={onChange}
       />
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-4 p-0.5 sm:grid-cols-3 md:grid-cols-[repeat(auto-fill,minmax(190px,1fr))]">
         {bulkItems.map((item) => (
           <BulkFileCard
             key={item.id}
@@ -27,6 +28,17 @@ const BulkCenterGrid = () => {
             isCreating={isCreating}
           />
         ))}
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={isCreating}
+          className="flex aspect-square w-full flex-col items-center justify-center gap-2 rounded-xl border-[1.5px] border-dashed border-[#C9C4B9] bg-white/40 text-[#8C8678] transition-colors hover:border-grey-moss-900 hover:text-grey-moss-900 disabled:opacity-50"
+        >
+          <Plus className="size-[26px]" strokeWidth={1.75} />
+          <span className="font-archivo-medium text-[12.5px] uppercase tracking-[0.06em]">
+            add media
+          </span>
+        </button>
       </div>
     </div>
   );

--- a/components/BulkUpload/BulkCreateButton.tsx
+++ b/components/BulkUpload/BulkCreateButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+import { CircleDot } from "lucide-react";
 
 const BulkCreateButton = () => {
   const { bulkItems, createBatch, isCreating } = useBulkCreateProvider();
@@ -20,8 +21,9 @@ const BulkCreateButton = () => {
       type="button"
       onClick={createBatch}
       disabled={isCreating || !allNamed || count === 0}
-      className="w-full rounded-sm bg-grey-moss-900 py-3 font-archivo text-lg text-grey-eggshell transition-colors hover:bg-grey-moss-700 disabled:cursor-not-allowed disabled:opacity-50"
+      className="flex w-full items-center justify-center gap-2 rounded-lg bg-grey-moss-900 px-4 py-4 font-archivo-bold text-[15.5px] text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:opacity-50 md:w-auto md:min-w-[160px] md:px-8 md:py-3.5"
     >
+      <CircleDot className="size-[18px]" strokeWidth={1.75} />
       {label}
     </button>
   );

--- a/components/BulkUpload/BulkDropZone.tsx
+++ b/components/BulkUpload/BulkDropZone.tsx
@@ -29,10 +29,10 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onClick={openFileDialog}
-      className={`group relative flex h-full min-h-[320px] w-full cursor-pointer flex-col items-center justify-center gap-5 rounded-2xl border-2 border-dashed transition-all duration-200 ${
+      className={`group relative flex h-full min-h-[320px] w-full cursor-pointer flex-col items-center justify-center gap-3.5 rounded-2xl border-2 border-dashed transition-all duration-200 md:gap-3.5 md:rounded-[16px] ${
         isDragging
-          ? "scale-[1.01] border-grey-moss-700 bg-grey-moss-200"
-          : "border-grey-moss-400 bg-grey-moss-100 hover:border-grey-moss-600 hover:bg-grey-moss-150"
+          ? "border-grey-moss-900 bg-white/50"
+          : "border-[#C9C4B9] bg-white/35 hover:border-grey-moss-900 hover:bg-white/50"
       }`}
     >
       <input
@@ -54,19 +54,14 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
         />
       )}
 
-      <div
-        className={`flex size-16 items-center justify-center rounded-full border-2 transition-all duration-200 ${
-          isDragging ? "border-grey-moss-700 bg-grey-moss-300" : "border-grey-moss-400 bg-white"
-        }`}
-      >
+      <div className="flex size-[66px] items-center justify-center rounded-full border-[1.5px] border-grey-moss-900 text-grey-moss-900">
         <svg
-          width="28"
-          height="28"
+          width="26"
+          height="26"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
-          strokeWidth="1.5"
-          className={`transition-colors ${isDragging ? "text-grey-moss-900" : "text-grey-moss-500"}`}
+          strokeWidth="1.75"
         >
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
           <polyline points="17 8 12 3 7 8" />
@@ -75,8 +70,10 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
       </div>
 
       <div className="flex flex-col items-center gap-2 px-6 text-center">
-        <p className="font-archivo-medium text-lg text-grey-moss-800">drop files here</p>
-        <p className="font-archivo text-sm text-grey-moss-500">
+        <p className="font-archivo-medium text-xl uppercase tracking-[0.04em] text-grey-moss-900">
+          drop files here
+        </p>
+        <p className="font-spectral-italic text-base uppercase tracking-[0.04em] text-[#6B6456]">
           {isMobile ? "or tap to choose files" : "or click to browse"}
         </p>
         {isMobile && (
@@ -93,12 +90,12 @@ const BulkDropZone = ({ onSingleFile }: BulkDropZoneProps) => {
             Take a photo
           </button>
         )}
-        <p className="mt-1 font-archivo text-xs text-grey-moss-400">
+        <p className="mt-1 font-archivo text-[12.5px] uppercase tracking-[0.06em] text-[#A8A296]">
           images · video · PDF · audio · 3D
         </p>
-        <p className="font-archivo text-xs text-grey-moss-400">
-          drop <span className="font-archivo-medium text-grey-moss-600">multiple files</span> to
-          bulk create
+        <p className="font-archivo text-[12.5px] uppercase tracking-[0.06em] text-[#A8A296]">
+          drop <span className="font-archivo-bold text-[#6B6456]">multiple files</span> to bulk
+          create
         </p>
       </div>
     </div>

--- a/components/BulkUpload/BulkFileCard.tsx
+++ b/components/BulkUpload/BulkFileCard.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { BulkItem } from "@/types/bulk";
 import { getStatusClass } from "@/lib/bulkUpload/getStatusClass";
 import { getMimeTypeIcon } from "@/lib/bulkUpload/getMimeTypeIcon";
+import { X } from "lucide-react";
 
 interface BulkFileCardProps {
   item: BulkItem;
@@ -14,52 +15,60 @@ interface BulkFileCardProps {
 
 const BulkFileCard = ({ item, onRemove, onNameChange, isCreating }: BulkFileCardProps) => {
   return (
-    <div
-      className={`relative flex flex-col overflow-hidden rounded-lg border-2 bg-grey-moss-100 transition-colors ${getStatusClass(item.status)}`}
-    >
-      {!isCreating && (
-        <button
-          type="button"
-          onClick={() => onRemove(item.id)}
-          className="absolute right-1.5 top-1.5 z-10 flex size-5 items-center justify-center rounded-full bg-grey-moss-900 text-white hover:bg-red-500"
-          aria-label="Remove"
-        >
-          ×
-        </button>
-      )}
-
-      <div className="relative aspect-square w-full overflow-hidden bg-grey-moss-200">
-        {item.previewUrl ? (
-          <Image src={item.previewUrl} alt={item.name} fill className="object-cover" unoptimized />
-        ) : (
-          <div className="flex size-full items-center justify-center text-2xl text-grey-moss-400">
-            {getMimeTypeIcon(item.mimeType)}
-          </div>
+    <div className="flex flex-col">
+      <div
+        className={`relative aspect-square w-full overflow-hidden rounded-xl border-2 shadow-[0_14px_34px_-18px_rgba(27,21,4,0.35),0_0_0_1px_rgba(27,21,4,0.06)] ${getStatusClass(item.status)}`}
+      >
+        {!isCreating && (
+          <button
+            type="button"
+            onClick={() => onRemove(item.id)}
+            className="absolute right-2 top-2 z-10 flex size-[26px] items-center justify-center rounded-full bg-grey-moss-900 text-white shadow-[0_4px_10px_rgba(0,0,0,0.3)]"
+            aria-label="Remove"
+          >
+            <X className="size-3.5" strokeWidth={1.75} />
+          </button>
         )}
 
-        {item.status === "uploading" && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/50">
-            <div className="mb-1.5 h-1.5 w-3/4 overflow-hidden rounded-full bg-grey-moss-300">
-              <div
-                className="h-full bg-white transition-all duration-300"
-                style={{ width: `${item.progress}%` }}
-              />
+        <div className="relative size-full overflow-hidden bg-[#EDEAE2]">
+          {item.previewUrl ? (
+            <Image
+              src={item.previewUrl}
+              alt={item.name}
+              fill
+              className="object-cover"
+              unoptimized
+            />
+          ) : (
+            <div className="flex size-full items-center justify-center text-2xl text-grey-moss-400">
+              {getMimeTypeIcon(item.mimeType)}
             </div>
-            <span className="font-archivo text-xs text-white">{item.progress}%</span>
-          </div>
-        )}
+          )}
 
-        {item.status === "done" && (
-          <div className="absolute inset-0 flex items-center justify-center bg-green-500/20">
-            <span className="text-2xl">✓</span>
-          </div>
-        )}
+          {item.status === "uploading" && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/50">
+              <div className="mb-1.5 h-1.5 w-3/4 overflow-hidden rounded-full bg-grey-moss-300">
+                <div
+                  className="h-full bg-white transition-all duration-300"
+                  style={{ width: `${item.progress}%` }}
+                />
+              </div>
+              <span className="font-archivo text-xs text-white">{item.progress}%</span>
+            </div>
+          )}
 
-        {item.status === "error" && (
-          <div className="absolute inset-0 flex items-center justify-center bg-red-500/20">
-            <span className="font-archivo text-xs text-red-600">{item.error || "Error"}</span>
-          </div>
-        )}
+          {item.status === "done" && (
+            <div className="absolute inset-0 flex items-center justify-center bg-green-500/20">
+              <span className="text-2xl">✓</span>
+            </div>
+          )}
+
+          {item.status === "error" && (
+            <div className="absolute inset-0 flex items-center justify-center bg-red-500/20">
+              <span className="font-archivo text-xs text-red-600">{item.error || "Error"}</span>
+            </div>
+          )}
+        </div>
       </div>
 
       <input
@@ -68,7 +77,7 @@ const BulkFileCard = ({ item, onRemove, onNameChange, isCreating }: BulkFileCard
         onChange={(e) => onNameChange(item.id, e.target.value)}
         disabled={isCreating}
         placeholder="name"
-        className="w-full border-t border-grey-moss-300 bg-transparent px-2 py-1.5 font-archivo text-xs text-grey-moss-900 placeholder-grey-moss-400 outline-none focus:bg-white disabled:opacity-60"
+        className="mt-2 w-full bg-transparent font-archivo text-[12.5px] text-[#6B6456] outline-none placeholder-[#B4AEA2] disabled:opacity-60"
       />
     </div>
   );

--- a/components/BulkUpload/BulkSideForm.tsx
+++ b/components/BulkUpload/BulkSideForm.tsx
@@ -23,7 +23,9 @@ const BulkSideForm = () => {
     <div className="col-span-1 w-full">
       <div className="flex h-fit flex-col gap-6 pb-4 md:min-h-full md:pb-0">
         <div className="flex items-center justify-between gap-3">
-          <div className="font-spectral-italic text-[22px] text-grey-moss-900">Details</div>
+          <div className="font-spectral-italic text-[22px] text-grey-moss-900">
+            {bulkItems.length} media selected
+          </div>
           <button
             type="button"
             onClick={clearAll}

--- a/components/BulkUpload/BulkSideForm.tsx
+++ b/components/BulkUpload/BulkSideForm.tsx
@@ -6,6 +6,7 @@ import Price from "@/components/CreateForm/Price";
 import { useCreateCollectionModalTriggerProvider } from "@/providers/CollectionCreateProvider/CreateCollectionModalTriggerProvider";
 import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
 import BulkCreateButton from "./BulkCreateButton";
+import { Trash2 } from "lucide-react";
 
 const BulkSideForm = () => {
   const { openModal } = useCreateCollectionModalTriggerProvider();
@@ -19,11 +20,20 @@ const BulkSideForm = () => {
   };
 
   return (
-    <div className="col-span-1 w-full md:pl-12">
-      <div className="flex h-fit flex-col space-y-3 pb-4">
-        <p className="font-archivo text-sm text-grey-moss-500">
-          {bulkItems.length} file{bulkItems.length !== 1 ? "s" : ""} selected
-        </p>
+    <div className="col-span-1 w-full">
+      <div className="flex h-fit flex-col gap-6 pb-4 md:min-h-full md:pb-0">
+        <div className="flex items-center justify-between gap-3">
+          <div className="font-spectral-italic text-[22px] text-grey-moss-900">Details</div>
+          <button
+            type="button"
+            onClick={clearAll}
+            disabled={isCreating}
+            className="inline-flex items-center gap-1.5 rounded-full border border-[#DCD6CA] bg-transparent px-2.5 py-1.5 font-archivo-medium text-xs text-[#8C8678] hover:text-grey-moss-900 disabled:opacity-50"
+          >
+            <Trash2 className="size-[13px]" strokeWidth={1.75} />
+            clear all
+          </button>
+        </div>
 
         <Collections onCreateNew={openModal} />
 
@@ -38,26 +48,19 @@ const BulkSideForm = () => {
           onChange={handleAddMore}
         />
 
-        <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={() => inputRef.current?.click()}
-            disabled={isCreating}
-            className="flex-1 rounded-sm border border-grey-moss-400 py-2 font-archivo text-sm text-grey-moss-700 hover:bg-grey-moss-200 disabled:opacity-50"
-          >
-            + add more
-          </button>
-          <button
-            type="button"
-            onClick={clearAll}
-            disabled={isCreating}
-            className="flex-1 rounded-sm border border-grey-moss-400 py-2 font-archivo text-sm text-grey-moss-700 hover:bg-grey-moss-200 disabled:opacity-50"
-          >
-            clear all
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={isCreating}
+          className="rounded-[10px] border border-[#DCD6CA] py-2.5 font-archivo-medium text-[12.5px] uppercase tracking-[0.06em] text-grey-moss-900 hover:bg-[#F1EEE8] disabled:opacity-50"
+        >
+          + add more
+        </button>
 
-        <BulkCreateButton />
+        <div className="hidden flex-1 md:block" />
+        <div className="md:hidden">
+          <BulkCreateButton />
+        </div>
       </div>
     </div>
   );

--- a/components/Collections/Collections.tsx
+++ b/components/Collections/Collections.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Label } from "@/components/ui/label";
 import { CollectionItem } from "@/types/collections";
 import CollectionsDropdown from "./CollectionsDropdown";
 
@@ -11,10 +10,13 @@ interface CollectionsProps {
 }
 
 const Collections = ({ onCreateNew, onSelect, disabled }: CollectionsProps) => (
-  <div className="flex w-full flex-col items-start gap-2">
-    <Label htmlFor="collection" className="text-md font-archivo">
+  <div className="flex w-full flex-col items-start">
+    <label
+      htmlFor="collection"
+      className="mb-1 font-archivo-medium text-[10.5px] uppercase tracking-[0.14em] text-[#A8A296]"
+    >
       collection
-    </Label>
+    </label>
     <CollectionsDropdown onCreateNew={onCreateNew} onSelect={onSelect} disabled={disabled} />
   </div>
 );

--- a/components/Collections/CollectionsDropdown.tsx
+++ b/components/Collections/CollectionsDropdown.tsx
@@ -53,15 +53,15 @@ const CollectionsDropdown = ({
           aria-expanded={open}
           disabled={disabled}
           className={cn(
-            "h-9 w-full justify-between rounded-[0px] border border-grey bg-white !font-spectral !ring-0 !ring-offset-0 disabled:opacity-50",
+            "h-auto w-full justify-between rounded-none border-0 border-b-[1.5px] border-[#DCD6CA] bg-transparent px-0.5 py-[9px] !font-archivo text-[15px] text-grey-moss-900 !ring-0 !ring-offset-0 shadow-none hover:bg-transparent disabled:opacity-50",
             className
           )}
         >
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2.5">
             {isLoading || !currentCollection ? (
-              <div className="h-[24px] w-[24px] animate-pulse rounded bg-neutral-200" />
+              <div className="h-4 w-4 animate-pulse rounded bg-neutral-200" />
             ) : (
-              <div className="relative h-[24px] w-[24px] shrink-0 overflow-hidden rounded">
+              <div className="relative h-4 w-4 shrink-0 overflow-hidden rounded-sm">
                 <BlurImage
                   src={imageUrl}
                   alt={displayName}
@@ -72,7 +72,7 @@ const CollectionsDropdown = ({
             )}
             <span>{displayName}</span>
           </div>
-          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          <ChevronDown className="ml-2 size-4 shrink-0 text-[#A8A296]" strokeWidth={1.75} />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">

--- a/components/CreateForm/Advanced.tsx
+++ b/components/CreateForm/Advanced.tsx
@@ -1,8 +1,6 @@
 import { Button } from "../ui/button";
 import { DateTimePicker } from "../ui/date-time-picker";
-import { ChevronDown } from "lucide-react";
-import { Textarea } from "../ui/textarea";
-import Price from "./Price";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import SplitsForm from "./SplitsForm";
 import { Controller } from "react-hook-form";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
@@ -12,42 +10,35 @@ const Advanced = () => {
   const { isOpenAdvanced, form, setIsOpenAdvanced } = useMetadataFormProvider();
 
   return (
-    <div className="z-10 flex flex-col gap-2 pt-2">
+    <div className="z-10 flex flex-col">
       <Button
         type="button"
-        className="text-md mb-3 flex h-fit w-full items-center justify-between self-center rounded-none border-b border-grey-moss-300 p-0 pb-1 font-archivo font-medium"
+        className="mb-0 flex h-fit w-full items-center justify-between self-center rounded-none border-0 p-0 py-0 pb-1 font-archivo-medium text-[11px] uppercase tracking-[0.14em] text-[#6B6456] hover:bg-transparent"
         onClick={() => setIsOpenAdvanced(!isOpenAdvanced)}
       >
         advanced
-        <ChevronDown
-          className={`text-grey-moss-200 transition-transform duration-200 ${isOpenAdvanced ? "rotate-180" : ""}`}
-        />
+        {isOpenAdvanced ? (
+          <ChevronUp className="size-[17px] text-[#6B6456]" strokeWidth={1.75} />
+        ) : (
+          <ChevronDown className="size-[17px] text-[#6B6456]" strokeWidth={1.75} />
+        )}
       </Button>
       {isOpenAdvanced && (
-        <div className="relative mx-[-16px] bg-grey-moss-100 px-[16px]">
-          <p className="font-archivo font-medium">Description</p>
-          <Textarea
-            {...form.register("description")}
-            placeholder="enter a description"
-            minRows={3}
-            className="resize-none font-spectral"
-          />
-          {form.formState.errors.description && (
-            <p className="mt-1 font-spectral text-xs text-red-500">
-              {form.formState.errors.description.message}
-            </p>
-          )}
-          <Price />
-          <SplitsForm />
+        <div className="relative flex flex-col gap-[22px] py-3.5">
           <TotalSupplyInput />
-          <p className="pt-2 font-archivo font-medium">time</p>
-          <Controller
-            name="startDate"
-            control={form.control}
-            render={({ field }) => (
-              <DateTimePicker date={field.value} setDate={(date) => field.onChange(date)} />
-            )}
-          />
+          <div>
+            <label className="mb-1 block font-archivo-medium text-[10.5px] uppercase tracking-[0.14em] text-[#A8A296]">
+              mint time
+            </label>
+            <Controller
+              name="startDate"
+              control={form.control}
+              render={({ field }) => (
+                <DateTimePicker date={field.value} setDate={(date) => field.onChange(date)} />
+              )}
+            />
+          </div>
+          <SplitsForm />
         </div>
       )}
     </div>

--- a/components/CreateForm/CreateButton.tsx
+++ b/components/CreateForm/CreateButton.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
 import { toast } from "sonner";
+import { CircleDot } from "lucide-react";
 
 const CreateButton = () => {
   const { create, creating } = useMomentCreateProvider();
@@ -50,8 +51,9 @@ const CreateButton = () => {
     <Button
       onClick={handleCreate}
       disabled={creating}
-      className="disabled:opacity-1 z-10 w-fit transform self-center !rounded-sm bg-black px-14 py-5 !font-archivo !text-xl text-grey-eggshell transition-transform duration-150 hover:bg-grey-moss-300 disabled:!pointer-events-auto disabled:!cursor-not-allowed md:!mt-4 md:h-[60px] md:w-full md:py-6"
+      className="disabled:opacity-1 z-10 flex w-full items-center justify-center gap-2 self-center !rounded-lg bg-grey-moss-900 px-4 py-4 !font-archivo-bold !text-[15.5px] text-white transition-colors hover:!bg-black disabled:!pointer-events-auto disabled:!cursor-not-allowed md:h-auto md:w-auto md:min-w-[160px] md:px-8 md:py-3.5"
     >
+      <CircleDot className="size-[18px]" strokeWidth={1.75} />
       {creating ? "creating..." : "create"}
     </Button>
   );

--- a/components/CreateForm/CreateForm.tsx
+++ b/components/CreateForm/CreateForm.tsx
@@ -4,6 +4,8 @@ import CreateButton from "./CreateButton";
 import Prompt from "./Prompt";
 import Advanced from "./Advanced";
 import Preview from "./Preview";
+import Price from "./Price";
+import Description from "./Description";
 import Collections from "@/components/Collections";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { useCreateCollectionModalTriggerProvider } from "@/providers/CollectionCreateProvider/CreateCollectionModalTriggerProvider";
@@ -13,13 +15,17 @@ const CreateForm = () => {
   const { openModal } = useCreateCollectionModalTriggerProvider();
 
   return (
-    <div className="col-span-1 w-full md:pl-12">
-      <div ref={inputRef} className="flex h-fit flex-col space-y-3 pb-4">
+    <div className="col-span-1 w-full md:pl-0">
+      <div ref={inputRef} className="flex h-fit flex-col gap-6 pb-4 md:min-h-full md:gap-6 md:pb-0">
+        <Preview />
         <Collections onCreateNew={openModal} />
         <Prompt />
+        <Price />
+        <Description />
         <Advanced />
-        <Preview />
-        <CreateButton />
+        <div className="md:hidden">
+          <CreateButton />
+        </div>
       </div>
     </div>
   );

--- a/components/CreateForm/CurrencySelect.tsx
+++ b/components/CreateForm/CurrencySelect.tsx
@@ -1,42 +1,19 @@
 "use client";
 
-import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
-import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
-import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
 import { ChevronDown } from "lucide-react";
-import { useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
-
-const OPTIONS = [
-  { value: "eth", label: "ETH" },
-  { value: "usdc", label: "USD" },
-] as const;
+import useCurrencySelect from "@/hooks/useCurrencySelect";
 
 export default function CurrencySelect() {
-  const { form } = useMetadataFormProvider();
-  const { creating } = useMomentCreateProvider();
-  const { isCreating } = useBulkCreateProvider();
-  const disabled = Boolean(creating) || isCreating;
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const priceUnit = form.watch("priceUnit");
-  const current = OPTIONS.find((o) => o.value === priceUnit) ?? OPTIONS[1];
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (e: PointerEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    return () => document.removeEventListener("pointerdown", onPointerDown);
-  }, [open]);
+  const { disabled, open, rootRef, priceUnit, current, options, toggleOpen, selectCurrency } =
+    useCurrencySelect();
 
   return (
     <div ref={rootRef} className="relative shrink-0">
       <button
         type="button"
         disabled={disabled}
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleOpen}
         className="inline-flex items-center gap-1.5 rounded-[9px] border border-[#DCD6CA] bg-white px-2.5 py-1.5 font-archivo-bold text-[13px] text-grey-moss-900 disabled:opacity-50"
       >
         {current.label}
@@ -44,16 +21,13 @@ export default function CurrencySelect() {
       </button>
       {open && (
         <div className="absolute right-0 top-[38px] z-30 w-24 rounded-[10px] border border-[#E4E0D7] bg-white p-1 shadow-[0_16px_34px_-14px_rgba(27,21,4,0.32)]">
-          {OPTIONS.map((option) => {
+          {options.map((option) => {
             const selected = option.value === priceUnit;
             return (
               <button
                 key={option.value}
                 type="button"
-                onClick={() => {
-                  form.setValue("priceUnit", option.value, { shouldValidate: true });
-                  setOpen(false);
-                }}
+                onClick={() => selectCurrency(option.value)}
                 className={cn(
                   "w-full rounded-[7px] px-2.5 py-2 text-left font-archivo-medium text-[13px]",
                   selected ? "bg-[#2F6BFF] text-white" : "text-grey-moss-900 hover:bg-[#F6F4EF]"

--- a/components/CreateForm/CurrencySelect.tsx
+++ b/components/CreateForm/CurrencySelect.tsx
@@ -3,20 +3,68 @@
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+import { ChevronDown } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+const OPTIONS = [
+  { value: "eth", label: "ETH" },
+  { value: "usdc", label: "USD" },
+] as const;
 
 export default function CurrencySelect() {
   const { form } = useMetadataFormProvider();
   const { creating } = useMomentCreateProvider();
   const { isCreating } = useBulkCreateProvider();
+  const disabled = Boolean(creating) || isCreating;
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const priceUnit = form.watch("priceUnit");
+  const current = OPTIONS.find((o) => o.value === priceUnit) ?? OPTIONS[1];
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
 
   return (
-    <select
-      {...form.register("priceUnit")}
-      disabled={Boolean(creating) || isCreating}
-      className="h-auto min-w-[70px] cursor-pointer appearance-none !rounded-[0px] !border-none bg-white px-3 py-0 text-center font-spectral focus-visible:ring-0 focus-visible:ring-offset-0"
-    >
-      <option value="eth">ETH</option>
-      <option value="usdc">USD</option>
-    </select>
+    <div ref={rootRef} className="relative shrink-0">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1.5 rounded-[9px] border border-[#DCD6CA] bg-white px-2.5 py-1.5 font-archivo-bold text-[13px] text-grey-moss-900 disabled:opacity-50"
+      >
+        {current.label}
+        <ChevronDown className="size-3.5 text-[#A8A296]" strokeWidth={1.75} />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-[38px] z-30 w-24 rounded-[10px] border border-[#E4E0D7] bg-white p-1 shadow-[0_16px_34px_-14px_rgba(27,21,4,0.32)]">
+          {OPTIONS.map((option) => {
+            const selected = option.value === priceUnit;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  form.setValue("priceUnit", option.value, { shouldValidate: true });
+                  setOpen(false);
+                }}
+                className={cn(
+                  "w-full rounded-[7px] px-2.5 py-2 text-left font-archivo-medium text-[13px]",
+                  selected ? "bg-[#2F6BFF] text-white" : "text-grey-moss-900 hover:bg-[#F6F4EF]"
+                )}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }

--- a/components/CreateForm/Description.tsx
+++ b/components/CreateForm/Description.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Textarea } from "../ui/textarea";
+import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+
+const Description = () => {
+  const { creating } = useMomentCreateProvider();
+  const { form } = useMetadataFormProvider();
+
+  return (
+    <div className="flex w-full flex-col items-start">
+      <label
+        htmlFor="description"
+        className="mb-1 font-archivo-medium text-[10.5px] uppercase tracking-[0.14em] text-[#A8A296]"
+      >
+        description
+      </label>
+      <Textarea
+        id="description"
+        {...form.register("description")}
+        placeholder="What's the story behind this?"
+        minRows={2}
+        disabled={Boolean(creating)}
+        className="resize-none rounded-none border-0 border-b-[1.5px] border-[#DCD6CA] bg-transparent px-0.5 py-2 font-archivo text-[15px] text-grey-moss-900 shadow-none outline-none ring-0 placeholder:text-[#B4AEA2] focus-visible:border-grey-moss-900 focus-visible:ring-0 focus-visible:ring-offset-0"
+      />
+      {form.formState.errors.description && (
+        <p className="mt-1 font-archivo text-xs text-red-500">
+          {form.formState.errors.description.message}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default Description;

--- a/components/CreateForm/Preview.tsx
+++ b/components/CreateForm/Preview.tsx
@@ -1,10 +1,9 @@
 import Image from "next/image";
 import PreviewModal from "./PreviewModal";
 import WritingPreview from "./WritingPreview";
-import PreviewSection from "./PreviewSection";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import useTypeParam from "@/hooks/useTypeParam";
-import { useFileAspectRatio } from "@/hooks/useFileAspectRatio";
+import UploadProgressOverlay from "../MetadataCreation/UploadProgressOverlay";
 
 const Preview = () => {
   const {
@@ -18,37 +17,43 @@ const Preview = () => {
   } = useMetadataFormProvider();
   const type = useTypeParam();
 
-  const aspectRatio = useFileAspectRatio(previewFile);
-
-  // Show preview if we have selected files (blob data only - this is creation phase)
   const hasSelectedFile = previewFile || animationFile || imageFile;
   const showWritingPreview = writingText && !hasSelectedFile;
-  const showImagePreview = hasSelectedFile && !showWritingPreview;
+  const showImagePreview = hasSelectedFile && !showWritingPreview && previewFileUrl;
+  const showPreviewControls = hasSelectedFile || type === "link";
+
+  if (!showImagePreview && !showWritingPreview && !showPreviewControls) {
+    return null;
+  }
 
   return (
-    <div>
-      {showImagePreview && previewFileUrl && (
-        <PreviewSection
-          showProgress={isUploading}
-          uploadProgress={uploadProgress}
-          aspectRatio={aspectRatio}
-        >
-          <Image
-            key={previewFile ? `${previewFile.name}-${previewFile.lastModified}` : previewFileUrl}
-            layout="fill"
-            objectFit="cover"
-            objectPosition="center"
-            src={previewFileUrl}
-            alt="not found preview."
-          />
-        </PreviewSection>
-      )}
-      {showWritingPreview && (
-        <PreviewSection showProgress={isUploading} uploadProgress={uploadProgress}>
-          <WritingPreview />
-        </PreviewSection>
-      )}
-      {(hasSelectedFile || type === "link") && <PreviewModal />}
+    <div className="border-b border-[#E4E0D7] pb-5">
+      <div className="flex items-center gap-3">
+        {(showImagePreview || showWritingPreview) && (
+          <div className="relative size-[60px] shrink-0 overflow-hidden rounded-[10px] border border-[#E4E0D7]">
+            {showImagePreview && previewFileUrl && (
+              <Image
+                key={
+                  previewFile ? `${previewFile.name}-${previewFile.lastModified}` : previewFileUrl
+                }
+                layout="fill"
+                objectFit="cover"
+                objectPosition="center"
+                src={previewFileUrl}
+                alt="not found preview."
+              />
+            )}
+            {showWritingPreview && (
+              <div className="flex size-full items-center justify-center bg-[#FBFAF7] p-1">
+                <WritingPreview />
+              </div>
+            )}
+            {isUploading && <UploadProgressOverlay uploadProgress={uploadProgress} />}
+          </div>
+        )}
+        <div className="min-w-0 flex-1" />
+        {showPreviewControls && <PreviewModal />}
+      </div>
     </div>
   );
 };

--- a/components/CreateForm/PreviewModal.tsx
+++ b/components/CreateForm/PreviewModal.tsx
@@ -19,14 +19,14 @@ const PreviewModal = () => {
       >
         <button
           type="button"
-          className="disabled:opacity-1 z-10 w-fit transform self-center !rounded-sm border border-grey-moss-900 font-archivo !text-xl text-grey-moss-900 transition-transform duration-150 hover:border-grey-moss-300 hover:bg-grey-moss-300 hover:text-grey-eggshell disabled:!pointer-events-auto disabled:!cursor-not-allowed md:!mt-4 md:h-[60px] md:w-full"
+          className="shrink-0 rounded-[10px] border border-[#DCD6CA] bg-transparent px-3.5 py-2 font-archivo-medium text-[12.5px] uppercase tracking-[0.06em] text-grey-moss-900 transition-colors hover:bg-[#F1EEE8] disabled:!pointer-events-auto disabled:!cursor-not-allowed"
         >
           set preview
         </button>
       </DialogTrigger>
-      <DialogContent className="flex max-w-xl flex-col items-center !gap-0 overflow-hidden !rounded-3xl border-none !bg-white bg-transparent !px-4 py-6 shadow-lg">
+      <DialogContent className="flex max-w-[440px] flex-col items-center !gap-4 overflow-hidden !rounded-[18px] border-none !bg-white !px-[26px] py-[26px] shadow-[0_40px_90px_-30px_rgba(27,21,4,0.55)]">
         <VisuallyHidden>
-          <DialogTitle>Leave feedback</DialogTitle>
+          <DialogTitle>Preview</DialogTitle>
         </VisuallyHidden>
         <CropImageProvider>
           <UploadPreview />

--- a/components/CreateForm/Price.tsx
+++ b/components/CreateForm/Price.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import CurrencySelect from "./CurrencySelect";
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
@@ -14,12 +12,15 @@ export default function Price() {
   const isDisabled = Boolean(creating) || isCreating;
 
   return (
-    <div className="w-full pt-2">
-      <Label htmlFor="price" className="text-md font-archivo">
+    <div className="w-full">
+      <label
+        htmlFor="price"
+        className="mb-1 block font-archivo-medium text-[10.5px] uppercase tracking-[0.14em] text-[#A8A296]"
+      >
         price
-      </Label>
-      <div className="flex overflow-hidden border border-grey-secondary">
-        <Input
+      </label>
+      <div className="flex items-center gap-2.5 border-b-[1.5px] border-[#DCD6CA] px-0.5 pb-2 pt-1">
+        <input
           id="price"
           type="number"
           inputMode="decimal"
@@ -36,16 +37,13 @@ export default function Price() {
           onWheel={(e) => {
             e.currentTarget.blur();
           }}
-          className="flex-grow !rounded-[0px] !border-none bg-white !font-spectral [appearance:textfield] focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          className="min-w-0 flex-1 border-none bg-transparent font-archivo-bold text-[26px] tracking-[-0.01em] text-grey-moss-900 outline-none [appearance:textfield] focus:ring-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           disabled={isDisabled}
         />
-        <div className="bg-white">
-          <div className="my-2 h-6 w-[1px] bg-grey-secondary" />
-        </div>
         <CurrencySelect />
       </div>
       {form.formState.errors.price && (
-        <p className="mt-1 font-spectral text-xs text-red-500">
+        <p className="mt-1 font-archivo text-xs text-red-500">
           {form.formState.errors.price.message}
         </p>
       )}

--- a/components/CreateForm/Prompt.tsx
+++ b/components/CreateForm/Prompt.tsx
@@ -1,6 +1,4 @@
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
-import { Label } from "@/components/ui/label";
-import { Input } from "../ui/input";
 import usePrompt from "@/hooks/usePrompt";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 
@@ -10,17 +8,21 @@ const Prompt = () => {
   const { placeholder, onActive, promptRef, rotatePrompt } = usePrompt();
 
   return (
-    <div className="flex w-full flex-col items-start gap-2">
-      <Label htmlFor="title" className="text-md font-archivo">
+    <div className="flex w-full flex-col items-start">
+      <label
+        htmlFor="title"
+        className="mb-1 font-archivo-medium text-[10.5px] uppercase tracking-[0.14em] text-[#A8A296]"
+      >
         title
-      </Label>
-      <Input
+      </label>
+      <input
+        id="title"
         {...form.register("name")}
         placeholder={placeholder}
         onFocus={onActive}
         onBlur={rotatePrompt}
-        className="rounded-[0px] border border-grey bg-white !font-spectral !ring-0 !ring-offset-0"
         disabled={Boolean(creating)}
+        className="w-full border-0 border-b-[1.5px] border-[#DCD6CA] bg-transparent px-0.5 py-[9px] font-archivo text-[15px] text-grey-moss-900 outline-none transition-colors placeholder:text-[#B4AEA2] focus:border-grey-moss-900"
         ref={(e) => {
           const { ref } = form.register("name");
           ref(e);
@@ -34,7 +36,7 @@ const Prompt = () => {
         }}
       />
       {form.formState.errors.name && (
-        <p className="mt-1 font-spectral text-xs text-red-500">
+        <p className="mt-1 font-archivo text-xs text-red-500">
           {form.formState.errors.name.message}
         </p>
       )}

--- a/components/CreateForm/SplitsForm.tsx
+++ b/components/CreateForm/SplitsForm.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Button } from "../ui/button";
-import { Input } from "../ui/input";
 import { Plus, X } from "lucide-react";
 import { Controller } from "react-hook-form";
 import useSplitsForm from "@/hooks/useSplitsForm";
@@ -10,27 +8,29 @@ const SplitsForm = () => {
   const { form, fields, handleAddressChange, handleAddSplit, handleRemoveSplit } = useSplitsForm();
 
   return (
-    <div className="w-full pt-4">
-      <div className="mb-2 flex items-center justify-between">
-        <p className="font-archivo font-medium">splits</p>
-        <Button
+    <div className="w-full">
+      <div className="mb-2.5 flex items-center justify-between">
+        <label className="m-0 font-archivo-medium text-[10.5px] uppercase tracking-[0.14em] text-[#A8A296]">
+          revenue splits
+        </label>
+        <button
           type="button"
           onClick={handleAddSplit}
-          className="h-8 w-8 rounded-sm bg-black p-0 text-grey-eggshell hover:bg-grey-moss-300"
+          className="flex size-7 items-center justify-center rounded-lg bg-grey-moss-900 text-white"
         >
-          <Plus className="h-4 w-4" />
-        </Button>
+          <Plus className="size-[15px]" strokeWidth={1.75} />
+        </button>
       </div>
       <div className="flex flex-col gap-2">
         {fields.map((field, index) => (
           <div key={field.id} className="flex flex-col gap-1">
-            <div className="flex items-start gap-2">
-              <div className="flex flex-1 flex-col">
+            <div className="flex items-center gap-2">
+              <div className="min-w-0 flex-1">
                 <Controller
                   name={`splits.${index}.address`}
                   control={form.control}
                   render={({ field: formField }) => (
-                    <Input
+                    <input
                       type="text"
                       placeholder="address"
                       {...formField}
@@ -39,61 +39,59 @@ const SplitsForm = () => {
                         handleAddressChange(index, e.target.value);
                         form.trigger("splits");
                       }}
-                      className={`font-spectral ${form.formState.errors.splits?.[index]?.address ? "border-red-500" : ""}`}
+                      className={`w-full rounded-[9px] border bg-white px-3 py-2.5 font-archivo text-[13.5px] text-grey-moss-900 outline-none ${
+                        form.formState.errors.splits?.[index]?.address
+                          ? "border-red-500"
+                          : "border-[#DCD6CA]"
+                      }`}
                     />
                   )}
                 />
                 {form.formState.errors.splits?.[index]?.address && (
-                  <p className="mt-1 pl-0 font-spectral text-xs text-red-500">
+                  <p className="mt-1 font-archivo text-xs text-red-500">
                     {form.formState.errors.splits?.[index]?.address?.message}
                   </p>
                 )}
               </div>
-              <div className="flex items-center gap-2">
-                <Controller
-                  name={`splits.${index}.percentAllocation`}
-                  control={form.control}
-                  render={({ field: formField }) => (
-                    <Input
-                      type="number"
-                      placeholder="%"
-                      min="0"
-                      max="100"
-                      step="0.01"
-                      {...formField}
-                      value={formField.value || ""}
-                      onChange={(e) => {
-                        const val = e.target.value;
-                        const numValue = val === "" ? 0 : parseFloat(val);
-                        if (!isNaN(numValue) && numValue >= 0 && numValue <= 100) {
-                          formField.onChange(numValue);
-                          form.trigger("splits");
-                        }
-                      }}
-                      className="w-20 font-spectral"
-                    />
-                  )}
-                />
-                <Button
-                  type="button"
-                  onClick={() => handleRemoveSplit(index)}
-                  className="h-8 w-8 rounded-sm bg-black p-0 text-grey-eggshell hover:bg-grey-moss-300"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
+              <Controller
+                name={`splits.${index}.percentAllocation`}
+                control={form.control}
+                render={({ field: formField }) => (
+                  <input
+                    type="number"
+                    placeholder="%"
+                    min="0"
+                    max="100"
+                    step="0.01"
+                    {...formField}
+                    value={formField.value || ""}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      const numValue = val === "" ? 0 : parseFloat(val);
+                      if (!isNaN(numValue) && numValue >= 0 && numValue <= 100) {
+                        formField.onChange(numValue);
+                        form.trigger("splits");
+                      }
+                    }}
+                    className="w-14 shrink-0 rounded-[9px] border border-[#DCD6CA] bg-white px-2.5 py-2.5 text-center font-archivo text-[13.5px] text-grey-moss-900 outline-none"
+                  />
+                )}
+              />
+              <button
+                type="button"
+                onClick={() => handleRemoveSplit(index)}
+                className="flex size-[34px] shrink-0 items-center justify-center rounded-lg bg-grey-moss-900 text-white"
+              >
+                <X className="size-[15px]" strokeWidth={1.75} />
+              </button>
             </div>
           </div>
         ))}
       </div>
-      {fields.length > 0 && (
-        <div className="mt-2">
-          {form.formState.errors.splits && (
-            <p className="mt-1 font-spectral text-xs text-red-500">
-              {form.formState.errors.splits.message}
-            </p>
-          )}
-        </div>
+      {fields.length > 0 && form.formState.errors.splits && (
+        <p className="mt-2 font-archivo text-xs text-[#AA2E2E]">
+          {form.formState.errors.splits.message}
+        </p>
       )}
     </div>
   );

--- a/components/CreateForm/TotalSupplyInput.tsx
+++ b/components/CreateForm/TotalSupplyInput.tsx
@@ -1,19 +1,19 @@
 import { Controller } from "react-hook-form";
-import { Input } from "../ui/input";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 
 const TotalSupplyInput = () => {
   const { form } = useMetadataFormProvider();
 
   return (
-    <>
-      <p className="pt-2 font-archivo font-medium">Total Supply</p>
-
+    <div>
+      <label className="mb-1 block font-archivo-medium text-[10.5px] uppercase tracking-[0.14em] text-[#A8A296]">
+        total supply
+      </label>
       <Controller
         name="totalSupply"
         control={form.control}
         render={({ field }) => (
-          <Input
+          <input
             type="number"
             min={1}
             placeholder="Leave empty for open edition"
@@ -30,16 +30,16 @@ const TotalSupplyInput = () => {
               }
             }}
             onBlur={field.onBlur}
-            className="font-spectral"
+            className="w-full border-0 border-b-[1.5px] border-[#DCD6CA] bg-transparent px-0.5 py-[9px] font-archivo text-[15px] text-grey-moss-900 outline-none transition-colors placeholder:text-[#B4AEA2] focus:border-grey-moss-900"
           />
         )}
       />
       {form.formState.errors.totalSupply && (
-        <p className="mt-1 font-spectral text-xs text-red-500">
+        <p className="mt-1 font-archivo text-xs text-red-500">
           {form.formState.errors.totalSupply.message}
         </p>
       )}
-    </>
+    </div>
   );
 };
 

--- a/components/CreateForm/UploadPreview.tsx
+++ b/components/CreateForm/UploadPreview.tsx
@@ -1,6 +1,5 @@
 import { Fragment } from "react";
 import WritingPreview from "./WritingPreview";
-import { Label } from "../ui/label";
 import { useCropImageProvider } from "@/providers/CropImageProvider";
 import CropImage from "@/components/CropImage";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
@@ -13,7 +12,9 @@ const UploadPreview = () => {
 
   return (
     <Fragment>
-      <Label className="w-full text-center font-archivo-medium text-2xl">Preview</Label>
+      <div className="w-full text-center font-spectral-italic text-2xl text-grey-moss-900">
+        Preview
+      </div>
       <input
         type="file"
         className="hidden"
@@ -21,7 +22,7 @@ const UploadPreview = () => {
         accept="image/*"
         onChange={handlePreviewUpload}
       />
-      <div className="relative mt-2 aspect-video w-3/4 overflow-hidden border border-grey font-spectral">
+      <div className="relative aspect-[4/3] w-full overflow-hidden rounded-xl border border-[#E4E0D7] bg-[#EDEAE2] font-spectral">
         {previewFile ? (
           <CropImage />
         ) : (
@@ -30,28 +31,34 @@ const UploadPreview = () => {
               <WritingPreview />
             ) : (
               <div className="flex size-full items-center justify-center p-3">
-                <p className="font-spectral text-3xl">No Preview.</p>
+                <p className="font-archivo text-sm uppercase tracking-[0.08em] text-[#A8A296]">
+                  Drop thumbnail
+                </p>
               </div>
             )}
           </>
         )}
       </div>
-      <p className="font-spectral-italic">drag / zoom to resize</p>
-      <button
-        type="button"
-        className="disabled:opacity-1 mt-2 w-3/4 transform rounded-sm border border-grey-moss-900 py-2 font-archivo transition-transform duration-150 hover:border-grey-moss-300 hover:bg-grey-moss-300 hover:text-grey-eggshell disabled:!pointer-events-auto disabled:!cursor-not-allowed"
-        onClick={handleClick}
-      >
-        upload thumbnail
-      </button>
-      <button
-        type="button"
-        className="disabled:opacity-1 mt-2 w-3/4 transform rounded-sm bg-grey-moss-900 py-2 font-archivo text-grey-eggshell transition-transform duration-150 hover:border-grey-moss-300 hover:bg-grey-moss-300 disabled:!pointer-events-auto disabled:!cursor-not-allowed"
-        onClick={handleDoneClick}
-        disabled={isUploadingCrop}
-      >
-        {isUploadingCrop ? "saving..." : "done"}
-      </button>
+      <p className="text-center font-archivo text-xs uppercase tracking-[0.08em] text-[#A8A296]">
+        drag / zoom to resize
+      </p>
+      <div className="flex w-full gap-2.5">
+        <button
+          type="button"
+          className="flex-1 rounded-[11px] border border-[#DCD6CA] bg-transparent py-3 font-archivo-medium text-[13px] uppercase tracking-[0.06em] text-grey-moss-900 transition-colors hover:bg-[#F1EEE8]"
+          onClick={handleClick}
+        >
+          upload thumbnail
+        </button>
+        <button
+          type="button"
+          className="flex-1 rounded-[11px] bg-grey-moss-900 py-3.5 font-archivo-bold text-[13px] uppercase tracking-[0.06em] text-white transition-colors hover:bg-black disabled:opacity-50"
+          onClick={handleDoneClick}
+          disabled={isUploadingCrop}
+        >
+          {isUploadingCrop ? "saving..." : "done"}
+        </button>
+      </div>
     </Fragment>
   );
 };

--- a/components/CreateModeSelect/CreateModeSelect.tsx
+++ b/components/CreateModeSelect/CreateModeSelect.tsx
@@ -7,7 +7,11 @@ import MobileSelect from "./MobileSelect";
 const CreateModeSelect = () => {
   const isMobile = useIsMobile();
 
-  return <div className="col-span-1">{isMobile ? <MobileSelect /> : <DesktopSelect />}</div>;
+  if (isMobile) {
+    return <div className="col-span-1">{<MobileSelect />}</div>;
+  }
+
+  return <DesktopSelect />;
 };
 
 export default CreateModeSelect;

--- a/components/CreateModeSelect/DesktopSelect.tsx
+++ b/components/CreateModeSelect/DesktopSelect.tsx
@@ -1,8 +1,15 @@
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
-import CTAButton from "./CTAButton";
 import { useRouter, useSearchParams } from "next/navigation";
 import useTypeParam from "@/hooks/useTypeParam";
 import { getUrlWithType } from "@/lib/create/getUrlWithType";
+import { cn } from "@/lib/utils";
+
+const TABS = [
+  { label: "new moment", type: undefined },
+  { label: "new thought", type: "writing" },
+  { label: "new link", type: "link" },
+  { label: "new embed", type: "embed" },
+] as const;
 
 const DesktopSelect = () => {
   const { titleRef } = useMetadataFormProvider();
@@ -10,30 +17,38 @@ const DesktopSelect = () => {
   const searchParams = useSearchParams();
   const type = useTypeParam();
   const baseRoute = "/create";
-  const isCreatePage = !type;
-  const isWritingPage = type === "writing";
-  const isLinkPage = type === "link";
-  const isEmbedPage = type === "embed";
 
   const handleClick = (newType?: string) => {
     push(getUrlWithType(newType ?? null, searchParams.toString(), baseRoute));
   };
+
+  const isActive = (tabType: string | undefined) =>
+    tabType === undefined ? !type : type === tabType;
+
   return (
-    <div className="h-fit w-full lg:max-w-[250px] xl:max-w-[300px]">
-      <div ref={titleRef} className="flex flex-col gap-3 pb-3">
-        <CTAButton isActive={isCreatePage} onClick={() => handleClick()}>
-          new moment
-        </CTAButton>
-        <CTAButton isActive={isWritingPage} onClick={() => handleClick("writing")}>
-          new thought
-        </CTAButton>
-        <CTAButton isActive={isLinkPage} onClick={() => handleClick("link")}>
-          new link
-        </CTAButton>
-        <CTAButton isActive={isEmbedPage} onClick={() => handleClick("embed")}>
-          new embed
-        </CTAButton>
-      </div>
+    <div
+      ref={titleRef}
+      className="mb-6 flex shrink-0 items-center gap-[30px] border-b-[1.5px] border-[#DCD6CA]"
+    >
+      {TABS.map((tab) => {
+        const active = isActive(tab.type);
+        return (
+          <button
+            key={tab.label}
+            type="button"
+            onClick={() => handleClick(tab.type)}
+            className={cn(
+              "relative px-0.5 pb-3.5 font-archivo-medium text-[12.5px] uppercase tracking-[0.12em] transition-colors",
+              active ? "text-grey-moss-900" : "text-[#A8A296] hover:text-grey-moss-900"
+            )}
+          >
+            {tab.label}
+            {active && (
+              <span className="absolute inset-x-0 -bottom-px z-[1] h-0.5 bg-grey-moss-900" />
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -12,22 +12,24 @@ import useIsMobile from "@/hooks/useIsMobile";
 const Layout = ({ children }: { children: ReactNode }) => {
   const { isOpenNavbar } = useLayoutProvider();
   const pathname = usePathname();
-  const isTextureLayout = !pathname.includes("/create");
+  const isCreatePage = pathname.includes("/create");
   const isMobile = useIsMobile();
 
   return (
     <MobileDrawersProvider>
       <div
-        className={cn("relative flex grow flex-col", isOpenNavbar && "h-screen overflow-hidden")}
-      >
-        {isTextureLayout && (
-          <div
-            aria-hidden
-            className="pointer-events-none fixed inset-0 z-0 bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat"
-          />
+        className={cn(
+          "relative flex grow flex-col",
+          isOpenNavbar && "h-screen overflow-hidden",
+          isCreatePage && "md:h-screen md:overflow-hidden"
         )}
+      >
+        <div
+          aria-hidden
+          className="pointer-events-none fixed inset-0 z-0 bg-[url('/bg-gray.png')] bg-cover bg-top bg-no-repeat"
+        />
         <Header />
-        <div className="relative z-10 flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:pb-0 md:pt-0">
+        <div className="relative z-10 flex grow flex-col pt-[calc(54px+env(safe-area-inset-top,0px))] pb-[calc(74px+env(safe-area-inset-bottom,0px))] md:min-h-0 md:pb-0 md:pt-0">
           {children}
         </div>
         {isMobile && <Footer />}

--- a/components/MetadataCreation/CollectionTag.tsx
+++ b/components/MetadataCreation/CollectionTag.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Feather } from "lucide-react";
+import { useCollectionsProvider } from "@/providers/CollectionsProvider";
+import { useMetadata } from "@/hooks/useMetadata";
+import BlurImage from "@/components/BlurImage";
+
+const CollectionTag = () => {
+  const {
+    collections,
+    selectedCollection,
+    isLoading: isCollectionsLoading,
+  } = useCollectionsProvider();
+
+  const selectedItem = collections.find(
+    (c) => c.address.toLowerCase() === selectedCollection?.toLowerCase()
+  );
+  const { data: metadata, isLoading: isMetadataLoading } = useMetadata(selectedItem?.uri ?? "");
+
+  if (isCollectionsLoading && !selectedItem) {
+    return (
+      <div className="inline-flex h-[28px] w-[88px] animate-pulse items-center rounded-full border border-[#E0DDD8] bg-white/65" />
+    );
+  }
+
+  if (!selectedItem) return null;
+
+  const imageUrl = metadata?.image;
+  const showImage = Boolean(imageUrl) && !isMetadataLoading;
+
+  return (
+    <div className="inline-flex items-center gap-[7px] rounded-full border border-[#E0DDD8] bg-white/65 px-[11px] py-[5px]">
+      {showImage ? (
+        <div className="relative size-[13px] shrink-0 overflow-hidden rounded-full">
+          <BlurImage src={imageUrl!} alt={selectedItem.name} fill className="object-cover" />
+        </div>
+      ) : (
+        <Feather className="size-[13px] shrink-0 text-tan-gold" strokeWidth={1.75} />
+      )}
+      <span className="font-archivo-medium text-[11px] tracking-[0.04em] text-grey-moss-900">
+        {selectedItem.name}
+      </span>
+    </div>
+  );
+};
+
+export default CollectionTag;

--- a/components/MetadataCreation/FileSelect.tsx
+++ b/components/MetadataCreation/FileSelect.tsx
@@ -28,10 +28,12 @@ const FileSelect = () => {
         disabled={Boolean(createdTokenId)}
       />
       {selected ? (
-        <>
-          {!createdTokenId && <ResetButton />}
-          <PreviewContainer handleImageClick={handleImageClick} />
-        </>
+        <div className="flex size-full items-center justify-center">
+          <div className="relative size-full overflow-hidden md:h-full md:max-h-full md:max-w-full">
+            {!createdTokenId && <ResetButton />}
+            <PreviewContainer handleImageClick={handleImageClick} />
+          </div>
+        </div>
       ) : (
         <NoFileSelected onSingleFile={handleSingleFile} />
       )}

--- a/components/MetadataCreation/Layout.tsx
+++ b/components/MetadataCreation/Layout.tsx
@@ -4,6 +4,7 @@ import CreateForm from "../CreateForm";
 import CreateModeSelect from "../CreateModeSelect";
 import MaskLines from "../CreateModeSelect/MaskLines";
 import Preview from "./Preview";
+import StageFooter from "./StageFooter";
 import BulkCenterGrid from "@/components/BulkUpload/BulkCenterGrid";
 import BulkSideForm from "@/components/BulkUpload/BulkSideForm";
 import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
@@ -14,9 +15,14 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <MaskLines />
-      <CreateModeSelect />
-      {isBulkMode ? <BulkCenterGrid /> : <Preview>{children}</Preview>}
-      {isBulkMode ? <BulkSideForm /> : <CreateForm />}
+      <section className="col-span-1 flex min-h-0 w-full flex-col md:flex-1 md:overflow-hidden md:px-11 md:pb-8 md:pt-7">
+        <CreateModeSelect />
+        {isBulkMode ? <BulkCenterGrid /> : <Preview>{children}</Preview>}
+        <StageFooter />
+      </section>
+      <aside className="col-span-1 w-full md:flex md:h-full md:w-[400px] md:shrink-0 md:flex-col md:overflow-y-auto md:border-l md:border-[#E0DDD8] md:bg-white/[.72] md:px-[34px] md:pb-10 md:pt-[34px] md:backdrop-blur-[16px]">
+        {isBulkMode ? <BulkSideForm /> : <CreateForm />}
+      </aside>
     </>
   );
 };

--- a/components/MetadataCreation/NoFileSelected.tsx
+++ b/components/MetadataCreation/NoFileSelected.tsx
@@ -11,7 +11,7 @@ const NoFileSelected = ({ onSingleFile }: NoFileSelectedProps) => {
   if (!onSingleFile) return <SimpleDropHint />;
 
   return (
-    <div className="size-full p-4">
+    <div className="size-full md:p-0">
       <BulkDropZone onSingleFile={onSingleFile} />
     </div>
   );

--- a/components/MetadataCreation/Preview.tsx
+++ b/components/MetadataCreation/Preview.tsx
@@ -2,12 +2,13 @@ import useIsMobile from "@/hooks/useIsMobile";
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
 import useTypeParam from "@/hooks/useTypeParam";
 import { ReactNode, useMemo } from "react";
+import { cn } from "@/lib/utils";
 
 const Preview = ({ children }: { children: ReactNode }) => {
   const { createdTokenId } = useMomentCreateProvider();
   const type = useTypeParam();
   const isMobile = useIsMobile();
-  const gridVisible = useMemo(() => {
+  const frameVisible = useMemo(() => {
     if (type === "link" && isMobile) return false;
     if (type === "embed" && isMobile) return false;
     if (createdTokenId) return false;
@@ -18,7 +19,17 @@ const Preview = ({ children }: { children: ReactNode }) => {
 
   return (
     <div
-      className={`w-full ${createdTokenId ? (isWritingPage || isCreatingPage ? "min-h-[300px]" : "min-h-auto") : "min-h-[400px]"} md:min-h-auto relative md:aspect-[571/692] overflow-hidden ${gridVisible && "bg-[url('/grid.svg')]"} bg-contain`}
+      className={cn(
+        "relative w-full overflow-hidden",
+        createdTokenId
+          ? isWritingPage || isCreatingPage
+            ? "min-h-[300px]"
+            : "min-h-auto"
+          : "min-h-[400px]",
+        "md:min-h-0 md:flex-1 md:aspect-auto",
+        frameVisible &&
+          "rounded-[12px] border border-[#E4E0D7] bg-[repeating-linear-gradient(45deg,#F1EEE8_0_12px,#EAE6DD_12px_24px)] shadow-[0_8px_26px_-12px_rgba(27,21,4,.3)] md:shadow-[0_10px_34px_-14px_rgba(27,21,4,.32)]"
+      )}
     >
       {children}
     </div>

--- a/components/MetadataCreation/ResetButton.tsx
+++ b/components/MetadataCreation/ResetButton.tsx
@@ -1,5 +1,5 @@
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
-import { TrashIcon } from "@radix-ui/react-icons";
+import { X } from "lucide-react";
 
 interface ResetButtonProps {
   onReset?: () => void;
@@ -16,10 +16,11 @@ const ResetButton = ({ onReset }: ResetButtonProps) => {
   return (
     <button
       type="button"
-      className="absolute right-4 top-4 z-10 rounded-full bg-grey p-2 text-white"
+      aria-label="Remove media"
+      className="absolute right-3 top-3 z-10 flex size-[30px] items-center justify-center rounded-full bg-grey-moss-900 text-white shadow-[0_4px_12px_rgba(0,0,0,0.35)]"
       onClick={handleClick}
     >
-      <TrashIcon className="size-4" />
+      <X className="size-4" strokeWidth={1.75} />
     </button>
   );
 };

--- a/components/MetadataCreation/StageFooter.tsx
+++ b/components/MetadataCreation/StageFooter.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import CollectionTag from "./CollectionTag";
+import CreateButton from "@/components/CreateForm/CreateButton";
+import BulkCreateButton from "@/components/BulkUpload/BulkCreateButton";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+
+const StageFooter = () => {
+  const { isBulkMode } = useBulkCreateProvider();
+
+  return (
+    <div className="mt-[22px] hidden shrink-0 items-center justify-between gap-4 md:flex">
+      <CollectionTag />
+      <div className="shrink-0">{isBulkMode ? <BulkCreateButton /> : <CreateButton />}</div>
+    </div>
+  );
+};
+
+export default StageFooter;

--- a/hooks/useCurrencySelect.ts
+++ b/hooks/useCurrencySelect.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+
+export const CURRENCY_OPTIONS = [
+  { value: "eth", label: "ETH" },
+  { value: "usdc", label: "USD" },
+] as const;
+
+export type CurrencyOptionValue = (typeof CURRENCY_OPTIONS)[number]["value"];
+
+const useCurrencySelect = () => {
+  const { form } = useMetadataFormProvider();
+  const { creating } = useMomentCreateProvider();
+  const { isCreating } = useBulkCreateProvider();
+  const disabled = Boolean(creating) || isCreating;
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const priceUnit = form.watch("priceUnit");
+  const current = CURRENCY_OPTIONS.find((o) => o.value === priceUnit) ?? CURRENCY_OPTIONS[1];
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  const toggleOpen = () => setOpen((v) => !v);
+
+  const selectCurrency = (value: CurrencyOptionValue) => {
+    form.setValue("priceUnit", value, { shouldValidate: true });
+    setOpen(false);
+  };
+
+  return {
+    disabled,
+    open,
+    rootRef,
+    priceUnit,
+    current,
+    options: CURRENCY_OPTIONS,
+    toggleOpen,
+    selectCurrency,
+  };
+};
+
+export default useCurrencySelect;


### PR DESCRIPTION
## Summary
- Rebuild the desktop create page as a two-column studio: left media gallery stage with horizontal type tabs, right inspector for moment details
- Move create CTA next to the selected collection badge under the media stage, and keep set-preview at the top of the inspector
- Restyle dropzone, form fields, price/currency, advanced, and preview chrome to match the new design while preserving existing create/bulk flows

## Test plan
- [ ] Open `/create` on desktop and confirm paper texture background, horizontal tabs, and two-column layout
- [ ] Empty state shows dropzone; single file shows media preview with MomentMediaFrame-style striped backdrop; multi-file bulk grid works
- [ ] Changing collection in the inspector updates the left collection badge
- [ ] Set preview stays visible at the top of the inspector without scrolling past Details
- [ ] Create button sits on the same row as the collection badge and successfully creates a moment
- [ ] Mobile create flow still works (create button remains in the form)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added description, pricing, currency selection, collection details, and improved preview controls to creation forms.
  * Added an “Add media” control for bulk uploads.
  * Added responsive create-type tabs and a footer with context-aware creation actions.
  * Added support for collection badges with collection imagery or fallback icons.

* **Improvements**
  * Refreshed bulk upload, creation form, preview, dropdown, and split-allocation interfaces.
  * Improved responsive layouts and mobile behavior across creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->