### PR TITLE
Refine create success previews and state derivation.

### DIFF
--- a/components/CreateSuccess/CreateSuccess.tsx
+++ b/components/CreateSuccess/CreateSuccess.tsx
@@ -4,22 +4,22 @@ import { useRouter } from "next/navigation";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { useCollectionsProvider } from "@/providers/CollectionsProvider";
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
-import { CHAIN, SITE_ORIGINAL_URL } from "@/lib/consts";
 import { getCollectionTimelineUrl } from "@/lib/collection/getCollectionTimelineUrl";
-import { getShortNetworkName } from "@/lib/zora/zoraToViem";
 import CreatedMomentAirdrop from "./CreatedMomentAirdrop";
 import MomentCreatedHeader from "./MomentCreatedHeader";
 import Buttons from "./Buttons";
 import useTokenIdParam from "@/hooks/useTokenIdParam";
-import { CHAIN_ID } from "@/lib/consts";
 import useMomentData from "@/hooks/useMomentData";
-import type { Address } from "viem";
 import MomentsGridPreview from "@/components/MomentsGrid/Preview";
 import { Skeleton } from "@/components/ui/skeleton";
 import useFireCreateSuccessConfetti from "@/hooks/useFireCreateSuccessConfetti";
+import ThoughtSuccessPreview from "./ThoughtSuccessPreview";
+import CreateSuccessSkeleton from "./CreateSuccessSkeleton";
+import getCreateSuccessDisplayState from "@/lib/createSuccess/getCreateSuccessDisplayState";
+import getCreateSuccessRequestState from "@/lib/createSuccess/getCreateSuccessRequestState";
 
 const CreateSuccess = () => {
-  const { name, description, price, priceUnit, resetForm } = useMetadataFormProvider();
+  const { name, description, price, priceUnit, writingText, resetForm } = useMetadataFormProvider();
   const { selectedCollection, collections } = useCollectionsProvider();
   const { createdTokenId, setCreatedTokenId } = useMomentCreateProvider();
   const { push } = useRouter();
@@ -27,39 +27,39 @@ const CreateSuccess = () => {
 
   const timestamp = useMemo(() => new Date().toLocaleString(), []);
   const tokenIdFromUrl = useTokenIdParam();
-  const liveTokenId = createdTokenId || tokenIdFromUrl;
-  const collectionItem = collections.find(
-    (collection) => collection.address.toLowerCase() === selectedCollection?.toLowerCase()
-  );
-
-  const shortNetworkName = getShortNetworkName(CHAIN.name.toLowerCase());
-  const shareUrl =
-    shortNetworkName && selectedCollection && liveTokenId
-      ? `${SITE_ORIGINAL_URL}/collect/${shortNetworkName}:${selectedCollection}/${liveTokenId}`
-      : undefined;
-  const moment = useMemo(
-    () => ({
-      // `useMomentData` internally disables the query when any field is falsy.
-      collectionAddress: selectedCollection as Address,
-      tokenId: liveTokenId || "",
-      chainId: CHAIN_ID,
-    }),
-    [selectedCollection, liveTokenId]
-  );
-  const { metadata: momentMetadata, owner, isLoading } = useMomentData(moment);
+  const { activeTokenId, selectedCollectionItem, momentQuery, shareUrl } =
+    getCreateSuccessRequestState({
+      createdTokenId,
+      tokenIdFromUrl,
+      selectedCollection,
+      collections,
+    });
+  const { metadata: momentMetadata, owner, isLoading } = useMomentData(momentQuery);
   const personalTimelineHref = owner ? `/${owner.toLowerCase()}` : undefined;
-  const showSuccessSkeleton = Boolean(liveTokenId) && isLoading && !momentMetadata;
+  const showSuccessSkeleton = Boolean(activeTokenId) && isLoading && !momentMetadata;
 
-  useFireCreateSuccessConfetti({ liveTokenId, isLoading, momentMetadata });
+  useFireCreateSuccessConfetti({ liveTokenId: activeTokenId, isLoading, momentMetadata });
 
-  const displayedName = momentMetadata?.name?.trim() || name.trim() || "Untitled moment";
-  const trimmedDescription = momentMetadata?.description?.trim() || description?.trim() || "";
-  const showDescriptionToggle = trimmedDescription.length > 160;
-  const displayedDescription = descExpanded
-    ? trimmedDescription
-    : trimmedDescription.slice(0, 160).trimEnd();
-  const displayedPrice = liveTokenId ? `${price} ${priceUnit.toUpperCase()}` : "--";
-  const displayedTimestamp = liveTokenId ? timestamp : "Created just now";
+  const {
+    displayedName,
+    displayedDescriptionSource,
+    showDescriptionToggle,
+    displayedDescription,
+    displayedPrice,
+    displayedTimestamp,
+    shareTitle,
+    isThoughtMoment,
+  } = getCreateSuccessDisplayState({
+    momentMetadata,
+    formName: name,
+    formDescription: description,
+    collectionName: selectedCollectionItem?.name,
+    price,
+    priceUnit,
+    activeTokenId,
+    timestamp,
+    descExpanded,
+  });
 
   const handleBackToCreate = () => {
     resetForm();
@@ -86,7 +86,11 @@ const CreateSuccess = () => {
                 {showSuccessSkeleton ? (
                   <Skeleton className="size-full rounded-none" />
                 ) : momentMetadata ? (
-                  <MomentsGridPreview data={momentMetadata} />
+                  isThoughtMoment ? (
+                    <ThoughtSuccessPreview text={writingText} metadata={momentMetadata} />
+                  ) : (
+                    <MomentsGridPreview data={momentMetadata} fit="contain" />
+                  )
                 ) : (
                   <div className="flex size-full items-center justify-center p-6">
                     <p className="text-center font-archivo text-[12.5px] uppercase tracking-[0.06em] text-[#A8A296]">
@@ -102,42 +106,14 @@ const CreateSuccess = () => {
             <MomentCreatedHeader />
 
             {showSuccessSkeleton ? (
-              <>
-                <div className="mt-4">
-                  <Skeleton className="h-8 w-48" />
-                  <Skeleton className="mt-3 h-4 w-full max-w-[360px]" />
-                  <Skeleton className="mt-2 h-4 w-3/4 max-w-[280px]" />
-                </div>
-
-                <div className="mt-5 flex items-baseline justify-between gap-4 border-b border-[#E4E0D7] pb-[18px]">
-                  <Skeleton className="h-8 w-28" />
-                  <Skeleton className="h-4 w-32" />
-                </div>
-
-                <div className="mt-3 flex flex-col gap-3 md:flex-row">
-                  <Skeleton className="h-[51px] flex-1 rounded-[12px]" />
-                  <Skeleton className="h-[51px] flex-1 rounded-[12px]" />
-                </div>
-
-                <div className="mt-7 rounded-[16px] border border-[#E4E0D7] bg-white p-[22px]">
-                  <Skeleton className="h-3 w-16" />
-                  <Skeleton className="mt-4 h-12 w-full rounded-none" />
-                  <Skeleton className="mt-4 h-3 w-28" />
-                  <div className="mt-3 flex gap-2">
-                    <Skeleton className="h-8 w-20 rounded-full" />
-                    <Skeleton className="h-8 w-24 rounded-full" />
-                    <Skeleton className="h-8 w-14 rounded-full" />
-                  </div>
-                  <Skeleton className="mt-4 h-12 w-full rounded-full" />
-                </div>
-              </>
+              <CreateSuccessSkeleton />
             ) : (
               <>
                 <div className="mt-4">
                   <div className="font-archivo-bold text-[24px] leading-[1.2] tracking-[-0.01em] text-grey-moss-900">
                     {displayedName}
                   </div>
-                  {trimmedDescription && (
+                  {displayedDescriptionSource && (
                     <>
                       <p className="mt-2 font-spectral text-[16px] leading-[1.6] text-[#4E4A40]">
                         {displayedDescription}
@@ -168,7 +144,7 @@ const CreateSuccess = () => {
                 <Buttons
                   shareUrl={shareUrl}
                   timelineHref={personalTimelineHref}
-                  shareTitle={displayedName || collectionItem?.name || "moment"}
+                  shareTitle={shareTitle}
                 />
 
                 <div className="mt-7">

--- a/components/CreateSuccess/CreateSuccessSkeleton.tsx
+++ b/components/CreateSuccess/CreateSuccessSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const CreateSuccessSkeleton = () => {
+  return (
+    <>
+      <div className="mt-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="mt-3 h-4 w-full max-w-[360px]" />
+        <Skeleton className="mt-2 h-4 w-3/4 max-w-[280px]" />
+      </div>
+
+      <div className="mt-5 flex items-baseline justify-between gap-4 border-b border-[#E4E0D7] pb-[18px]">
+        <Skeleton className="h-8 w-28" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+
+      <div className="mt-3 flex flex-col gap-3 md:flex-row">
+        <Skeleton className="h-[51px] flex-1 rounded-[12px]" />
+        <Skeleton className="h-[51px] flex-1 rounded-[12px]" />
+      </div>
+
+      <div className="mt-7 rounded-[16px] border border-[#E4E0D7] bg-white p-[22px]">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="mt-4 h-12 w-full rounded-none" />
+        <Skeleton className="mt-4 h-3 w-28" />
+        <div className="mt-3 flex gap-2">
+          <Skeleton className="h-8 w-20 rounded-full" />
+          <Skeleton className="h-8 w-24 rounded-full" />
+          <Skeleton className="h-8 w-14 rounded-full" />
+        </div>
+        <Skeleton className="mt-4 h-12 w-full rounded-full" />
+      </div>
+    </>
+  );
+};
+
+export default CreateSuccessSkeleton;

--- a/components/CreateSuccess/ThoughtSuccessPreview.tsx
+++ b/components/CreateSuccess/ThoughtSuccessPreview.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import useTextContent from "@/hooks/useTextContent";
+import { MomentMetadata } from "@/types/moment";
+
+interface ThoughtSuccessPreviewProps {
+  text: string;
+  metadata: MomentMetadata;
+}
+
+const ThoughtSuccessPreview = ({ text, metadata }: ThoughtSuccessPreviewProps) => {
+  const metadataText = useTextContent(metadata);
+  const displayText = text.trim() || metadataText.trim() || metadata.description?.trim() || "";
+
+  return (
+    <div className="flex size-full items-center justify-center bg-white p-6 md:p-8">
+      <p className="max-w-[88%] whitespace-pre-wrap break-words text-center font-spectral text-[17px] leading-[1.7] text-grey-moss-900 md:text-[20px]">
+        {displayText || "Thought"}
+      </p>
+    </div>
+  );
+};
+
+export default ThoughtSuccessPreview;

--- a/components/MomentsGrid/Preview.tsx
+++ b/components/MomentsGrid/Preview.tsx
@@ -8,9 +8,10 @@ import VideoMomentPreview from "./VideoMomentPreview";
 
 interface PreviewProps {
   data: MomentMetadata;
+  fit?: "cover" | "contain";
 }
 
-const Preview = ({ data }: PreviewProps) => {
+const Preview = ({ data, fit = "cover" }: PreviewProps) => {
   const mediaType = data.content?.mime ? determineMediaType(data.content.mime) : null;
   const hasImage = !!data.image;
 
@@ -36,7 +37,7 @@ const Preview = ({ data }: PreviewProps) => {
       className="z-[1] transition-transform duration-300 group-hover:scale-[1.02]"
       fill
       sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
-      style={{ objectFit: "cover", objectPosition: "center" }}
+      style={{ objectFit: fit, objectPosition: "center" }}
     />
   );
 };

--- a/components/MomentsGrid/TextMomentPreview.tsx
+++ b/components/MomentsGrid/TextMomentPreview.tsx
@@ -11,8 +11,8 @@ const TextMomentPreview = ({ data }: TextMomentPreviewProps) => {
   const text = useTextContent(data);
 
   return (
-    <div className="absolute inset-0 z-[1] flex items-start overflow-hidden bg-grey-eggshell p-4 pt-6 transition-transform duration-300 group-hover:scale-[1.02]">
-      <p className="line-clamp-[8] whitespace-pre-wrap break-words font-spectral text-xs leading-relaxed text-grey-moss-900">
+    <div className="absolute inset-0 z-[1] flex w-full items-center justify-center overflow-hidden bg-grey-eggshell p-5 text-center transition-transform duration-300 group-hover:scale-[1.02] md:p-7">
+      <p className="line-clamp-[10] max-w-[88%] whitespace-pre-wrap break-words font-spectral text-[15px] leading-[1.65] text-grey-moss-900 md:text-[17px]">
         {text || data.description || data.name || "Text Moment"}
       </p>
     </div>

--- a/lib/createSuccess/getCreateSuccessDisplayState.ts
+++ b/lib/createSuccess/getCreateSuccessDisplayState.ts
@@ -1,0 +1,48 @@
+import { MomentMetadata } from "@/types/moment";
+
+interface GetCreateSuccessDisplayStateParams {
+  momentMetadata: MomentMetadata | null;
+  formName: string;
+  formDescription: string;
+  collectionName?: string;
+  price: string;
+  priceUnit: string;
+  activeTokenId?: string;
+  timestamp: string;
+  descExpanded: boolean;
+}
+
+const DESCRIPTION_PREVIEW_LIMIT = 160;
+
+const getCreateSuccessDisplayState = ({
+  momentMetadata,
+  formName,
+  formDescription,
+  collectionName,
+  price,
+  priceUnit,
+  activeTokenId,
+  timestamp,
+  descExpanded,
+}: GetCreateSuccessDisplayStateParams) => {
+  const displayedName = momentMetadata?.name?.trim() || formName.trim() || "Untitled moment";
+  const displayedDescriptionSource =
+    momentMetadata?.description?.trim() || formDescription.trim() || "";
+  const showDescriptionToggle = displayedDescriptionSource.length > DESCRIPTION_PREVIEW_LIMIT;
+  const displayedDescription = descExpanded
+    ? displayedDescriptionSource
+    : displayedDescriptionSource.slice(0, DESCRIPTION_PREVIEW_LIMIT).trimEnd();
+
+  return {
+    displayedName,
+    displayedDescriptionSource,
+    showDescriptionToggle,
+    displayedDescription,
+    displayedPrice: activeTokenId ? `${price} ${priceUnit.toUpperCase()}` : "--",
+    displayedTimestamp: activeTokenId ? timestamp : "Created just now",
+    shareTitle: displayedName || collectionName || "moment",
+    isThoughtMoment: momentMetadata?.content?.mime?.startsWith("text/plain"),
+  };
+};
+
+export default getCreateSuccessDisplayState;

--- a/lib/createSuccess/getCreateSuccessRequestState.ts
+++ b/lib/createSuccess/getCreateSuccessRequestState.ts
@@ -1,0 +1,47 @@
+import { Address } from "viem";
+import { CHAIN_ID, CHAIN, SITE_ORIGINAL_URL } from "@/lib/consts";
+import { getShortNetworkName } from "@/lib/zora/zoraToViem";
+import { Moment } from "@/types/moment";
+
+interface CollectionItem {
+  address: string;
+  name?: string;
+}
+
+interface GetCreateSuccessRequestStateParams {
+  createdTokenId?: string;
+  tokenIdFromUrl?: string;
+  selectedCollection?: string;
+  collections: CollectionItem[];
+}
+
+const getCreateSuccessRequestState = ({
+  createdTokenId,
+  tokenIdFromUrl,
+  selectedCollection,
+  collections,
+}: GetCreateSuccessRequestStateParams) => {
+  const activeTokenId = createdTokenId || tokenIdFromUrl;
+  const selectedCollectionItem = collections.find(
+    (collection) => collection.address.toLowerCase() === selectedCollection?.toLowerCase()
+  );
+  const shortNetworkName = getShortNetworkName(CHAIN.name.toLowerCase());
+
+  const momentQuery: Moment = {
+    collectionAddress: selectedCollection as Address,
+    tokenId: activeTokenId || "",
+    chainId: CHAIN_ID,
+  };
+
+  return {
+    activeTokenId,
+    selectedCollectionItem,
+    momentQuery,
+    shareUrl:
+      shortNetworkName && selectedCollection && activeTokenId
+        ? `${SITE_ORIGINAL_URL}/collect/${shortNetworkName}:${selectedCollection}/${activeTokenId}`
+        : undefined,
+  };
+};
+
+export default getCreateSuccessRequestState;


### PR DESCRIPTION
Keep the success page HTML readable while moving derived state into helpers, show thought previews from form or metadata text, and make success media fit without cropping.