### PR TITLE
Fix writing preview layout on collect page

### DIFF
--- a/components/MomentPage/MomentMediaFrame.tsx
+++ b/components/MomentPage/MomentMediaFrame.tsx
@@ -9,8 +9,8 @@ const MomentMediaFrame = () => {
   if (!metadata) return null;
 
   return (
-    <div className="relative w-full max-w-none overflow-hidden rounded-[12px] border border-[#E4E0D7] bg-[repeating-linear-gradient(45deg,#F1EEE8_0_12px,#EAE6DD_12px_24px)] shadow-[0_8px_26px_-12px_rgba(27,21,4,.3)] md:max-w-[520px] md:shadow-[0_10px_34px_-14px_rgba(27,21,4,.32)]">
-      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral [&_iframe]:aspect-video [&_iframe]:h-auto [&_iframe]:max-h-[calc(100vh-260px)] [&_iframe]:w-full [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain [&_video]:h-auto [&_video]:max-h-[calc(100vh-260px)] [&_video]:w-full [&_video]:object-contain [&_.pdf-viewer-root]:!h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!max-h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!min-h-0 [&_.writing-root]:!max-h-[calc(100vh-260px)] [&_.writing-root]:!min-h-0 [&_.writing-root>*]:!max-h-[calc(100vh-260px)]">
+    <div className="relative w-full overflow-hidden rounded-[12px] border border-[#E4E0D7] bg-[repeating-linear-gradient(45deg,#F1EEE8_0_12px,#EAE6DD_12px_24px)] shadow-[0_8px_26px_-12px_rgba(27,21,4,.3)] md:shadow-[0_10px_34px_-14px_rgba(27,21,4,.32)]">
+      <div className="relative max-h-[calc(100vh-260px)] w-full overflow-hidden font-spectral [&_iframe]:aspect-video [&_iframe]:h-auto [&_iframe]:max-h-[calc(100vh-260px)] [&_iframe]:w-full [&_img]:max-h-[calc(100vh-260px)] [&_img]:object-contain [&_video]:h-auto [&_video]:max-h-[calc(100vh-260px)] [&_video]:w-full [&_video]:object-contain [&_.pdf-viewer-root]:!h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!max-h-[calc(100vh-260px)] [&_.pdf-viewer-root]:!min-h-0 [&_.writing-root]:!h-[calc(100vh-260px)] [&_.writing-root]:!max-h-[calc(100vh-260px)] [&_.writing-root>[role=region]]:!h-full [&_.writing-root>[role=region]]:!max-h-full [&_.writing-root>[role=region]]:!pt-12">
         <ContentRenderer
           metadata={metadata}
           variant="natural"
@@ -21,7 +21,7 @@ const MomentMediaFrame = () => {
         />
       </div>
       {protocol === Protocol.InProcess && (
-        <span className="pointer-events-none absolute left-3 top-3 rounded-[5px] bg-[rgba(27,21,4,.72)] px-2.5 py-1 font-archivo-medium text-[10.5px] tracking-wide text-white">
+        <span className="pointer-events-none absolute left-3 top-3 z-[1] rounded-[5px] bg-[rgba(27,21,4,.72)] px-2.5 py-1 font-archivo-medium text-[10.5px] tracking-wide text-white">
           in_process
         </span>
       )}


### PR DESCRIPTION
## Summary
- Remove `md:max-w-[520px]` so the media frame spans the left column
- Give writing previews a fixed viewport height so short text still fills the panel
- Add top padding so writing body clears the `in_process` protocol badge

## Test plan
- [ ] Open a short text/thought moment collect page — white preview fills left column height
- [ ] Confirm `in_process` badge does not cover the first line of text
- [ ] Open a long writing moment — scroll still works inside the frame
- [ ] Open an image/video moment — layout unchanged aside from full column width


Made with [Cursor](https://cursor.com)