### PR TITLE
Update timeline label immediately after successful save

### DIFF
--- a/hooks/useSetTimelineVisibility.ts
+++ b/hooks/useSetTimelineVisibility.ts
@@ -8,24 +8,28 @@ import saleStartToDate from "@/lib/moment/saleStartToDate";
 import { isPermissionError } from "@/lib/errors/isPermissionError";
 
 const useSetTimelineVisibility = () => {
-  const { moment, saleConfig, fetchMomentData } = useMomentProvider();
+  const { moment, saleConfig } = useMomentProvider();
   const { getAccessToken } = usePrivy();
   const [timelineAt, setTimelineAt] = useState<Date>(new Date());
+  const [currentSaleStart, setCurrentSaleStart] = useState<number | undefined>();
   const [showPermissionModal, setShowPermissionModal] = useState(false);
 
   useEffect(() => {
     if (!saleConfig) return;
     setTimelineAt(saleStartToDate(saleConfig.saleStart));
+    setCurrentSaleStart(saleConfig.saleStart);
   }, [saleConfig]);
 
   const { mutate, isPending } = useMutation({
     mutationFn: async () => {
       const accessToken = await getAccessToken();
       if (!accessToken) throw new Error("Authentication required");
-      return setSale(accessToken, moment, Math.floor(timelineAt.getTime() / 1000));
+      const saleStart = Math.floor(timelineAt.getTime() / 1000);
+      await setSale(accessToken, moment, saleStart);
+      return saleStart;
     },
-    onSuccess: async () => {
-      await fetchMomentData();
+    onSuccess: (saleStart) => {
+      setCurrentSaleStart(saleStart);
       toast.success("Timeline visibility updated");
     },
     onError: (error: Error) => {
@@ -40,7 +44,7 @@ const useSetTimelineVisibility = () => {
   return {
     timelineAt,
     setTimelineAt,
-    currentSaleStart: saleConfig?.saleStart,
+    currentSaleStart,
     hasSaleConfig: Boolean(saleConfig),
     save: () => mutate(),
     isLoading: isPending,


### PR DESCRIPTION
## Summary
- After a successful timeline sale write, update the label next to Timeline from the saved timestamp instead of refetching moment data
- Avoids showing a stale Supabase/indexer value right after the on-chain update succeeds

## Test plan
- [ ] As moment owner, change timeline datetime and click Update
- [ ] Confirm success toast and the tan-gold label next to Timeline updates to the chosen datetime immediately
- [ ] Reload the page later and confirm the label matches once indexing catches up


Made with [Cursor](https://cursor.com)