### PR TITLE
Switch to Base before signing wallet connect messages

### DIFF
--- a/components/ExternalWalletButton/ConnectButton.tsx
+++ b/components/ExternalWalletButton/ConnectButton.tsx
@@ -1,4 +1,5 @@
 import { classNames } from "@/lib/utils/classNames";
+import { CHAIN_ID } from "@/lib/consts";
 import connectEOA from "@/lib/wallets/connectEOA";
 import { signWalletConnectMessage } from "@/lib/wallets/signWalletConnectMessage";
 import { useWalletsProvider } from "@/providers/WalletsProvider";
@@ -16,6 +17,7 @@ const ConnectButton = () => {
     onSuccess: async ({ wallet }: any) => {
       setIsLoading(true);
       try {
+        await wallet.switchChain(CHAIN_ID);
         const provider = await wallet?.getEthereumProvider?.();
         if (!provider) throw new Error("No Ethereum provider found");
         const { message, signature } = await signWalletConnectMessage(


### PR DESCRIPTION
## Summary
- switch the connected wallet to Base before requesting the wallet connect signature
- keep Coinbase smart wallet signatures on the same chain the API verifies
- match the existing grant-permission `switchChain` flow

## Test plan
- [ ] Connect a Base smart wallet from the manage page
- [ ] Confirm the Coinbase popup signs after the chain switch
- [ ] Confirm a normal EOA wallet connect still succeeds