### PR TITLE
Bound long thought moments so feed cards scroll inside

### DIFF
--- a/components/MomentPage/MomentMediaFrame.tsx
+++ b/components/MomentPage/MomentMediaFrame.tsx
@@ -10,7 +10,7 @@ const MomentMediaFrame = () => {
 
   return (
     <div className="relative w-full max-w-none overflow-hidden rounded-[12px] border border-[#E4E0D7] bg-[repeating-linear-gradient(45deg,#F1EEE8_0_12px,#EAE6DD_12px_24px)] shadow-[0_8px_26px_-12px_rgba(27,21,4,.3)] md:max-w-[520px] md:shadow-[0_10px_34px_-14px_rgba(27,21,4,.32)]">
-      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral [&_iframe]:aspect-video [&_iframe]:h-auto [&_iframe]:max-h-[calc(100vh-260px)] [&_iframe]:w-full [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain [&_video]:h-auto [&_video]:max-h-[calc(100vh-260px)] [&_video]:w-full [&_video]:object-contain [&_.pdf-viewer-root]:!h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!max-h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!min-h-0">
+      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral [&_iframe]:aspect-video [&_iframe]:h-auto [&_iframe]:max-h-[calc(100vh-260px)] [&_iframe]:w-full [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain [&_video]:h-auto [&_video]:max-h-[calc(100vh-260px)] [&_video]:w-full [&_video]:object-contain [&_.pdf-viewer-root]:!h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!max-h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!min-h-0 [&_.writing-root]:!h-[calc(100vh-260px)] [&_.writing-root]:!max-h-[calc(100vh-260px)] [&_.writing-root]:!min-h-0">
         <ContentRenderer
           metadata={metadata}
           variant="natural"

--- a/components/Renderers/Writing.tsx
+++ b/components/Renderers/Writing.tsx
@@ -47,10 +47,10 @@ const Writing = ({ fileUrl, description }: WritingProps) => {
     updateScrollState();
   }, [text, isLoading, updateScrollState]);
 
-  if (isLoading && !text) return <Skeleton className="size-full min-h-[200px]" />;
+  if (isLoading && !text) return <Skeleton className="h-[min(70vh,560px)] w-full min-h-[200px]" />;
 
   return (
-    <div className="relative size-full border border-grey-moss-300 bg-white !font-spectral shadow-[5px_6px_2px_2px_#0000000f]">
+    <div className="writing-root relative h-[min(70vh,560px)] w-full min-h-[200px] overflow-hidden border border-grey-moss-300 bg-white !font-spectral shadow-[5px_6px_2px_2px_#0000000f]">
       <div
         className="relative z-[2] size-full overflow-y-auto whitespace-pre-wrap break-words bg-grey-eggshell p-2 pt-24 text-sm md:p-4 md:text-base"
         onScroll={handleScroll}

--- a/components/Renderers/Writing.tsx
+++ b/components/Renderers/Writing.tsx
@@ -50,7 +50,7 @@ const Writing = ({ fileUrl, description }: WritingProps) => {
   if (isLoading && !text) return <Skeleton className="h-[min(70vh,560px)] w-full min-h-[200px]" />;
 
   return (
-    <div className="writing-root relative h-[min(70vh,560px)] w-full min-h-[200px] overflow-hidden border border-grey-moss-300 bg-white !font-spectral shadow-[5px_6px_2px_2px_#0000000f]">
+    <div className="writing-root relative h-[min(70vh,560px)] w-full min-h-[200px] overflow-hidden bg-grey-eggshell !font-spectral">
       <div
         className="relative z-[2] size-full overflow-y-auto whitespace-pre-wrap break-words bg-grey-eggshell p-2 pt-24 text-sm md:p-4 md:text-base"
         onScroll={handleScroll}


### PR DESCRIPTION
## Summary
- Cap writing/thought media height like PDF viewers so long text no longer stretches feed and collected cards
- Keep moment-page writing media sized to the existing media frame

## Test plan
- [ ] Open the home feed with a long thought moment and confirm the card height is bounded
- [ ] Scroll inside the thought card and confirm the full text is still readable
- [ ] Open the same thought on the moment page and confirm it fits the media frame
- [ ] Confirm short thoughts still render normally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved writing content sizing across viewport dimensions.
  * Prevented writing content from overflowing its display area.
  * Updated loading placeholders to better match the final content layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->