### PR TITLE
Add hover hints for profile social and shortcut icons

### DIFF
--- a/components/ArtistPage/ArtistPageContent.tsx
+++ b/components/ArtistPage/ArtistPageContent.tsx
@@ -8,6 +8,7 @@ import { TimelineProvider } from "@/providers/TimelineProvider";
 import { Address } from "viem";
 import ProfileWithStats from "@/components/ProfileWithStats";
 import ArtistFilters from "./ArtistFilters";
+import IconHint from "./IconHint";
 import { useTimelineStats } from "@/hooks/useTimelineStats";
 import { formatStatValue } from "@/lib/stats/formatStatValue";
 import type {
@@ -59,10 +60,11 @@ const ArtistPageContent = ({ address }: { address: Address }) => {
           extraSocials={
             <Link
               href={`/${address}/collected`}
-              aria-label="View collected"
-              className="flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:text-[#1c1a17] active:opacity-70"
+              aria-label="Collected"
+              className="group relative flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:text-[#1c1a17] active:opacity-70"
             >
               <GalleryHorizontal className="size-[17px]" strokeWidth={1.5} />
+              <IconHint label="Collected" />
             </Link>
           }
           toolbar={

--- a/components/ArtistPage/IconHint.tsx
+++ b/components/ArtistPage/IconHint.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  label: string;
+};
+
+const IconHint = ({ label }: Props) => (
+  <span className="pointer-events-none absolute -top-8 left-1/2 z-10 -translate-x-1/2 whitespace-nowrap rounded-md bg-grey-moss-900 px-2 py-1 font-archivo text-[11px] text-white opacity-0 transition-opacity group-hover:opacity-100">
+    {label}
+  </span>
+);
+
+export default IconHint;

--- a/components/ArtistPage/Social.tsx
+++ b/components/ArtistPage/Social.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { validateUrl } from "@/lib/url/validateUrl";
+import IconHint from "./IconHint";
 
 interface SocialProps {
   link: string;
   icon: React.ReactNode;
+  label: string;
 }
 
-const Social = ({ link, icon }: SocialProps) => {
+const Social = ({ link, icon, label }: SocialProps) => {
   const handleClick = () => {
-    // Validate URL before opening to prevent phishing
     if (validateUrl(link)) {
       window.open(link, "_blank", "noopener,noreferrer");
     }
@@ -16,11 +17,13 @@ const Social = ({ link, icon }: SocialProps) => {
 
   return (
     <button
-      className="flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:text-[#1c1a17] active:opacity-70"
+      className="group relative flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:text-[#1c1a17] active:opacity-70"
       type="button"
+      aria-label={label}
       onClick={handleClick}
     >
       {icon}
+      <IconHint label={label} />
     </button>
   );
 };

--- a/components/ArtistPage/SocialAccounts.tsx
+++ b/components/ArtistPage/SocialAccounts.tsx
@@ -65,13 +65,22 @@ const SocialAccounts = ({ extras }: Props) => {
         <Social
           link={`https://instagram.com/${extractSocialUsername(instagram)}`}
           icon={instagramIcon}
+          label="Instagram"
         />
       )}
       {twitter && (
-        <Social link={`https://x.com/@${extractSocialUsername(twitter)}`} icon={twitterIcon} />
+        <Social
+          link={`https://x.com/@${extractSocialUsername(twitter)}`}
+          icon={twitterIcon}
+          label="X"
+        />
       )}
       {telegram && (
-        <Social link={`https://t.me/${extractSocialUsername(telegram)}`} icon={telegramIcon} />
+        <Social
+          link={`https://t.me/${extractSocialUsername(telegram)}`}
+          icon={telegramIcon}
+          label="Telegram"
+        />
       )}
     </div>
   );

--- a/components/CollectedPage/CollectedPage.tsx
+++ b/components/CollectedPage/CollectedPage.tsx
@@ -16,6 +16,7 @@ import { formatStatValue } from "@/lib/stats/formatStatValue";
 import { useMasonryColumnCount } from "@/hooks/useMasonryColumnCount";
 import { useFeedScroll } from "@/hooks/useFeedScroll";
 import { distributeIntoColumns } from "@/lib/moment/distributeIntoColumns";
+import IconHint from "@/components/ArtistPage/IconHint";
 
 const RENDER_PAGE_SIZE = 30;
 
@@ -68,10 +69,11 @@ const CollectedPageContent = ({ address }: { address: Address }) => {
           extraSocials={
             <Link
               href={`/${address}`}
-              aria-label="View timeline"
-              className="flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:opacity-80 active:opacity-70"
+              aria-label="Timeline"
+              className="group relative flex size-8 items-center justify-center rounded-full border border-[rgba(28,26,23,0.2)] bg-white/55 text-[#8a8578] transition-colors hover:border-[rgba(28,26,23,0.4)] hover:bg-white/75 hover:opacity-80 active:opacity-70"
             >
               <Image src="/footer_logo.svg" alt="" width={17} height={17} className="opacity-60" />
+              <IconHint label="Timeline" />
             </Link>
           }
           toolbar={


### PR DESCRIPTION
## Summary
- Add a shared `IconHint` component for CSS hover tooltips on profile header icons
- Show labels on Instagram, X, Telegram, Timeline, and Collected shortcut icons

## Test plan
- [ ] Hover Instagram / X / Telegram icons on an artist profile and confirm labels appear
- [ ] Hover the Collected shortcut on the artist timeline and confirm the Collected hint
- [ ] Hover the Timeline shortcut on the collected page and confirm the Timeline hint
- [ ] Confirm hints do not block clicks


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved accessible labels for collected items, timelines, and social media links.
  * Added hover hints to icon-only navigation and social buttons.

* **UI Improvements**
  * Added visual labels that appear when hovering over relevant icons.
  * Preserved existing social links and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->