### PR TITLE
Rename manage earnings tab

### DIFF
--- a/components/MomentManagePage/ManageTabs.tsx
+++ b/components/MomentManagePage/ManageTabs.tsx
@@ -38,7 +38,7 @@ const ManageTabs = ({ selectedTab, onChangeTab }: ManageTabsProps) => {
               onClick={() => onChangeTab(MANAGE_TABS.SALE)}
             />
             <TabButton
-              label="Splits"
+              label="Earnings"
               active={selectedTab === MANAGE_TABS.SPLITS}
               onClick={() => onChangeTab(MANAGE_TABS.SPLITS)}
             />


### PR DESCRIPTION
## Summary
- rename the moment manage page `Splits` tab label to `Earnings`
- keep the existing tab key and behavior unchanged

## Test plan
- not run (label-only UI change)

Made with [Cursor](https://cursor.com)