### PR TITLE
Preserve newlines in moment comment list

### DIFF
--- a/components/MomentPage/CommentThread.tsx
+++ b/components/MomentPage/CommentThread.tsx
@@ -67,7 +67,7 @@ export const CommentThread = ({ comment, depth = 0, replyTo }: CommentThreadProp
           {commentText?.trim() ? (
             <EmojiText
               text={commentText}
-              className="mb-1 font-spectral text-[14.5px] leading-snug text-grey-moss-900"
+              className="mb-1 whitespace-pre-wrap font-spectral text-[14.5px] leading-snug text-grey-moss-900"
             />
           ) : (
             <div className="mb-1 inline-flex items-center gap-1.5 font-archivo text-[11.5px] text-[#8B8474]">


### PR DESCRIPTION
## Summary
- Add `whitespace-pre-wrap` to comment body text in `CommentThread` so API `\n` characters render as line breaks

## Test plan
- [ ] Open a moment with a multi-line comment (bullets / blank lines)
- [ ] Confirm line breaks match the API text on desktop and mobile comment drawer
- [ ] Confirm long single-line comments still wrap normally


Made with [Cursor](https://cursor.com)