### PR TITLE
Allow airdrop recipients to be emails

### DIFF
--- a/components/SMSMomentPage/AddressChip.tsx
+++ b/components/SMSMomentPage/AddressChip.tsx
@@ -20,7 +20,7 @@ const AddressChip = ({ item, index }: AddressChipProps) => {
     >
       {item.status === "validating"
         ? "validating..."
-        : item.ensName || truncateAddress(item.address)}
+        : item.email || item.ensName || truncateAddress(item.address)}
       <button
         type="button"
         onClick={() => removeAddress(index)}

--- a/components/SMSMomentPage/AddressChipInput.tsx
+++ b/components/SMSMomentPage/AddressChipInput.tsx
@@ -12,7 +12,7 @@ const AddressChipInput = () => {
   return (
     <div className="flex flex-wrap items-center gap-1.5 border-b-2 border-grey-moss-900 py-2">
       {airdropToItems.map((item: AirdropItem, index) => (
-        <AddressChip item={item} index={index} key={`${index}-${item.address || item.ensName}`} />
+        <AddressChip item={item} index={index} key={`${index}-${item.address || item.email || item.ensName}`} />
       ))}
       <input
         type="text"
@@ -21,7 +21,7 @@ const AddressChipInput = () => {
         onKeyDown={handleInput}
         onPaste={handlePaste}
         onBlur={handleBlur}
-        placeholder="Wallet address or ENS"
+        placeholder="Wallet address, ENS, or email"
         className="min-w-[130px] flex-1 border-none bg-transparent py-1.5 font-archivo text-sm text-grey-moss-900 outline-none"
       />
     </div>

--- a/hooks/useAirdrop.ts
+++ b/hooks/useAirdrop.ts
@@ -10,6 +10,7 @@ import { useMomentProvider } from "@/providers/MomentProvider";
 import { AirdropItem } from "@/types/airdrop";
 import { processAirdropItems } from "@/lib/airdrop/processAirdropItems";
 import resolveAddressForAirdrop from "@/lib/ens/resolveAddressForAirdrop";
+import isEmail from "@/lib/utils/isEmail";
 
 const useAirdrop = () => {
   const { moment } = useMomentProvider();
@@ -29,6 +30,20 @@ const useAirdrop = () => {
         ...prev,
         {
           address: value,
+          email: "",
+          status: "valid",
+          ensName: "",
+        },
+      ]);
+      return;
+    }
+
+    if (isEmail(value)) {
+      setAirdropToItems((prev) => [
+        ...prev,
+        {
+          address: "",
+          email: value.trim().toLowerCase(),
           status: "valid",
           ensName: "",
         },
@@ -39,6 +54,7 @@ const useAirdrop = () => {
     // For ENS names, add with "validating" status first for immediate UI feedback
     const newItem: AirdropItem = {
       address: "",
+      email: "",
       status: "validating",
       ensName: value,
     };
@@ -90,7 +106,7 @@ const useAirdrop = () => {
 
       if (validItems.length === 0) {
         setLoading(false);
-        toast.error("No valid addresses to airdrop");
+        toast.error("No valid recipients to airdrop");
         return;
       }
 

--- a/lib/airdrop/processAirdropItems.ts
+++ b/lib/airdrop/processAirdropItems.ts
@@ -14,11 +14,9 @@ export const processAirdropItems = async (
   const alreadyValidItems: AirdropItem[] = [];
 
   airdropToItems.forEach((item, index) => {
-    if (item.status === "validating" || (item.status === "valid" && !item.address)) {
-      // Item needs resolution - preserve original index for mapping
+    if (item.status === "validating") {
       itemsNeedingResolution.push({ item, originalIndex: index });
     } else if (item.status === "valid" && item.address) {
-      // Item is already valid - keep as is
       alreadyValidItems.push(item);
     }
   });
@@ -40,7 +38,9 @@ export const processAirdropItems = async (
   });
 
   // Filter out invalid items for airdrop execution
-  const validItems = finalItems.filter((item) => item.status === "valid" && item.address);
+  const validItems = finalItems.filter(
+    (item) => item.status === "valid" && (item.address || item.email)
+  );
 
   return {
     finalItems,

--- a/lib/ens/resolveAddressForAirdrop.ts
+++ b/lib/ens/resolveAddressForAirdrop.ts
@@ -1,15 +1,26 @@
 import { isAddress } from "viem";
 import resolveEnsToAddress from "./resolveEnsToAddress";
 import { AirdropItem } from "@/types/airdrop";
+import isEmail from "@/lib/utils/isEmail";
 
 const resolveAddressForAirdrop = async (value: string): Promise<AirdropItem> => {
   if (!value) {
-    return { address: "", status: "invalid", ensName: "" };
+    return { address: "", email: "", status: "invalid", ensName: "" };
   }
 
   if (isAddress(value)) {
     return {
       address: value,
+      email: "",
+      status: "valid",
+      ensName: "",
+    };
+  }
+
+  if (isEmail(value)) {
+    return {
+      address: "",
+      email: value.trim().toLowerCase(),
       status: "valid",
       ensName: "",
     };
@@ -19,6 +30,7 @@ const resolveAddressForAirdrop = async (value: string): Promise<AirdropItem> => 
 
   return {
     address: ensAddress || "",
+    email: "",
     status: ensAddress ? "valid" : "invalid",
     ensName: value,
   };

--- a/lib/moment/executeAirdrop.ts
+++ b/lib/moment/executeAirdrop.ts
@@ -3,13 +3,13 @@ import { Moment } from "@/types/moment";
 import buildHeaders from "@/lib/http/buildHeaders";
 
 interface ExecuteAirdropParams {
-  airdropToItems: Array<{ address: string }>;
+  airdropToItems: Array<{ address: string; email?: string }>;
   moment: Moment;
   headers: HeadersInit;
 }
 
 export const executeAirdrop = async ({ airdropToItems, moment, headers }: ExecuteAirdropParams) => {
-  const recipients = airdropToItems.map((item) => item.address);
+  const recipients = airdropToItems.map((item) => item.email || item.address);
 
   // Execute airdrop API call
   const response = await fetch(`${IN_PROCESS_API}/moment/airdrop`, {

--- a/lib/utils/isEmail.ts
+++ b/lib/utils/isEmail.ts
@@ -1,0 +1,4 @@
+const isEmail = (value: string): boolean =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+
+export default isEmail;

--- a/types/airdrop.ts
+++ b/types/airdrop.ts
@@ -2,6 +2,7 @@ import type { MomentMetadata, Protocol } from "@/types/moment";
 
 export interface AirdropItem {
   address: string;
+  email: string;
   status: "validating" | "invalid" | "valid";
   ensName: string;
 }


### PR DESCRIPTION
## Summary
- Accept email addresses in the airdrop recipient input, in addition to wallet addresses and ENS names.
- Send email recipients to the API as-is so it can resolve them to an In Process primary wallet.

Depends on https://github.com/sweetmantech/in_process_api/pull/444

## Test plan
- [ ] Enter a `0x` address or ENS name — existing airdrop behavior is unchanged.
- [ ] Enter an email and airdrop — the chip shows the email, and the API receives that email as a recipient.
- [ ] Invalid input still shows as an invalid chip and blocks submit.


Made with [Cursor](https://cursor.com)