### PR TITLE
Redesign create and success pages for mobile

### DIFF
--- a/components/CreateSuccess/Buttons.tsx
+++ b/components/CreateSuccess/Buttons.tsx
@@ -11,9 +11,9 @@ interface ButtonsProps {
 }
 
 const PRIMARY_BUTTON_CLASS =
-  "flex-1 rounded-[12px] px-4 py-[15px] font-archivo-bold text-[15px] transition-colors";
+  "flex-1 rounded-[12px] px-[15px] py-[15px] font-archivo-bold text-[15px] transition-colors";
 const SECONDARY_BUTTON_CLASS =
-  "flex-1 rounded-[11px] border border-[#E4E0D7] bg-white px-4 py-[13px] font-archivo-medium text-[13.5px] transition-colors hover:bg-[#F7F5F0]";
+  "flex-1 rounded-[11px] border border-[#E4E0D7] bg-white p-[12px] font-archivo-medium text-[13.5px] transition-colors hover:bg-[#F7F5F0]";
 
 const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps) => {
   const { push } = useRouter();
@@ -50,7 +50,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
 
   return (
     <>
-      <div className="mt-3 flex flex-col gap-3 md:flex-row md:gap-3">
+      <div className="mt-[18px] flex flex-row gap-[11px]">
         <button
           type="button"
           onClick={() => setShareOpen((current) => !current)}
@@ -60,32 +60,32 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
           <Share2 className="size-[18px]" strokeWidth={1.75} />
           Share
         </button>
-        <button
+          <button
           type="button"
           onClick={() => timelineHref && push(timelineHref)}
           disabled={!timelineHref}
           className={`${PRIMARY_BUTTON_CLASS} inline-flex items-center justify-center gap-2 border border-[#DCD6CA] bg-transparent font-archivo-medium text-grey-moss-900 hover:bg-[#F1EEE8] disabled:cursor-not-allowed disabled:opacity-50`}
         >
           <LayoutGrid className="size-[18px]" strokeWidth={1.75} />
-          Visit timeline
+          Timeline
         </button>
       </div>
       {shareOpen && (
-        <div className="mt-3 flex flex-col gap-2.5 sm:flex-row">
+        <div className="mt-[11px] flex flex-row gap-[9px]">
           <button
             type="button"
             onClick={handleXShare}
             disabled={!shareUrl}
-            className={`${SECONDARY_BUTTON_CLASS} disabled:cursor-not-allowed disabled:opacity-50`}
+            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
           >
-            <span className="font-archivo-bold">X</span>
-            <span className="ml-2">Post</span>
+            <span className="font-archivo-bold">𝕏</span>
+            <span>Post</span>
           </button>
           <button
             type="button"
             onClick={handleFarcasterShare}
             disabled={!shareUrl}
-            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-2 disabled:cursor-not-allowed disabled:opacity-50`}
+            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
           >
             <Image src="/images/farcaster.svg" alt="Farcaster icon" width={18} height={18} />
             Farcaster
@@ -94,7 +94,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
             type="button"
             onClick={handleCopyLink}
             disabled={!shareUrl}
-            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-2 disabled:cursor-not-allowed disabled:opacity-50`}
+            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
           >
             {copied ? (
               <Check className="size-4" strokeWidth={1.75} />

--- a/components/CreateSuccess/Buttons.tsx
+++ b/components/CreateSuccess/Buttons.tsx
@@ -13,7 +13,7 @@ interface ButtonsProps {
 const PRIMARY_BUTTON_CLASS =
   "flex-1 whitespace-nowrap rounded-[12px] px-[15px] py-[15px] font-archivo-bold text-[15px] transition-colors";
 const SECONDARY_BUTTON_CLASS =
-  "flex-1 whitespace-nowrap rounded-[11px] border border-[#E4E0D7] bg-white p-[12px] font-archivo-medium text-[13.5px] transition-colors hover:bg-[#F7F5F0]";
+  "flex-1 rounded-[11px] border border-[#E4E0D7] bg-white p-[12px] font-archivo-medium text-[13.5px] transition-colors hover:bg-[#F7F5F0]";
 
 const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps) => {
   const { push } = useRouter();
@@ -50,7 +50,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
 
   return (
     <>
-      <div className="mt-[12px] flex flex-row gap-[11px]">
+      <div className="flex flex-row gap-[11px]">
         <button
           type="button"
           onClick={() => setShareOpen((current) => !current)}
@@ -60,14 +60,15 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
           <Share2 className="size-[18px]" strokeWidth={1.75} />
           Share
         </button>
-          <button
+        <button
           type="button"
           onClick={() => timelineHref && push(timelineHref)}
           disabled={!timelineHref}
           className={`${PRIMARY_BUTTON_CLASS} inline-flex items-center justify-center gap-2 border border-[#DCD6CA] bg-transparent font-archivo-medium text-grey-moss-900 hover:bg-[#F1EEE8] disabled:cursor-not-allowed disabled:opacity-50`}
         >
           <LayoutGrid className="size-[18px]" strokeWidth={1.75} />
-          Timeline
+          <span className="md:hidden">Timeline</span>
+          <span className="hidden md:inline">Visit timeline</span>
         </button>
       </div>
       {shareOpen && (
@@ -76,25 +77,25 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
             type="button"
             onClick={handleXShare}
             disabled={!shareUrl}
-            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
+            className={`${SECONDARY_BUTTON_CLASS} inline-flex flex-col items-center justify-center gap-1.5 md:flex-row md:gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
           >
-            <span className="font-archivo-bold whitespace-nowrap">𝕏</span>
+            <span className="font-archivo-bold whitespace-nowrap leading-none">𝕏</span>
             <span className="whitespace-nowrap">Post</span>
           </button>
           <button
             type="button"
             onClick={handleFarcasterShare}
             disabled={!shareUrl}
-            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
+            className={`${SECONDARY_BUTTON_CLASS} inline-flex flex-col items-center justify-center gap-1.5 md:flex-row md:gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
           >
             <Image src="/images/farcaster.svg" alt="Farcaster icon" width={18} height={18} />
-            Farcaster
+            <span className="whitespace-nowrap">Farcaster</span>
           </button>
           <button
             type="button"
             onClick={handleCopyLink}
             disabled={!shareUrl}
-            className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
+            className={`${SECONDARY_BUTTON_CLASS} inline-flex flex-col items-center justify-center gap-1.5 md:flex-row md:gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
           >
             {copied ? (
               <Check className="size-4" strokeWidth={1.75} />

--- a/components/CreateSuccess/Buttons.tsx
+++ b/components/CreateSuccess/Buttons.tsx
@@ -11,9 +11,9 @@ interface ButtonsProps {
 }
 
 const PRIMARY_BUTTON_CLASS =
-  "flex-1 rounded-[12px] px-[15px] py-[15px] font-archivo-bold text-[15px] transition-colors";
+  "flex-1 whitespace-nowrap rounded-[12px] px-[15px] py-[15px] font-archivo-bold text-[15px] transition-colors";
 const SECONDARY_BUTTON_CLASS =
-  "flex-1 rounded-[11px] border border-[#E4E0D7] bg-white p-[12px] font-archivo-medium text-[13.5px] transition-colors hover:bg-[#F7F5F0]";
+  "flex-1 whitespace-nowrap rounded-[11px] border border-[#E4E0D7] bg-white p-[12px] font-archivo-medium text-[13.5px] transition-colors hover:bg-[#F7F5F0]";
 
 const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps) => {
   const { push } = useRouter();
@@ -50,7 +50,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
 
   return (
     <>
-      <div className="mt-[18px] flex flex-row gap-[11px]">
+      <div className="mt-[14px] flex flex-row gap-[11px]">
         <button
           type="button"
           onClick={() => setShareOpen((current) => !current)}
@@ -71,15 +71,15 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
         </button>
       </div>
       {shareOpen && (
-        <div className="mt-[11px] flex flex-row gap-[9px]">
+        <div className="mt-[9px] flex flex-row gap-[9px]">
           <button
             type="button"
             onClick={handleXShare}
             disabled={!shareUrl}
             className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-[7px] disabled:cursor-not-allowed disabled:opacity-50`}
           >
-            <span className="font-archivo-bold">𝕏</span>
-            <span>Post</span>
+            <span className="font-archivo-bold whitespace-nowrap">𝕏</span>
+            <span className="whitespace-nowrap">Post</span>
           </button>
           <button
             type="button"
@@ -101,7 +101,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
             ) : (
               <Copy className="size-4" strokeWidth={1.75} />
             )}
-            {copied ? "Copied" : "Copy link"}
+            <span className="whitespace-nowrap">{copied ? "Copied" : "Copy link"}</span>
           </button>
         </div>
       )}

--- a/components/CreateSuccess/Buttons.tsx
+++ b/components/CreateSuccess/Buttons.tsx
@@ -50,7 +50,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
 
   return (
     <>
-      <div className="mt-[14px] flex flex-row gap-[11px]">
+      <div className="mt-[12px] flex flex-row gap-[11px]">
         <button
           type="button"
           onClick={() => setShareOpen((current) => !current)}
@@ -71,7 +71,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
         </button>
       </div>
       {shareOpen && (
-        <div className="mt-[9px] flex flex-row gap-[9px]">
+        <div className="mt-[8px] flex flex-row gap-[9px]">
           <button
             type="button"
             onClick={handleXShare}

--- a/components/CreateSuccess/Buttons.tsx
+++ b/components/CreateSuccess/Buttons.tsx
@@ -1,7 +1,8 @@
-import { Check, Copy, LayoutGrid, Share2, Webhook } from "lucide-react";
+import { Check, Copy, LayoutGrid, Share2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import Image from "next/image";
 
 interface ButtonsProps {
   shareUrl?: string;
@@ -86,7 +87,7 @@ const Buttons = ({ shareUrl, timelineHref, shareTitle = "moment" }: ButtonsProps
             disabled={!shareUrl}
             className={`${SECONDARY_BUTTON_CLASS} inline-flex items-center justify-center gap-2 disabled:cursor-not-allowed disabled:opacity-50`}
           >
-            <Webhook className="size-4" strokeWidth={1.75} />
+            <Image src="/images/farcaster.svg" alt="Farcaster icon" width={18} height={18} />
             Farcaster
           </button>
           <button

--- a/components/CreateSuccess/CreateSuccess.tsx
+++ b/components/CreateSuccess/CreateSuccess.tsx
@@ -69,7 +69,7 @@ const CreateSuccess = () => {
 
   return (
     <div className="col-span-1 w-full md:col-span-2">
-      <div className="mx-auto mt-8 w-full max-w-[1440px] px-6 pb-12 md:mt-6 md:px-14 md:pb-20">
+      <div className="mx-auto mt-8 w-full max-w-[1440px] px-[18px] pb-12 md:mt-6 md:px-14 md:pb-20">
         <button
           type="button"
           onClick={handleBackToCreate}

--- a/components/CreateSuccess/CreateSuccess.tsx
+++ b/components/CreateSuccess/CreateSuccess.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
@@ -16,6 +16,7 @@ import useMomentData from "@/hooks/useMomentData";
 import type { Address } from "viem";
 import MomentsGridPreview from "@/components/MomentsGrid/Preview";
 import { Skeleton } from "@/components/ui/skeleton";
+import fireCollectConfetti from "@/lib/moment/fireCollectConfetti";
 
 const CreateSuccess = () => {
   const { name, description, price, priceUnit, resetForm } = useMetadataFormProvider();
@@ -48,6 +49,16 @@ const CreateSuccess = () => {
   const { metadata: momentMetadata, owner, isLoading } = useMomentData(moment);
   const personalTimelineHref = owner ? `/${owner.toLowerCase()}` : undefined;
   const showSuccessSkeleton = Boolean(liveTokenId) && isLoading && !momentMetadata;
+
+  const hasFiredConfettiRef = useRef(false);
+  useEffect(() => {
+    if (hasFiredConfettiRef.current) return;
+    if (!liveTokenId) return;
+    if (showSuccessSkeleton) return;
+    if (!momentMetadata) return;
+    hasFiredConfettiRef.current = true;
+    fireCollectConfetti();
+  }, [liveTokenId, showSuccessSkeleton, momentMetadata]);
 
   const displayedName = momentMetadata?.name?.trim() || name.trim() || "Untitled moment";
   const trimmedDescription = momentMetadata?.description?.trim() || description?.trim() || "";

--- a/components/CreateSuccess/CreateSuccess.tsx
+++ b/components/CreateSuccess/CreateSuccess.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
@@ -16,7 +16,7 @@ import useMomentData from "@/hooks/useMomentData";
 import type { Address } from "viem";
 import MomentsGridPreview from "@/components/MomentsGrid/Preview";
 import { Skeleton } from "@/components/ui/skeleton";
-import fireCollectConfetti from "@/lib/moment/fireCollectConfetti";
+import useFireCreateSuccessConfetti from "@/hooks/useFireCreateSuccessConfetti";
 
 const CreateSuccess = () => {
   const { name, description, price, priceUnit, resetForm } = useMetadataFormProvider();
@@ -50,15 +50,7 @@ const CreateSuccess = () => {
   const personalTimelineHref = owner ? `/${owner.toLowerCase()}` : undefined;
   const showSuccessSkeleton = Boolean(liveTokenId) && isLoading && !momentMetadata;
 
-  const hasFiredConfettiRef = useRef(false);
-  useEffect(() => {
-    if (hasFiredConfettiRef.current) return;
-    if (!liveTokenId) return;
-    if (showSuccessSkeleton) return;
-    if (!momentMetadata) return;
-    hasFiredConfettiRef.current = true;
-    fireCollectConfetti();
-  }, [liveTokenId, showSuccessSkeleton, momentMetadata]);
+  useFireCreateSuccessConfetti({ liveTokenId, isLoading, momentMetadata });
 
   const displayedName = momentMetadata?.name?.trim() || name.trim() || "Untitled moment";
   const trimmedDescription = momentMetadata?.description?.trim() || description?.trim() || "";
@@ -87,8 +79,8 @@ const CreateSuccess = () => {
           Back to create
         </button>
 
-        <div className="grid items-start gap-6 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] md:gap-12">
-          <div className="overflow-hidden rounded-[16px] border border-[#E4E0D7] bg-white shadow-[0_30px_70px_-34px_rgba(27,21,4,.45)] md:sticky md:top-9">
+        <div className="grid items-start gap-4 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] md:gap-12">
+          <div className="overflow-hidden rounded-[16px] border border-[#E4E0D7] bg-white shadow-[0_24px_56px_-30px_rgba(27,21,4,.45),0_0_0_1px_rgba(27,21,4,.03)] md:sticky md:top-9">
             <div className="aspect-square bg-[#EDEAE2]">
               <div className="relative size-full overflow-hidden">
                 {showSuccessSkeleton ? (
@@ -165,7 +157,7 @@ const CreateSuccess = () => {
                 </div>
 
                 <div className="mt-5 flex items-baseline justify-between gap-4 border-b border-[#E4E0D7] pb-[18px]">
-                  <span className="font-archivo-bold text-[26px] tracking-[-0.015em] text-[#A8862F] md:text-[30px]">
+                  <span className="font-archivo-bold text-[30px] tracking-[-0.015em] text-[#A8862F]">
                     {displayedPrice}
                   </span>
                   <span className="pr-2 text-right font-archivo text-[13px] text-[#8C8678] md:pr-4">

--- a/components/CreateSuccess/CreateSuccess.tsx
+++ b/components/CreateSuccess/CreateSuccess.tsx
@@ -69,7 +69,7 @@ const CreateSuccess = () => {
 
   return (
     <div className="col-span-1 w-full md:col-span-2">
-      <div className="mx-auto mt-8 w-full max-w-[1440px] px-[6px] pb-12 md:mt-6 md:px-14 md:pb-20">
+      <div className="mx-auto mt-2 md:mt-8 w-full max-w-[1440px] px-[6px] pb-12 md:mt-6 md:px-14 md:pb-20">
         <button
           type="button"
           onClick={handleBackToCreate}
@@ -156,7 +156,7 @@ const CreateSuccess = () => {
                   )}
                 </div>
 
-                <div className="mt-5 flex items-baseline justify-between gap-4 border-b border-[#E4E0D7] pb-[18px]">
+                <div className="my-2 md:my-4 flex items-baseline justify-between gap-4 border-b border-[#E4E0D7]">
                   <span className="font-archivo-bold text-[30px] tracking-[-0.015em] text-[#A8862F]">
                     {displayedPrice}
                   </span>

--- a/components/CreateSuccess/CreateSuccess.tsx
+++ b/components/CreateSuccess/CreateSuccess.tsx
@@ -69,7 +69,7 @@ const CreateSuccess = () => {
 
   return (
     <div className="col-span-1 w-full md:col-span-2">
-      <div className="mx-auto mt-8 w-full max-w-[1440px] px-[18px] pb-12 md:mt-6 md:px-14 md:pb-20">
+      <div className="mx-auto mt-8 w-full max-w-[1440px] px-[6px] pb-12 md:mt-6 md:px-14 md:pb-20">
         <button
           type="button"
           onClick={handleBackToCreate}

--- a/components/CreateSuccess/MomentCreatedHeader.tsx
+++ b/components/CreateSuccess/MomentCreatedHeader.tsx
@@ -1,7 +1,7 @@
 const MomentCreatedHeader = () => {
   return (
     <div className="w-full">
-      <h1 className="font-archivo-medium text-[36px] leading-[1.02] tracking-[-0.01em] text-grey-moss-900 md:text-[52px]">
+      <h1 className="font-archivo-medium text-[38px] leading-[1.02] tracking-[-0.01em] text-grey-moss-900 md:text-[52px]">
         moment created
       </h1>
     </div>

--- a/hooks/useFireCreateSuccessConfetti.ts
+++ b/hooks/useFireCreateSuccessConfetti.ts
@@ -29,4 +29,3 @@ export default function useFireCreateSuccessConfetti({
     fireCollectConfetti();
   }, [liveTokenId, isLoading, momentMetadata]);
 }
-

--- a/hooks/useFireCreateSuccessConfetti.ts
+++ b/hooks/useFireCreateSuccessConfetti.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from "react";
+import fireCollectConfetti from "@/lib/moment/fireCollectConfetti";
+
+interface UseFireCreateSuccessConfettiParams {
+  liveTokenId?: string;
+  isLoading: boolean;
+  momentMetadata: unknown | null;
+}
+
+/**
+ * `/create/success`에서 collect success와 동일한 confetti를
+ * moment metadata 로딩 완료 후 1회만 실행합니다.
+ */
+export default function useFireCreateSuccessConfetti({
+  liveTokenId,
+  isLoading,
+  momentMetadata,
+}: UseFireCreateSuccessConfettiParams) {
+  const hasFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (hasFiredRef.current) return;
+    if (!liveTokenId) return;
+    // Skeleton 구간(isLoading & metadata 없음)에서는 실행하지 않음.
+    if (isLoading && !momentMetadata) return;
+    if (!momentMetadata) return;
+
+    hasFiredRef.current = true;
+    fireCollectConfetti();
+  }, [liveTokenId, isLoading, momentMetadata]);
+}
+


### PR DESCRIPTION
## Summary
- redesign the create flow for mobile with shared create tabs, updated stage/details layouts, and a sticky mobile create bar
- update the create success page to match the latest desktop and mobile designs, including responsive button behavior and timeline/share actions
- remove dead create-page code and move the success confetti trigger into a dedicated hook

## Test plan
- [ ] Open `/create` on mobile and verify tabs, media stage, details sheet, and sticky create bar spacing
- [ ] Create a moment on mobile and verify the success page layout, preview, spacing, and share button behavior
- [ ] Refresh `/create/success` and confirm the skeleton appears before metadata loads, then confetti fires once after load
- [ ] Check desktop `/create/success` and confirm `Visit timeline` remains unchanged while mobile keeps the compact labels
