### PR TITLE
Add Splits tab on moment manage

### DIFF
--- a/components/MomentManagePage/FundsRecipientHint.tsx
+++ b/components/MomentManagePage/FundsRecipientHint.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import useIsSplitContract from "@/hooks/useIsSplitContract";
+import truncateAddress from "@/lib/utils/truncateAddress";
+
+const FundsRecipientHint = () => {
+  const { isSplit, fundsRecipient } = useIsSplitContract();
+
+  if (!fundsRecipient || isSplit !== false) return null;
+
+  return (
+    <div className="mb-4 rounded-lg border border-grey-moss-100 bg-grey-moss-50/60 px-3.5 py-3">
+      <p className="font-archivo text-[13px] text-grey-moss-900">
+        The current fundsRecipient is {truncateAddress(fundsRecipient)}, not a split.
+      </p>
+      <p className="mt-1 font-archivo text-[12px] text-grey-moss-300">
+        Create a split to set fundsRecipient to the new split address.
+      </p>
+    </div>
+  );
+};
+
+export default FundsRecipientHint;

--- a/components/MomentManagePage/ManageTabs.tsx
+++ b/components/MomentManagePage/ManageTabs.tsx
@@ -5,6 +5,7 @@ export enum MANAGE_TABS {
   MEDIA,
   AIRDROP,
   SALE,
+  SPLITS,
   ADMIN,
 }
 
@@ -35,6 +36,11 @@ const ManageTabs = ({ selectedTab, onChangeTab }: ManageTabsProps) => {
               label="Sale"
               active={selectedTab === MANAGE_TABS.SALE}
               onClick={() => onChangeTab(MANAGE_TABS.SALE)}
+            />
+            <TabButton
+              label="Splits"
+              active={selectedTab === MANAGE_TABS.SPLITS}
+              onClick={() => onChangeTab(MANAGE_TABS.SPLITS)}
             />
             <TabButton
               label="Admins"

--- a/components/MomentManagePage/MomentManagePage.tsx
+++ b/components/MomentManagePage/MomentManagePage.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useState } from "react";
 import ManageTabs, { MANAGE_TABS } from "./ManageTabs";
 import Sale from "./Sale";
+import Splits from "./Splits";
 import MomentMedia from "../Media/MomentMedia";
 import { useParams } from "next/navigation";
 import { MomentProvider } from "@/providers/MomentProvider";
@@ -44,6 +45,7 @@ const MomentManagePage = () => {
               <div className="pb-2">
                 {selectedTab === MANAGE_TABS.AIRDROP && <MomentAirdrop />}
                 {selectedTab === MANAGE_TABS.SALE && <Sale />}
+                {selectedTab === MANAGE_TABS.SPLITS && <Splits />}
                 {selectedTab === MANAGE_TABS.MEDIA && <MomentMedia />}
                 {selectedTab === MANAGE_TABS.ADMIN && <Admins />}
               </div>

--- a/components/MomentManagePage/Splits.tsx
+++ b/components/MomentManagePage/Splits.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import SplitsForm from "@/components/CreateForm/SplitsForm";
+import PermissionErrorModal from "@/components/PermissionErrorModal";
+import useManageSplits from "@/hooks/useManageSplits";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import FundsRecipientHint from "./FundsRecipientHint";
+
+const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
+
+const Splits = () => {
+  const {
+    handleCreate,
+    handleDistribute,
+    isCreating,
+    isDistributing,
+    isSplit,
+    showPermissionModal,
+    closePermissionModal,
+  } = useManageSplits();
+  const { isOwner, moment } = useMomentProvider();
+
+  const isBusy = isCreating || isDistributing;
+  const isDisabled = isBusy || !isOwner;
+  const isDistributeDisabled = isDisabled || isSplit !== true;
+
+  return (
+    <div className="rounded-lg border border-grey-moss-100 bg-white p-4 shadow-sm md:p-6">
+      <div className="mb-4 flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-[#887bff]" />
+        <span className={FIELD_LABEL_CLASS}>splits</span>
+      </div>
+
+      <FundsRecipientHint />
+
+      <SplitsForm />
+
+      <div className="mt-[18px] flex items-center justify-end gap-3 border-t border-grey-moss-50 pt-4">
+        <button
+          type="button"
+          onClick={handleDistribute}
+          disabled={isDistributeDisabled}
+          className="rounded-full border border-grey-moss-900 bg-white px-[18px] py-2 font-archivo-medium text-xs text-grey-moss-900 transition-colors hover:bg-grey-moss-50 disabled:opacity-50"
+        >
+          {isDistributing ? "Distributing..." : "Distribute"}
+        </button>
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={isDisabled}
+          className="rounded-full border border-grey-moss-900 bg-grey-moss-900 px-[18px] py-2 font-archivo-medium text-xs text-white transition-colors hover:bg-black disabled:opacity-50"
+        >
+          {isCreating ? "Creating..." : "Create"}
+        </button>
+      </div>
+
+      <PermissionErrorModal
+        open={showPermissionModal}
+        onClose={closePermissionModal}
+        contractAddress={moment.collectionAddress}
+      />
+    </div>
+  );
+};
+
+export default Splits;

--- a/components/MomentManagePage/Splits.tsx
+++ b/components/MomentManagePage/Splits.tsx
@@ -3,6 +3,7 @@
 import SplitsForm from "@/components/CreateForm/SplitsForm";
 import PermissionErrorModal from "@/components/PermissionErrorModal";
 import useManageSplits from "@/hooks/useManageSplits";
+import useLoadSplitRecipients from "@/hooks/useLoadSplitRecipients";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import FundsRecipientHint from "./FundsRecipientHint";
 
@@ -18,6 +19,7 @@ const Splits = () => {
     showPermissionModal,
     closePermissionModal,
   } = useManageSplits();
+  const { showCreate } = useLoadSplitRecipients();
   const { isOwner, moment } = useMomentProvider();
 
   const isBusy = isCreating || isDistributing;
@@ -44,14 +46,16 @@ const Splits = () => {
         >
           {isDistributing ? "Distributing..." : "Distribute"}
         </button>
-        <button
-          type="button"
-          onClick={handleCreate}
-          disabled={isDisabled}
-          className="rounded-full border border-grey-moss-900 bg-grey-moss-900 px-[18px] py-2 font-archivo-medium text-xs text-white transition-colors hover:bg-black disabled:opacity-50"
-        >
-          {isCreating ? "Creating..." : "Create"}
-        </button>
+        {showCreate && (
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={isDisabled}
+            className="rounded-full border border-grey-moss-900 bg-grey-moss-900 px-[18px] py-2 font-archivo-medium text-xs text-white transition-colors hover:bg-black disabled:opacity-50"
+          >
+            {isCreating ? "Creating..." : "Create"}
+          </button>
+        )}
       </div>
 
       <PermissionErrorModal

--- a/hooks/useIsSplitContract.ts
+++ b/hooks/useIsSplitContract.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import isSplitContract from "@/lib/splits/isSplitContract";
+
+const useIsSplitContract = () => {
+  const { saleConfig, moment } = useMomentProvider();
+  const fundsRecipient = saleConfig?.fundsRecipient;
+  const { data: isSplit, isLoading } = useQuery({
+    queryKey: ["isSplitContract", fundsRecipient, moment.chainId],
+    queryFn: () => isSplitContract(fundsRecipient!, moment.chainId),
+    enabled: Boolean(fundsRecipient),
+  });
+
+  return { isSplit, isLoading, fundsRecipient };
+};
+
+export default useIsSplitContract;

--- a/hooks/useLoadSplitRecipients.ts
+++ b/hooks/useLoadSplitRecipients.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { useFieldArray, useWatch } from "react-hook-form";
+import { useQuery } from "@tanstack/react-query";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import useIsSplitContract from "@/hooks/useIsSplitContract";
+import getSplitRecipients from "@/lib/splits/getSplitRecipients";
+import type { SplitRecipientInput } from "@/lib/splits/createSplit";
+
+const areSplitsEqual = (a?: SplitRecipientInput[], b?: SplitRecipientInput[]) => {
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every(
+    (row, i) =>
+      row.address.toLowerCase() === b[i].address.toLowerCase() &&
+      row.percentAllocation === b[i].percentAllocation
+  );
+};
+
+const useLoadSplitRecipients = () => {
+  const { moment } = useMomentProvider();
+  const { form } = useMetadataFormProvider();
+  const { isSplit, fundsRecipient } = useIsSplitContract();
+  const { replace } = useFieldArray({
+    control: form.control,
+    name: "splits",
+  });
+  const [hydratedAddress, setHydratedAddress] = useState<string | null>(null);
+  const formSplits = useWatch({ control: form.control, name: "splits" });
+
+  const { data: recipients } = useQuery({
+    queryKey: ["splitRecipients", fundsRecipient, moment.chainId],
+    queryFn: () => getSplitRecipients(fundsRecipient!, moment.chainId),
+    enabled: Boolean(fundsRecipient) && isSplit === true,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  useEffect(() => {
+    if (!recipients || !fundsRecipient) return;
+    if (hydratedAddress === fundsRecipient) return;
+    replace(recipients);
+    setHydratedAddress(fundsRecipient);
+  }, [recipients, fundsRecipient, hydratedAddress, replace]);
+
+  const hasSplitsChanged =
+    hydratedAddress === fundsRecipient &&
+    Boolean(recipients) &&
+    !areSplitsEqual(formSplits, recipients);
+
+  return {
+    showCreate: isSplit !== true || hasSplitsChanged,
+  };
+};
+
+export default useLoadSplitRecipients;

--- a/hooks/useManageSplits.ts
+++ b/hooks/useManageSplits.ts
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import { useMomentProvider } from "@/providers/MomentProvider";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { createSplit } from "@/lib/splits/createSplit";
+import { distributeSplit } from "@/lib/splits/distributeSplit";
+import { setSale } from "@/lib/moment/setSale";
+import { isPermissionError } from "@/lib/errors/isPermissionError";
+import { MomentType } from "@/types/moment";
+import { USDC_ADDRESS } from "@/lib/consts";
+import useIsSplitContract from "@/hooks/useIsSplitContract";
+
+const useManageSplits = () => {
+  const { moment, saleConfig, fetchMomentData } = useMomentProvider();
+  const { isSplit } = useIsSplitContract();
+  const { form } = useMetadataFormProvider();
+  const { getAccessToken } = usePrivy();
+  const [isCreating, setIsCreating] = useState(false);
+  const [isDistributing, setIsDistributing] = useState(false);
+  const [showPermissionModal, setShowPermissionModal] = useState(false);
+
+  const handleCreate = async () => {
+    const isValid = await form.trigger("splits");
+    const splits = form.getValues("splits");
+    if (!isValid) {
+      toast.error(form.formState.errors.splits?.message || "Splits validation failed");
+      return;
+    }
+    if (!splits || splits.length < 2) {
+      toast.error("Splits must have at least 2 recipients");
+      return;
+    }
+
+    setIsCreating(true);
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Authentication required");
+
+      const { splitAddress } = await createSplit(accessToken, splits);
+      await setSale(accessToken, moment, { fundsRecipient: splitAddress });
+      await fetchMomentData();
+      toast.success("Split created and set as funds recipient");
+    } catch (error: unknown) {
+      if (isPermissionError(error)) {
+        setShowPermissionModal(true);
+      } else {
+        toast.error((error as Error)?.message || "Failed to create split");
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleDistribute = async () => {
+    const splitAddress = saleConfig?.fundsRecipient;
+    if (!splitAddress || isSplit !== true) {
+      toast.error("No split to distribute");
+      return;
+    }
+
+    setIsDistributing(true);
+    try {
+      const tokenAddress =
+        saleConfig.type === MomentType.Erc20Mint ? USDC_ADDRESS[moment.chainId] : undefined;
+      await distributeSplit({
+        splitAddress,
+        tokenAddress,
+        chainId: moment.chainId,
+      });
+      toast.success("Split distributed");
+    } catch (error: unknown) {
+      toast.error((error as Error)?.message || "Failed to distribute split");
+    } finally {
+      setIsDistributing(false);
+    }
+  };
+
+  return {
+    handleCreate,
+    handleDistribute,
+    isCreating,
+    isDistributing,
+    isSplit,
+    showPermissionModal,
+    closePermissionModal: () => setShowPermissionModal(false),
+  };
+};
+
+export default useManageSplits;

--- a/hooks/useSetSale.ts
+++ b/hooks/useSetSale.ts
@@ -45,7 +45,11 @@ const useSetSale = () => {
         : parseEther(priceInput).toString();
       const saleStartUnix = Math.floor(saleStart.getTime() / 1000);
       const saleEndUnix = saleEnd ? Math.floor(saleEnd.getTime() / 1000) : undefined;
-      return setSale(accessToken, moment, saleStartUnix, pricePerToken, saleEndUnix);
+      return setSale(accessToken, moment, {
+        saleStart: saleStartUnix,
+        pricePerToken,
+        saleEnd: saleEndUnix,
+      });
     },
     onSuccess: () => toast.success("Sale updated successfully"),
     onError: (error: any) => {

--- a/hooks/useSetTimelineVisibility.ts
+++ b/hooks/useSetTimelineVisibility.ts
@@ -25,7 +25,7 @@ const useSetTimelineVisibility = () => {
       const accessToken = await getAccessToken();
       if (!accessToken) throw new Error("Authentication required");
       const saleStart = Math.floor(timelineAt.getTime() / 1000);
-      await setSale(accessToken, moment, saleStart);
+      await setSale(accessToken, moment, { saleStart });
       return saleStart;
     },
     onSuccess: (saleStart) => {

--- a/lib/moment/setSale.ts
+++ b/lib/moment/setSale.ts
@@ -1,14 +1,23 @@
+import { Address } from "viem";
 import { IN_PROCESS_API } from "@/lib/consts";
 import { Moment } from "@/types/moment";
 
 export const setSale = async (
   accessToken: string,
   moment: Moment,
-  saleStart: number,
-  pricePerToken?: string,
-  saleEnd?: number
+  {
+    saleStart,
+    pricePerToken,
+    saleEnd,
+    fundsRecipient,
+  }: {
+    saleStart?: number;
+    pricePerToken?: string;
+    saleEnd?: number;
+    fundsRecipient?: Address;
+  }
 ): Promise<{ hash: string; chainId: number }> => {
-  const res = await fetch(`${IN_PROCESS_API}/moment/sale`, {
+  const res = await fetch(`${IN_PROCESS_API}/sale`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -20,9 +29,10 @@ export const setSale = async (
         collectionAddress: moment.collectionAddress,
         chainId: moment.chainId,
       },
-      saleStart,
+      ...(saleStart !== undefined && { saleStart }),
       ...(pricePerToken !== undefined && { pricePerToken }),
       ...(saleEnd !== undefined && { saleEnd }),
+      ...(fundsRecipient !== undefined && { fundsRecipient }),
     }),
   });
   if (!res.ok) {

--- a/lib/splits/createSplit.ts
+++ b/lib/splits/createSplit.ts
@@ -1,0 +1,26 @@
+import { Address } from "viem";
+import { IN_PROCESS_API } from "@/lib/consts";
+
+export type SplitRecipientInput = {
+  address: string;
+  percentAllocation: number;
+};
+
+export const createSplit = async (
+  accessToken: string,
+  splits: SplitRecipientInput[]
+): Promise<{ splitAddress: Address; chainId: number }> => {
+  const res = await fetch(`${IN_PROCESS_API}/splits`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ splits }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || "Failed to create split");
+  }
+  return res.json();
+};

--- a/lib/splits/distributeSplit.ts
+++ b/lib/splits/distributeSplit.ts
@@ -1,0 +1,25 @@
+import { Address } from "viem";
+import { IN_PROCESS_API } from "@/lib/consts";
+
+export const distributeSplit = async ({
+  splitAddress,
+  tokenAddress,
+  chainId,
+}: {
+  splitAddress: Address;
+  tokenAddress?: Address;
+  chainId: number;
+}): Promise<{ status: string; hash: string }> => {
+  const params = new URLSearchParams({
+    splitAddress,
+    chainId: String(chainId),
+  });
+  if (tokenAddress) params.set("tokenAddress", tokenAddress);
+
+  const res = await fetch(`${IN_PROCESS_API}/splits?${params.toString()}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || body.message || "Failed to distribute split");
+  }
+  return res.json();
+};

--- a/lib/splits/getSplitRecipients.ts
+++ b/lib/splits/getSplitRecipients.ts
@@ -1,0 +1,37 @@
+import { Address } from "viem";
+import { getSplitsClient } from "./getSplitsClient";
+import { getPublicClient } from "@/lib/viem/publicClient";
+import { retriesGeneric } from "@/lib/protocolSdk/retries";
+import type { SplitRecipientInput } from "@/lib/splits/createSplit";
+
+const getSplitRecipients = async (
+  splitAddress: Address,
+  chainId: number
+): Promise<SplitRecipientInput[]> => {
+  const publicClient = getPublicClient(chainId);
+  const splitsClient = getSplitsClient({
+    chainId,
+    publicClient,
+  });
+
+  const splitMetadata = await retriesGeneric({
+    tryFn: async () => {
+      return await splitsClient.getSplitMetadataViaProvider({
+        splitAddress,
+      });
+    },
+    maxTries: 3,
+    linearBackoffMS: 200,
+    shouldRetryOnError: (err: { code?: number; message?: string }) =>
+      err?.code === 429 ||
+      Boolean(err?.message?.includes("timeout")) ||
+      Boolean(err?.message?.includes("network")),
+  });
+
+  return splitMetadata.split.recipients.map((recipient) => ({
+    address: recipient.recipient.address,
+    percentAllocation: Number(recipient.percentAllocation),
+  }));
+};
+
+export default getSplitRecipients;

--- a/lib/splits/getSplitsClient.ts
+++ b/lib/splits/getSplitsClient.ts
@@ -1,0 +1,15 @@
+import { SplitV2Client } from "@0xsplits/splits-sdk";
+import { PublicClient } from "viem";
+
+export const getSplitsClient = ({
+  chainId,
+  publicClient,
+}: {
+  chainId: number;
+  publicClient: PublicClient;
+}): SplitV2Client => {
+  return new SplitV2Client({
+    chainId,
+    publicClient,
+  });
+};

--- a/lib/splits/isSplitContract.ts
+++ b/lib/splits/isSplitContract.ts
@@ -1,0 +1,13 @@
+import { Address } from "viem";
+import { getPublicClient } from "@/lib/viem/publicClient";
+
+const SPLIT_BYTECODE =
+  "0x36602c57343d527f9e4ac34f21c619cefc926c8bd93b54bf5a39c7ab2127a895af1cc0691d7e3dff593da1005b3d3d3d3d363d3d37363d731e2086a7e84a32482ac03000d56925f607ccb7085af43d3d93803e605757fd5bf3";
+
+const isSplitContract = async (address: Address, chainId: number): Promise<boolean> => {
+  const publicClient = getPublicClient(chainId);
+  const bytecode = await publicClient.getCode({ address });
+  return bytecode === SPLIT_BYTECODE;
+};
+
+export default isSplitContract;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@0xsplits/splits-sdk": "^6.5.0",
     "@ar.io/wayfinder-core": "^1.9.1",
     "@ar.io/wayfinder-react": "^1.0.28",
     "@farcaster/miniapp-sdk": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      "@0xsplits/splits-sdk":
+        specifier: ^6.5.0
+        version: 6.5.0(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       "@ar.io/wayfinder-core":
         specifier: ^1.9.1
         version: 1.9.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -313,6 +316,28 @@ importers:
         version: 5.9.3
 
 packages:
+  "@0no-co/graphql.web@1.2.0":
+    resolution:
+      {
+        integrity: sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==,
+      }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+
+  "@0xsplits/splits-sdk@6.5.0":
+    resolution:
+      {
+        integrity: sha512-npgB9u7FsTs0ab2m5FCfYvP/lRZwUUoezZuLvl/xS3PtjSMm6QIJ5fSfifhzKt2jvzuwQdgGUImBQalQF9pdog==,
+      }
+    peerDependencies:
+      viem: ^2.0.0
+    peerDependenciesMeta:
+      viem:
+        optional: true
+
   "@acemir/cssom@0.9.29":
     resolution:
       {
@@ -4718,6 +4743,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@urql/core@4.3.0":
+    resolution:
+      {
+        integrity: sha512-wT+FeL8DG4x5o6RfHEnONNFVDM3616ouzATMYUClB6CB+iIu2mwfBKd7xSUxYOZmwtxna5/hDRQdMl3nbQZlnw==,
+      }
+
   "@vercel/analytics@1.6.1":
     resolution:
       {
@@ -5496,6 +5527,12 @@ packages:
     resolution:
       {
         integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+      }
+
+  base-64@1.0.0:
+    resolution:
+      {
+        integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==,
       }
 
   base-x@3.0.11:
@@ -7408,6 +7445,13 @@ packages:
         integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==,
       }
 
+  graphql@16.14.0:
+    resolution:
+      {
+        integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==,
+      }
+    engines: { node: "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0" }
+
   h3@1.15.4:
     resolution:
       {
@@ -8361,6 +8405,12 @@ packages:
     resolution:
       {
         integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
+      }
+
+  lodash@4.18.1:
+    resolution:
+      {
+        integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
       }
 
   log-update@6.1.0:
@@ -11456,6 +11506,12 @@ packages:
     engines: { node: ">= 8" }
     hasBin: true
 
+  wonka@6.3.6:
+    resolution:
+      {
+        integrity: sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==,
+      }
+
   word-wrap@1.2.5:
     resolution:
       {
@@ -11743,6 +11799,19 @@ packages:
         optional: true
 
 snapshots:
+  "@0no-co/graphql.web@1.2.0(graphql@16.14.0)":
+    optionalDependencies:
+      graphql: 16.14.0
+
+  "@0xsplits/splits-sdk@6.5.0(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))":
+    dependencies:
+      "@urql/core": 4.3.0(graphql@16.14.0)
+      base-64: 1.0.0
+      graphql: 16.14.0
+      lodash: 4.18.1
+    optionalDependencies:
+      viem: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+
   "@acemir/cssom@0.9.29": {}
 
   "@adraffy/ens-normalize@1.11.1": {}
@@ -15865,6 +15934,13 @@ snapshots:
   "@unrs/resolver-binding-win32-x64-msvc@1.11.1":
     optional: true
 
+  "@urql/core@4.3.0(graphql@16.14.0)":
+    dependencies:
+      "@0no-co/graphql.web": 1.2.0(graphql@16.14.0)
+      wonka: 6.3.6
+    transitivePeerDependencies:
+      - graphql
+
   "@vercel/analytics@1.6.1(next@16.0.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)":
     optionalDependencies:
       next: 16.0.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -17247,6 +17323,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base-64@1.0.0: {}
+
   base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -18516,6 +18594,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.14.0: {}
+
   h3@1.15.4:
     dependencies:
       cookie-es: 1.2.2
@@ -19082,6 +19162,8 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -21242,6 +21324,8 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wonka@6.3.6: {}
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary
- Add a Splits tab on the moment manage page using the create-page splits form, with Create and Distribute actions.
- Create a split then set the sale `fundsRecipient` to that address via `POST /sale`.
- Disable Distribute when the current `fundsRecipient` is not a split, and explain that Create will point proceeds at the new split.

Depends on API `POST /sale` ([#447](https://github.com/sweetmantech/in_process_api/pull/447)) and sale indexing after `setSale` ([in_process_api indexSale PR](https://github.com/sweetmantech/in_process_api/pull/new/techengme/index-sale-after-update)).

## Test plan
- [ ] Open manage for a moment whose `fundsRecipient` is not a split: hint is visible, Distribute is disabled
- [ ] Create a valid 2+ recipient split: toast succeeds, hint disappears, Distribute enables
- [ ] Distribute on an existing split succeeds
- [ ] Sale tab still saves price/window via `POST /sale`


Made with [Cursor](https://cursor.com)