### PR TITLE
Clear media on create tab switch

### DIFF
--- a/components/CreateForm/ClearMediaOnCreateTypeChange.tsx
+++ b/components/CreateForm/ClearMediaOnCreateTypeChange.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import useClearMediaOnCreateTypeChange from "@/hooks/useClearMediaOnCreateTypeChange";
+
+const ClearMediaOnCreateTypeChange = () => {
+  useClearMediaOnCreateTypeChange();
+  return null;
+};
+
+export default ClearMediaOnCreateTypeChange;

--- a/components/MetadataCreation/EmbedCode.tsx
+++ b/components/MetadataCreation/EmbedCode.tsx
@@ -32,7 +32,7 @@ const EmbedCode = () => {
               height={66}
               className="block md:hidden"
             />
-            <p className="text-center font-archivo-medium">paste embed code</p>
+            <p className="text-center font-archivo-medium uppercase">paste embed code</p>
           </div>
           <textarea
             className="w-full grow bg-grey-moss-50 p-2 font-spectral !outline-none !ring-0"

--- a/components/MetadataCreation/LinkPreview.tsx
+++ b/components/MetadataCreation/LinkPreview.tsx
@@ -41,7 +41,9 @@ const LinkPreview = () => {
               height={44}
               alt="not found link"
             />
-            <p className="text-center font-archivo-medium">Paste any link from the internet</p>
+            <p className="text-center font-archivo-medium uppercase">
+              Paste any link from the internet
+            </p>
           </div>
           <LinkInput />
           {previewFileUrl && (

--- a/hooks/useClearMediaOnCreateTypeChange.ts
+++ b/hooks/useClearMediaOnCreateTypeChange.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import useTypeParam from "@/hooks/useTypeParam";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+
+/**
+ * On create-tab switches, keep form details (title, price, collection, etc.)
+ * and clear only media-related state (files, writing, link, embed, bulk).
+ */
+const useClearMediaOnCreateTypeChange = () => {
+  const type = useTypeParam();
+  const { resetFiles, setIsOpenPreviewUpload } = useMetadataFormProvider();
+  const { clearAll } = useBulkCreateProvider();
+  const prevTypeRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (prevTypeRef.current === undefined) {
+      prevTypeRef.current = type;
+      return;
+    }
+    if (prevTypeRef.current === type) return;
+    prevTypeRef.current = type;
+
+    resetFiles();
+    clearAll();
+    setIsOpenPreviewUpload(false);
+  }, [type, resetFiles, clearAll, setIsOpenPreviewUpload]);
+};
+
+export default useClearMediaOnCreateTypeChange;

--- a/hooks/useMetadataForm.ts
+++ b/hooks/useMetadataForm.ts
@@ -1,7 +1,7 @@
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createFormSchema, CreateFormData } from "@/lib/schema/createFormSchema";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useBlobUrls } from "./useBlobUrls";
 import { Currency } from "@/types/balances";
 
@@ -70,7 +70,7 @@ const useMetadataForm = () => {
   const onChangeStartDate = (val: Date) =>
     form.setValue("startDate", val, { shouldValidate: false });
 
-  const clearMediaState = () => {
+  const clearMediaState = useCallback(() => {
     setImageFile(null);
     setAnimationFile(null);
     setPreviewFile(null);
@@ -79,21 +79,24 @@ const useMetadataForm = () => {
     setEmbedCode("");
     setLink("");
     setWritingText("");
-  };
+    setUploadProgress(0);
+    setIsUploading(false);
+    setIsOpenPreviewUpload(false);
+  }, []);
 
-  const resetForm = () => {
+  const resetForm = useCallback(() => {
     form.setValue("name", "", { shouldValidate: false });
     form.setValue("description", undefined, { shouldValidate: false });
     clearMediaState();
-  };
+  }, [form, clearMediaState]);
 
-  const resetFiles = () => {
+  const resetFiles = useCallback(() => {
     clearMediaState();
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
     // name and description live in form — clearMediaState doesn't touch them
-  };
+  }, [clearMediaState]);
 
   const hasMedia = Boolean(previewFile || imageFile || animationFile);
 

--- a/providers/MomentCreateProvider/MomentCreateProviderWrapper.tsx
+++ b/providers/MomentCreateProvider/MomentCreateProviderWrapper.tsx
@@ -5,6 +5,7 @@ import { MetadataFormProvider } from "../MetadataFormProvider";
 import { MetadataUploadProvider } from "../MetadataUploadProvider";
 import { MomentCreateProvider } from "./MomentCreateProvider";
 import { BulkCreateProvider } from "../BulkCreateProvider";
+import ClearMediaOnCreateTypeChange from "@/components/CreateForm/ClearMediaOnCreateTypeChange";
 
 interface MomentCreateProviderWrapperProps {
   children: React.ReactNode;
@@ -15,7 +16,10 @@ const MomentCreateProviderWrapper = ({ children }: MomentCreateProviderWrapperPr
     <MetadataFormProvider>
       <MetadataUploadProvider>
         <MomentCreateProvider>
-          <BulkCreateProvider>{children}</BulkCreateProvider>
+          <BulkCreateProvider>
+            <ClearMediaOnCreateTypeChange />
+            {children}
+          </BulkCreateProvider>
         </MomentCreateProvider>
       </MetadataUploadProvider>
     </MetadataFormProvider>

--- a/providers/NounsCreateProvider/NounsCreateProviderWrapper.tsx
+++ b/providers/NounsCreateProvider/NounsCreateProviderWrapper.tsx
@@ -6,12 +6,14 @@ import { MetadataUploadProvider } from "../MetadataUploadProvider";
 import { MomentCreateProvider } from "../MomentCreateProvider/MomentCreateProvider";
 import { BulkCreateProvider } from "../BulkCreateProvider";
 import { NounsProposalProvider } from "./NounsProposalProvider";
+import ClearMediaOnCreateTypeChange from "@/components/CreateForm/ClearMediaOnCreateTypeChange";
 
 const NounsCreateProviderWrapper = ({ children }: { children: React.ReactNode }) => (
   <MetadataFormProvider>
     <MetadataUploadProvider>
       <MomentCreateProvider>
         <BulkCreateProvider>
+          <ClearMediaOnCreateTypeChange />
           <NounsProposalProvider>{children}</NounsProposalProvider>
         </BulkCreateProvider>
       </MomentCreateProvider>


### PR DESCRIPTION
## Summary
- Clear media-related create state when switching between moment / thought / link / embed tabs, while preserving details fields (title, price, collection, description, advanced)
- Also clear bulk selections and close the preview modal on tab change
- Uppercase the embed and link stage labels for consistency with the create redesign

## Test plan
- [ ] On `/create`, enter a title/price, add media, then switch to thought — title/price remain, media is cleared
- [ ] Enter writing text on thought, switch to link — writing is cleared, details remain
- [ ] Paste a link, switch to moment — link/preview cleared
- [ ] Select multiple files in bulk mode, switch tabs — bulk selection cleared
- [ ] Confirm embed/link headlines render in uppercase


Made with [Cursor](https://cursor.com)