### PR TITLE
Add timeline visibility editor for moment owners

### DIFF
--- a/components/SMSMomentPage/MomentDetailsCard.tsx
+++ b/components/SMSMomentPage/MomentDetailsCard.tsx
@@ -10,6 +10,7 @@ import Description from "../MomentPage/Description";
 import SaveMediaButton from "../MomentManagePage/SaveMediaButton";
 import CollectLinkRow from "./CollectLinkRow";
 import MomentThumbnailField from "./MomentThumbnailField";
+import TimelineVisibilityField from "./TimelineVisibilityField";
 
 const MomentDetailsCard = () => {
   const { metadata, isOwner } = useMomentProvider();
@@ -73,6 +74,7 @@ const MomentDetailsCard = () => {
           <SaveMediaButton className="rounded-full px-5 py-1.5 font-archivo text-sm font-semibold" />
         </div>
       )}
+      {isOwner && <TimelineVisibilityField disabled={!canEdit} />}
     </div>
   );
 };

--- a/components/SMSMomentPage/TimelineVisibilityField.tsx
+++ b/components/SMSMomentPage/TimelineVisibilityField.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { DateTimePicker } from "@/components/ui/date-time-picker";
+import PermissionErrorModal from "@/components/PermissionErrorModal";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import useSetTimelineVisibility from "@/hooks/useSetTimelineVisibility";
+
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+const PICKER_CLASS =
+  "!rounded-md !border-grey-moss-100 !font-archivo text-[15px] text-grey-moss-900 hover:!bg-white";
+
+interface TimelineVisibilityFieldProps {
+  disabled?: boolean;
+}
+
+const TimelineVisibilityField = ({ disabled = false }: TimelineVisibilityFieldProps) => {
+  const { moment } = useMomentProvider();
+  const {
+    timelineAt,
+    setTimelineAt,
+    currentSaleStart,
+    hasSaleConfig,
+    save,
+    isLoading,
+    showPermissionModal,
+    closePermissionModal,
+  } = useSetTimelineVisibility();
+
+  if (!hasSaleConfig || currentSaleStart === undefined) return null;
+
+  const normalized = BigInt(String(Math.floor(Number(currentSaleStart))));
+  const currentLabel =
+    normalized === BigInt(0) ? "Open" : new Date(Number(normalized) * 1000).toLocaleString();
+
+  return (
+    <div className="flex flex-col gap-1 border-t border-grey-moss-100 pt-3">
+      <div className="flex items-center justify-between gap-2">
+        <label className={FIELD_LABEL_CLASS}>timeline</label>
+        <span className="font-archivo text-[10.5px] text-tan-gold">{currentLabel}</span>
+      </div>
+      <p className="font-archivo text-[11px] text-grey-moss-200">
+        When this moment appears on the timeline
+      </p>
+      <DateTimePicker
+        date={timelineAt}
+        setDate={setTimelineAt}
+        disabled={disabled || isLoading}
+        className={PICKER_CLASS}
+      />
+      <div className="mt-2 flex items-center justify-end">
+        <button
+          type="button"
+          onClick={save}
+          disabled={disabled || isLoading}
+          className="rounded-full border border-grey-moss-900 bg-grey-moss-900 px-[18px] py-1.5 font-archivo-medium text-xs text-white transition-colors hover:bg-black disabled:opacity-50"
+        >
+          {isLoading ? "Updating..." : "Update"}
+        </button>
+      </div>
+      <PermissionErrorModal
+        open={showPermissionModal}
+        onClose={closePermissionModal}
+        contractAddress={moment.collectionAddress}
+      />
+    </div>
+  );
+};
+
+export default TimelineVisibilityField;

--- a/hooks/useSetSale.ts
+++ b/hooks/useSetSale.ts
@@ -8,6 +8,7 @@ import { setSale } from "@/lib/moment/setSale";
 import { MomentType } from "@/types/moment";
 import { isPermissionError } from "@/lib/errors/isPermissionError";
 import { isOpenEndedSale } from "@/lib/moment/isOpenEndedSale";
+import saleStartToDate from "@/lib/moment/saleStartToDate";
 
 const useSetSale = () => {
   const { moment, saleConfig: sale } = useMomentProvider();
@@ -24,11 +25,7 @@ const useSetSale = () => {
     if (!sale) return;
     const erc20 = sale.type === MomentType.Erc20Mint;
     setIsErc20(erc20);
-    setSaleStart(
-      BigInt(sale.saleStart) === BigInt(0)
-        ? new Date()
-        : new Date(parseInt(sale.saleStart.toString(), 10) * 1000)
-    );
+    setSaleStart(saleStartToDate(sale.saleStart));
     setSaleEnd(
       isOpenEndedSale(sale.saleEnd)
         ? undefined

--- a/hooks/useSetTimelineVisibility.ts
+++ b/hooks/useSetTimelineVisibility.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import { setSale } from "@/lib/moment/setSale";
+import { isPermissionError } from "@/lib/errors/isPermissionError";
+
+const saleStartToDate = (saleStart: number | string) =>
+  BigInt(saleStart) === BigInt(0)
+    ? new Date()
+    : new Date(parseInt(saleStart.toString(), 10) * 1000);
+
+const useSetTimelineVisibility = () => {
+  const { moment, saleConfig, fetchMomentData } = useMomentProvider();
+  const { getAccessToken } = usePrivy();
+  const [timelineAt, setTimelineAt] = useState<Date>(new Date());
+  const [showPermissionModal, setShowPermissionModal] = useState(false);
+
+  useEffect(() => {
+    if (!saleConfig) return;
+    setTimelineAt(saleStartToDate(saleConfig.saleStart));
+  }, [saleConfig]);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Authentication required");
+      return setSale(accessToken, moment, Math.floor(timelineAt.getTime() / 1000));
+    },
+    onSuccess: async () => {
+      await fetchMomentData();
+      toast.success("Timeline visibility updated");
+    },
+    onError: (error: Error) => {
+      if (isPermissionError(error)) {
+        setShowPermissionModal(true);
+      } else {
+        toast.error(error.message || "Failed to update timeline visibility");
+      }
+    },
+  });
+
+  return {
+    timelineAt,
+    setTimelineAt,
+    currentSaleStart: saleConfig?.saleStart,
+    hasSaleConfig: Boolean(saleConfig),
+    save: () => mutate(),
+    isLoading: isPending,
+    showPermissionModal,
+    closePermissionModal: () => setShowPermissionModal(false),
+  };
+};
+
+export default useSetTimelineVisibility;

--- a/hooks/useSetTimelineVisibility.ts
+++ b/hooks/useSetTimelineVisibility.ts
@@ -4,12 +4,8 @@ import { usePrivy } from "@privy-io/react-auth";
 import { toast } from "sonner";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import { setSale } from "@/lib/moment/setSale";
+import saleStartToDate from "@/lib/moment/saleStartToDate";
 import { isPermissionError } from "@/lib/errors/isPermissionError";
-
-const saleStartToDate = (saleStart: number | string) =>
-  BigInt(saleStart) === BigInt(0)
-    ? new Date()
-    : new Date(parseInt(saleStart.toString(), 10) * 1000);
 
 const useSetTimelineVisibility = () => {
   const { moment, saleConfig, fetchMomentData } = useMomentProvider();

--- a/lib/moment/saleStartToDate.ts
+++ b/lib/moment/saleStartToDate.ts
@@ -1,0 +1,7 @@
+/** On-chain saleStart 0 means open/immediate, not Unix epoch. */
+const saleStartToDate = (saleStart: number | string): Date =>
+  BigInt(saleStart) === BigInt(0)
+    ? new Date()
+    : new Date(parseInt(saleStart.toString(), 10) * 1000);
+
+export default saleStartToDate;

--- a/lib/moment/saleStartToDate.ts
+++ b/lib/moment/saleStartToDate.ts
@@ -1,4 +1,3 @@
-/** On-chain saleStart 0 means open/immediate, not Unix epoch. */
 const saleStartToDate = (saleStart: number | string): Date =>
   BigInt(saleStart) === BigInt(0)
     ? new Date()


### PR DESCRIPTION
## Summary
- Let moment owners set when a moment appears on the timeline via `saleStart`
- Surface the current timeline time and an Update control on the manage details card
- Polish labels (Update / Updating...) and show the current value in tan-gold

## Test plan
- [ ] As moment owner, open manage/details and confirm the timeline section appears when sale config exists
- [ ] Change the datetime and click Update; confirm success toast and refreshed current value
- [ ] Confirm non-owners do not see the control
- [ ] Confirm permission errors open the permission modal


Made with [Cursor](https://cursor.com)