### PR TITLE
Improve collected profile links and filters

### DIFF
--- a/components/ArtistPage/Social.tsx
+++ b/components/ArtistPage/Social.tsx
@@ -16,7 +16,7 @@ const Social = ({ link, icon }: SocialProps) => {
 
   return (
     <button
-      className="flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:text-[#1c1a17] active:opacity-70"
+      className="flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:text-[#1c1a17] active:opacity-70"
       type="button"
       onClick={handleClick}
     >

--- a/components/ArtistPage/SocialAccounts.tsx
+++ b/components/ArtistPage/SocialAccounts.tsx
@@ -1,10 +1,15 @@
+import { ReactNode } from "react";
 import { useProfileProvider } from "@/providers/ProfileProvider";
 import { Icons } from "../ui/icons";
 import { Send, InstagramIcon } from "lucide-react";
 import Social from "./Social";
 import { extractSocialUsername } from "@/lib/socials/extractSocialUsername";
 
-const SocialAccounts = () => {
+type Props = {
+  extras?: ReactNode;
+};
+
+const SocialAccounts = ({ extras }: Props) => {
   const {
     twitter,
     instagram,
@@ -16,7 +21,8 @@ const SocialAccounts = () => {
     setTelegram,
   } = useProfileProvider();
 
-  const iconWrapClass = "rounded-full border border-[rgba(28,26,23,0.2)] p-1.5 text-[#8a8578]";
+  const iconWrapClass =
+    "rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 p-1.5 text-[#8a8578]";
 
   const instagramIcon = <InstagramIcon className="size-[18px] text-current" />;
   const twitterIcon = <Icons.twitter className="size-[16px] fill-current" />;
@@ -54,6 +60,7 @@ const SocialAccounts = () => {
 
   return (
     <div className="flex items-center gap-1">
+      {extras}
       {instagram && (
         <Social
           link={`https://instagram.com/${extractSocialUsername(instagram)}`}

--- a/components/CollectedPage/CollectedPage.tsx
+++ b/components/CollectedPage/CollectedPage.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Image from "next/image";
+import Link from "next/link";
 import { Address } from "viem";
 import { useParams } from "next/navigation";
 import ProfileProvider from "@/providers/ProfileProvider";
@@ -53,8 +55,21 @@ const CollectedPageContent = ({ address }: { address: Address }) => {
   return (
     <div className="relative flex min-h-full w-full grow flex-col text-[#1c1a17]">
       <div className="relative grow px-[18px] pb-[30px] pt-[22px] md:px-10 md:pb-11 xl:px-14 2xl:px-20 3xl:px-28">
-        <ProfileWithStats stats={stats} />
-        <CollectedToolbar tabs={typeTabs} active={contentType} onChange={setContentType} />
+        <ProfileWithStats
+          stats={stats}
+          extraSocials={
+            <Link
+              href={`/${address}`}
+              aria-label="View timeline"
+              className="flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:opacity-80 active:opacity-70"
+            >
+              <Image src="/footer_logo.svg" alt="" width={17} height={17} className="opacity-60" />
+            </Link>
+          }
+          toolbar={
+            <CollectedToolbar tabs={typeTabs} active={contentType} onChange={setContentType} />
+          }
+        />
         {isTransfersLoading ? (
           <div className="py-16 text-center font-archivo text-sm text-[#8a8578]">
             Loading collected moments…

--- a/components/CollectedPage/CollectedPage.tsx
+++ b/components/CollectedPage/CollectedPage.tsx
@@ -14,7 +14,10 @@ import { useCollectorTransfers } from "@/hooks/useCollectorTransfers";
 import FetchMore from "@/components/FetchMore";
 import { formatStatValue } from "@/lib/stats/formatStatValue";
 import { useMasonryColumnCount } from "@/hooks/useMasonryColumnCount";
+import { useFeedScroll } from "@/hooks/useFeedScroll";
 import { distributeIntoColumns } from "@/lib/moment/distributeIntoColumns";
+
+const RENDER_PAGE_SIZE = 30;
 
 const CollectedPageContent = ({ address }: { address: Address }) => {
   const { data: collectingStats, isLoading: isStatsLoading } = useCollectingStats(address);
@@ -30,6 +33,11 @@ const CollectedPageContent = ({ address }: { address: Address }) => {
     transfers: sourceTransfers,
   });
   const columnCount = useMasonryColumnCount();
+  const {
+    visibleMoments: visibleTransfers,
+    hasMore,
+    sentinelRef,
+  } = useFeedScroll(transfers, RENDER_PAGE_SIZE);
 
   const showStatsLoading = isStatsLoading && !collectingStats;
   const showCountLoading = isTransfersLoading && collectedCount == null;
@@ -81,15 +89,21 @@ const CollectedPageContent = ({ address }: { address: Address }) => {
         ) : (
           <>
             <div className="flex w-full gap-3 md:gap-3.5">
-              {distributeIntoColumns(transfers, columnCount).map((columnTransfers, columnIndex) => (
-                <div key={columnIndex} className="flex min-w-0 flex-1 flex-col">
-                  {columnTransfers.map((transfer) => (
-                    <CollectedCard key={transfer.id} transfer={transfer} />
-                  ))}
-                </div>
-              ))}
+              {distributeIntoColumns(visibleTransfers, columnCount).map(
+                (columnTransfers, columnIndex) => (
+                  <div key={columnIndex} className="flex min-w-0 flex-1 flex-col">
+                    {columnTransfers.map((transfer) => (
+                      <CollectedCard key={transfer.id} transfer={transfer} />
+                    ))}
+                  </div>
+                )
+              )}
             </div>
-            {hasNextPage && <FetchMore fetchMore={fetchMore} />}
+            {hasMore ? (
+              <div ref={sentinelRef} className="h-px" />
+            ) : (
+              hasNextPage && <FetchMore fetchMore={fetchMore} />
+            )}
           </>
         )}
       </div>

--- a/components/CollectedPage/CollectedToolbar.tsx
+++ b/components/CollectedPage/CollectedToolbar.tsx
@@ -12,11 +12,7 @@ type Props = {
 };
 
 const CollectedToolbar = ({ tabs, active, onChange }: Props) => {
-  return (
-    <div className="mb-4">
-      <FilterToolbar tabs={tabs} active={active} onChange={onChange} />
-    </div>
-  );
+  return <FilterToolbar tabs={tabs} active={active} onChange={onChange} />;
 };
 
 export default CollectedToolbar;

--- a/components/FilterToolbar.tsx
+++ b/components/FilterToolbar.tsx
@@ -16,7 +16,7 @@ function FilterToolbar<T extends string>({ tabs, active, onChange }: FilterToolb
             type="button"
             onClick={() => onChange(tab.label)}
             className={cn(
-              "inline-flex shrink-0 items-center gap-1.5 rounded-[20px] px-3.5 py-[7px] font-archivo text-[13px] transition-all duration-150",
+              "inline-flex shrink-0 items-center gap-1.5 rounded-[20px] px-3 py-1 font-archivo text-[13px] transition-all duration-150",
               isActive
                 ? "border border-[#1c1a17] bg-[#1c1a17] text-[#f4f0e6]"
                 : "border border-[rgba(28,26,23,0.14)] bg-transparent text-[#1c1a17]"

--- a/components/ProfileWithStats.tsx
+++ b/components/ProfileWithStats.tsx
@@ -15,9 +15,11 @@ type Props = {
   stats: ProfileStat[];
   /** When set, socials move to a second row with this content on the right. */
   toolbar?: ReactNode;
+  /** Extra icons rendered before social account icons (e.g. timeline link). */
+  extraSocials?: ReactNode;
 };
 
-const ProfileWithStats = ({ stats, toolbar }: Props) => {
+const ProfileWithStats = ({ stats, toolbar, extraSocials }: Props) => {
   const {
     isEditing,
     toggleEditing,
@@ -82,7 +84,7 @@ const ProfileWithStats = ({ stats, toolbar }: Props) => {
           )}
           {!toolbar && (
             <div className="mt-3">
-              <SocialAccounts />
+              <SocialAccounts extras={extraSocials} />
             </div>
           )}
         </div>
@@ -92,7 +94,7 @@ const ProfileWithStats = ({ stats, toolbar }: Props) => {
 
       {toolbar ? (
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6">
-          <SocialAccounts />
+          <SocialAccounts extras={extraSocials} />
           <div className="min-w-0 md:ml-auto">{toolbar}</div>
         </div>
       ) : null}

--- a/components/ProfileWithStats.tsx
+++ b/components/ProfileWithStats.tsx
@@ -15,7 +15,6 @@ type Props = {
   stats: ProfileStat[];
   /** When set, socials move to a second row with this content on the right. */
   toolbar?: ReactNode;
-  /** Extra icons rendered before social account icons (e.g. timeline link). */
   extraSocials?: ReactNode;
 };
 

--- a/hooks/useFeedScroll.ts
+++ b/hooks/useFeedScroll.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { TimelineMoment } from "@/types/moment";
 
 const DEFAULT_PAGE_SIZE = 10;
 
-export const useFeedScroll = (moments: TimelineMoment[], pageSize = DEFAULT_PAGE_SIZE) => {
+export const useFeedScroll = <T>(items: T[], pageSize = DEFAULT_PAGE_SIZE) => {
   const [visibleCount, setVisibleCount] = useState(pageSize);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -15,18 +14,18 @@ export const useFeedScroll = (moments: TimelineMoment[], pageSize = DEFAULT_PAGE
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          setVisibleCount((prev) => Math.min(prev + pageSize, moments.length));
+          setVisibleCount((prev) => Math.min(prev + pageSize, items.length));
         }
       },
       { threshold: 0 }
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [moments.length, pageSize]);
+  }, [items.length, pageSize]);
 
   return {
-    visibleMoments: moments.slice(0, visibleCount),
-    hasMore: visibleCount < moments.length,
+    visibleMoments: items.slice(0, visibleCount),
+    hasMore: visibleCount < items.length,
     sentinelRef,
   };
 };


### PR DESCRIPTION
## Summary
- Add an In Process logo icon (before socials) that links to the artist timeline.
- Give social/logo icon buttons a soft white fill so they stay readable on the textured background.
- Keep content-type filters on the same row as socials, with slightly tighter pill padding.

## Test plan
- [ ] Open a collected page with social links set
- [ ] Confirm In Process logo is first and navigates to `/{address}`
- [ ] Confirm icons remain readable on the textured background without looking too loud
- [ ] Confirm All/Audio/Video/Image/Other sit on the same row as socials on desktop
- [ ] Confirm filter pills look slightly shorter and still easy to tap


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a profile link with logo to collected pages.
  * Improved profile layouts by supporting additional social content and integrated toolbar placement.

* **Style**
  * Updated social icons with translucent backgrounds and hover states.
  * Refined toolbar button spacing for a more compact appearance.
  * Improved alignment and presentation of collected-page controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->