### PR TITLE
Fix squished audio play button on collected and feed cards

### DIFF
--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -52,30 +52,46 @@ const AudioPlayer = ({
         </div>
       )}
 
-      {/* Album Art — size by available height so controls don't clip the square */}
+      {/* Album art — fill sizes by height (create stage); natural sizes by width (feed cards) */}
       <div className="relative flex min-h-0 flex-1 items-center justify-center p-3">
-        <div
-          className={cn(
-            "relative aspect-square h-full max-h-full w-auto max-w-full overflow-hidden rounded-lg shadow-2xl",
-            isNatural ? "max-w-[62%]" : "max-w-[70%] sm:max-w-[95%]"
-          )}
-        >
-          {hasThumbnail ? (
-            <Image
-              src={thumbnailUrl!}
-              alt="Audio cover"
-              fill
-              sizes="70vw"
-              className="object-contain"
-            />
-          ) : allowThumbnailUpload ? (
-            <ThumbnailUpload />
-          ) : (
-            <div className="absolute inset-[12%]">
-              <DiscPlaceholder />
+        {isNatural ? (
+          <div className="relative w-full max-w-[62%]">
+            <div className="aspect-square w-full" aria-hidden />
+            <div className="absolute inset-0 overflow-hidden rounded-lg shadow-2xl">
+              {hasThumbnail ? (
+                <Image
+                  src={thumbnailUrl!}
+                  alt="Audio cover"
+                  fill
+                  sizes="70vw"
+                  className="object-contain"
+                />
+              ) : (
+                <div className="absolute inset-[12%]">
+                  <DiscPlaceholder />
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          </div>
+        ) : (
+          <div className="relative aspect-square h-full max-h-full w-auto max-w-[70%] overflow-hidden rounded-lg shadow-2xl sm:max-w-[95%]">
+            {hasThumbnail ? (
+              <Image
+                src={thumbnailUrl!}
+                alt="Audio cover"
+                fill
+                sizes="70vw"
+                className="object-contain"
+              />
+            ) : allowThumbnailUpload ? (
+              <ThumbnailUpload />
+            ) : (
+              <div className="absolute inset-[12%]">
+                <DiscPlaceholder />
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <Controls />

--- a/components/AudioPlayer/Controls.tsx
+++ b/components/AudioPlayer/Controls.tsx
@@ -72,7 +72,7 @@ const Controls = () => {
             togglePlayPause();
           }}
           disabled={isLoading && !isPlaying}
-          className="flex size-12 items-center justify-center rounded-full bg-white text-black shadow-lg transition-transform active:scale-95 disabled:opacity-50 sm:size-14 sm:hover:scale-105"
+          className="flex size-12 shrink-0 items-center justify-center rounded-full bg-white text-black shadow-lg transition-transform active:scale-95 disabled:opacity-50 sm:size-14 sm:hover:scale-105"
         >
           {isLoading ? (
             <Loader2 className="size-6 animate-spin sm:size-7" />


### PR DESCRIPTION
## Summary
- Restore width-based album art sizing for `natural` audio cards used on collected and home feeds
- Keep height-based sizing for the create page `fill` layout so upload thumbnails are not clipped
- Prevent the play button from shrinking inside the controls row

## Test plan
- [ ] Open a collected page with audio moments and confirm the play button stays circular
- [ ] Confirm audio cards on the home feed still render correctly
- [ ] Upload audio on `/create` without a preview and confirm the upload thumbnail area is not clipped


Made with [Cursor](https://cursor.com)