### PR TITLE
Fix collected page left-to-right chronology

### DIFF
--- a/components/CollectedPage/CollectedCard.tsx
+++ b/components/CollectedPage/CollectedCard.tsx
@@ -49,7 +49,7 @@ const CollectedCard = ({ transfer }: Props) => {
         tabIndex={0}
         onClick={handleMomentClick}
         onKeyDown={(e) => e.key === "Enter" && handleMomentClick()}
-        className="group mb-3 w-full break-inside-avoid cursor-pointer overflow-hidden rounded-[6px] border border-grey-moss-100 bg-white text-left shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)] md:mb-2"
+        className="group mb-3 w-full cursor-pointer overflow-hidden rounded-[6px] border border-grey-moss-100 bg-white text-left shadow-[0_4px_16px_-6px_rgba(27,21,4,.14)] md:mb-2"
       >
         <div className="relative isolate z-0 w-full overflow-hidden">
           <ContentRenderer metadata={metadata ?? undefined} variant="natural" />

--- a/components/CollectedPage/CollectedPage.tsx
+++ b/components/CollectedPage/CollectedPage.tsx
@@ -11,6 +11,8 @@ import { useCollectingStats } from "@/hooks/useCollectingStats";
 import { useCollectorTransfers } from "@/hooks/useCollectorTransfers";
 import FetchMore from "@/components/FetchMore";
 import { formatStatValue } from "@/lib/stats/formatStatValue";
+import { useMasonryColumnCount } from "@/hooks/useMasonryColumnCount";
+import { distributeIntoColumns } from "@/lib/moment/distributeIntoColumns";
 
 const CollectedPageContent = ({ address }: { address: Address }) => {
   const { data: collectingStats, isLoading: isStatsLoading } = useCollectingStats(address);
@@ -25,6 +27,7 @@ const CollectedPageContent = ({ address }: { address: Address }) => {
   const { transfers, typeTabs, contentType, setContentType } = useCollectedPageState({
     transfers: sourceTransfers,
   });
+  const columnCount = useMasonryColumnCount();
 
   const showStatsLoading = isStatsLoading && !collectingStats;
   const showCountLoading = isTransfersLoading && collectedCount == null;
@@ -62,9 +65,13 @@ const CollectedPageContent = ({ address }: { address: Address }) => {
           </div>
         ) : (
           <>
-            <div className="w-full columns-1 gap-3 md:columns-[232px] md:gap-3.5">
-              {transfers.map((transfer) => (
-                <CollectedCard key={transfer.id} transfer={transfer} />
+            <div className="flex w-full gap-3 md:gap-3.5">
+              {distributeIntoColumns(transfers, columnCount).map((columnTransfers, columnIndex) => (
+                <div key={columnIndex} className="flex min-w-0 flex-1 flex-col">
+                  {columnTransfers.map((transfer) => (
+                    <CollectedCard key={transfer.id} transfer={transfer} />
+                  ))}
+                </div>
               ))}
             </div>
             {hasNextPage && <FetchMore fetchMore={fetchMore} />}

--- a/lib/moment/distributeIntoColumns.ts
+++ b/lib/moment/distributeIntoColumns.ts
@@ -1,13 +1,8 @@
-import { TimelineMoment } from "@/types/moment";
-
 /** Round-robins items across columns so reading left-to-right, top-to-bottom follows original order. */
-export const distributeIntoColumns = (
-  moments: TimelineMoment[],
-  columnCount: number
-): TimelineMoment[][] => {
-  const columns: TimelineMoment[][] = Array.from({ length: columnCount }, () => []);
-  moments.forEach((moment, index) => {
-    columns[index % columnCount].push(moment);
+export const distributeIntoColumns = <T>(items: T[], columnCount: number): T[][] => {
+  const columns: T[][] = Array.from({ length: columnCount }, () => []);
+  items.forEach((item, index) => {
+    columns[index % columnCount].push(item);
   });
   return columns;
 };


### PR DESCRIPTION
## Summary
- Collected page used CSS `columns`, which fills top-to-bottom and broke chronological left-to-right reading vs the home feed.
- Reuse `distributeIntoColumns` + `useMasonryColumnCount` so collected moments round-robin across columns like the home masonry grid.
- Make `distributeIntoColumns` generic so it works for transfers as well as timeline moments.

## Test plan
- [ ] Open a collected page with many items of mixed heights
- [ ] Confirm newest transferred moments appear left-to-right across the first row
- [ ] Resize across breakpoints and confirm column count still adapts
- [ ] Spot-check home feed masonry still lays out correctly


Made with [Cursor](https://cursor.com)