### PR TITLE
Add collected shortcut to artist timeline

### DIFF
--- a/components/ArtistPage/ArtistPageContent.tsx
+++ b/components/ArtistPage/ArtistPageContent.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+import { GalleryHorizontal } from "lucide-react";
 import { useState } from "react";
 import MomentsTimeline from "../Timeline/MomentsTimeline";
 import { TimelineProvider } from "@/providers/TimelineProvider";
@@ -54,6 +56,15 @@ const ArtistPageContent = ({ address }: { address: Address }) => {
       <div className="relative grow px-[18px] pb-[30px] pt-[22px] md:px-10 md:pb-11 xl:px-14 2xl:px-20 3xl:px-28">
         <ProfileWithStats
           stats={stats}
+          extraSocials={
+            <Link
+              href={`/${address}/collected`}
+              aria-label="View collected"
+              className="flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:text-[#1c1a17] active:opacity-70"
+            >
+              <GalleryHorizontal className="size-[17px]" strokeWidth={1.5} />
+            </Link>
+          }
           toolbar={
             <ArtistFilters
               protocol={protocolFilter}


### PR DESCRIPTION
## Summary
- add a gallery icon before the social links on the artist timeline header
- link the icon directly to the artist collected page
- reuse the existing rounded icon button styling so it matches the collected page shortcut

## Test plan
- [ ] Open an artist timeline page
- [ ] Confirm a gallery icon appears before the social icons
- [ ] Click it and confirm it navigates to `/{address}/collected`
- [ ] Confirm the icon styling matches the existing header shortcuts


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a gallery icon button to artist profiles, providing direct access to the artist’s collected page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->