### PR TITLE
Bound PDF viewer height for long documents

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -158,6 +158,13 @@
   display: none !important;
 }
 
+.pdf-viewer-root .rpv-core__viewer,
+.pdf-viewer-root .rpv-default-layout__container,
+.pdf-viewer-root .rpv-default-layout__main,
+.pdf-viewer-root .rpv-default-layout__body {
+  height: 100%;
+}
+
 .rpv-toolbar__right {
   display: none !important;
 }

--- a/components/Renderers/PdfViewer.tsx
+++ b/components/Renderers/PdfViewer.tsx
@@ -10,7 +10,7 @@ interface PdfViewerProps {
 const PdfViewer = ({ fileUrl }: PdfViewerProps) => {
   const defaultLayoutPluginInstance = defaultLayoutPlugin();
   return (
-    <div className="pdf-viewer-root size-full min-h-[200px] min-w-[300px]">
+    <div className="pdf-viewer-root h-[min(70vh,560px)] w-full min-h-[200px] min-w-0 overflow-hidden">
       <Worker workerUrl={`https://unpkg.com/pdfjs-dist@${PDFJS_DIST_VERSION}/build/pdf.worker.js`}>
         <Viewer fileUrl={fileUrl} plugins={[defaultLayoutPluginInstance]} />
       </Worker>


### PR DESCRIPTION
## Summary
- Give `PdfViewer` a capped height (`min(70vh, 560px)`) with overflow hidden so multi-page PDFs scroll inside the viewer.
- Ensure react-pdf-viewer layout children fill that height so scrolling works in feed cards and previews.

## Test plan
- [ ] Open a feed/collected card with a many-page PDF and confirm the card stays a normal height
- [ ] Scroll inside the PDF viewer to reach later pages
- [ ] Open a PDF on the moment detail page and confirm it still uses the viewport-based height
- [ ] Spot-check create preview for a PDF upload


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the PDF viewer layout to use the full available screen height and width.
  * Updated responsive sizing and overflow handling for a more consistent viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->