### PR TITLE
Fix clipped upload thumbnail on create page audio preview

### DIFF
--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -52,33 +52,29 @@ const AudioPlayer = ({
         </div>
       )}
 
-      {/* Album Art */}
+      {/* Album Art — size by available height so controls don't clip the square */}
       <div className="relative flex min-h-0 flex-1 items-center justify-center p-3">
         <div
           className={cn(
-            "relative w-full",
+            "relative aspect-square h-full max-h-full w-auto max-w-full overflow-hidden rounded-lg shadow-2xl",
             isNatural ? "max-w-[62%]" : "max-w-[70%] sm:max-w-[95%]"
           )}
         >
-          {/* In-flow sizer so the frame keeps height when children are absolute. */}
-          <div className="aspect-square w-full" aria-hidden />
-          <div className="absolute inset-0 overflow-hidden rounded-lg shadow-2xl">
-            {hasThumbnail ? (
-              <Image
-                src={thumbnailUrl!}
-                alt="Audio cover"
-                fill
-                sizes="70vw"
-                className="object-contain"
-              />
-            ) : allowThumbnailUpload ? (
-              <ThumbnailUpload />
-            ) : (
-              <div className="absolute inset-[12%]">
-                <DiscPlaceholder />
-              </div>
-            )}
-          </div>
+          {hasThumbnail ? (
+            <Image
+              src={thumbnailUrl!}
+              alt="Audio cover"
+              fill
+              sizes="70vw"
+              className="object-contain"
+            />
+          ) : allowThumbnailUpload ? (
+            <ThumbnailUpload />
+          ) : (
+            <div className="absolute inset-[12%]">
+              <DiscPlaceholder />
+            </div>
+          )}
         </div>
       </div>
 

--- a/components/MetadataCreation/ThumbnailUpload.tsx
+++ b/components/MetadataCreation/ThumbnailUpload.tsx
@@ -11,11 +11,11 @@ const ThumbnailUpload = () => {
   return (
     <button
       type="button"
-      className="flex size-full flex-col items-center justify-center border-2 border-dashed border-gray-300 rounded-lg bg-neutral-600 cursor-pointer"
+      className="flex size-full flex-col items-center justify-center gap-2 border-2 border-dashed border-gray-300 rounded-lg bg-neutral-600 p-3 cursor-pointer"
       onClick={() => setIsOpenPreviewUpload(true)}
     >
-      <ImageIcon className="mb-3 size-12 text-white" strokeWidth={1.5} />
-      <p className="text-sm font-medium text-white">Upload thumbnail</p>
+      <ImageIcon className="size-10 shrink-0 text-white" strokeWidth={1.5} />
+      <p className="text-center text-xs font-medium text-white sm:text-sm">Upload thumbnail</p>
     </button>
   );
 };


### PR DESCRIPTION
## Summary
- Size the create-page audio preview square by available height so playback controls no longer clip the thumbnail area
- Tighten upload-thumbnail button spacing so the label stays visible in smaller frames

## Test plan
- [ ] Upload an audio file on `/create` without a preview thumbnail
- [ ] Confirm the full "Upload thumbnail" box is visible above the playback controls
- [ ] Click the box and confirm the preview upload modal opens
- [ ] Upload audio with an auto-generated or custom preview and confirm the cover art still renders correctly


Made with [Cursor](https://cursor.com)