### PR TITLE
Ignore Supabase storage URLs in moment external links

### DIFF
--- a/lib/moment/getMomentUrl.ts
+++ b/lib/moment/getMomentUrl.ts
@@ -2,6 +2,7 @@ import { TimelineMoment } from "@/types/moment";
 import { validateUrl } from "@/lib/url/validateUrl";
 import { isYoutubeUrl } from "@/lib/url/isYoutubeUrl";
 import { isDeprecatedUrl } from "@/lib/url/isDeprecatedUrl";
+import { isSupabaseStorageUrl } from "@/lib/url/isSupabaseStorageUrl";
 import { getShortNameFromChainId } from "@/lib/zora/getShortNameFromChainId";
 
 export interface MomentUrl {
@@ -12,7 +13,12 @@ export interface MomentUrl {
 export const getMomentUrl = (moment: TimelineMoment): MomentUrl | undefined => {
   const { chain_id, address, token_id, metadata } = moment;
   const externalUrl = metadata?.external_url;
-  if (externalUrl && !isDeprecatedUrl(externalUrl) && !isYoutubeUrl(externalUrl)) {
+  if (
+    externalUrl &&
+    !isDeprecatedUrl(externalUrl) &&
+    !isYoutubeUrl(externalUrl) &&
+    !isSupabaseStorageUrl(externalUrl)
+  ) {
     const validatedUrl = validateUrl(externalUrl);
     if (validatedUrl) return { href: validatedUrl, isExternal: true };
   }

--- a/lib/url/isSupabaseStorageUrl.ts
+++ b/lib/url/isSupabaseStorageUrl.ts
@@ -1,0 +1,1 @@
+export const isSupabaseStorageUrl = (url: string): boolean => url.includes("supabase.co/storage");


### PR DESCRIPTION
## Summary
- Treat Supabase Storage URLs like YouTube/deprecated links in `getMomentUrl`
- Thought moments that incorrectly stored a preview URI in `external_url` now open the normal collect page instead of a broken storage URL

## Test plan
- [ ] Open a thought moment whose metadata `external_url` is a `supabase.co/storage` URL
- [ ] Confirm clicking the feed/card goes to `/collect/...` instead of Supabase
- [ ] Confirm normal external links still open externally
- [ ] Confirm YouTube moments still use in-app YouTube rendering (not external redirect)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supabase Storage links now resolve to the appropriate internal collection URL instead of being treated as external metadata links.
  * Improved URL handling alongside existing support for deprecated and YouTube links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->