### PR TITLE
Update manage splits destination links

### DIFF
--- a/components/MomentManagePage/Splits.tsx
+++ b/components/MomentManagePage/Splits.tsx
@@ -5,22 +5,14 @@ import PermissionErrorModal from "@/components/PermissionErrorModal";
 import CopyButton from "@/components/CopyButton";
 import useManageSplits from "@/hooks/useManageSplits";
 import useLoadSplitRecipients from "@/hooks/useLoadSplitRecipients";
+import getExplorerBaseUrl from "@/lib/chains/getExplorerBaseUrl";
 import { useMomentProvider } from "@/providers/MomentProvider";
-import { mainnet, optimism, base, baseSepolia, zora } from "viem/chains";
 import FundsRecipientHint from "./FundsRecipientHint";
 
 const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
 
 const SPLIT_ADDRESS_PILL_CLASS =
   "rounded-full border border-grey-moss-100 bg-white px-2.5 py-1 font-mono text-[11.5px] text-grey-moss-300 hover:text-grey-moss-900";
-
-const EXPLORER_BY_CHAIN_ID: Record<number, string> = {
-  [mainnet.id]: "https://etherscan.io",
-  [optimism.id]: "https://optimistic.etherscan.io",
-  [base.id]: "https://basescan.org",
-  [baseSepolia.id]: "https://sepolia.basescan.org",
-  [zora.id]: "https://explorer.zora.energy",
-};
 
 const Splits = () => {
   const { handleCreate, isCreating, isSplit, showPermissionModal, closePermissionModal } =
@@ -31,7 +23,7 @@ const Splits = () => {
   const isBusy = isCreating;
   const isDisabled = isBusy || !isOwner;
   const fundsRecipientAddress = saleConfig?.fundsRecipient;
-  const explorerBaseUrl = EXPLORER_BY_CHAIN_ID[moment.chainId] ?? "https://basescan.org";
+  const explorerBaseUrl = getExplorerBaseUrl(moment.chainId);
   const splitUrl =
     fundsRecipientAddress && isSplit === true
       ? `https://app.splits.org/accounts/${fundsRecipientAddress}`

--- a/components/MomentManagePage/Splits.tsx
+++ b/components/MomentManagePage/Splits.tsx
@@ -6,6 +6,7 @@ import CopyButton from "@/components/CopyButton";
 import useManageSplits from "@/hooks/useManageSplits";
 import useLoadSplitRecipients from "@/hooks/useLoadSplitRecipients";
 import { useMomentProvider } from "@/providers/MomentProvider";
+import { mainnet, optimism, base, baseSepolia, zora } from "viem/chains";
 import FundsRecipientHint from "./FundsRecipientHint";
 
 const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider text-grey-moss-300";
@@ -13,22 +14,30 @@ const FIELD_LABEL_CLASS = "font-archivo text-[10.5px] uppercase tracking-wider t
 const SPLIT_ADDRESS_PILL_CLASS =
   "rounded-full border border-grey-moss-100 bg-white px-2.5 py-1 font-mono text-[11.5px] text-grey-moss-300 hover:text-grey-moss-900";
 
+const EXPLORER_BY_CHAIN_ID: Record<number, string> = {
+  [mainnet.id]: "https://etherscan.io",
+  [optimism.id]: "https://optimistic.etherscan.io",
+  [base.id]: "https://basescan.org",
+  [baseSepolia.id]: "https://sepolia.basescan.org",
+  [zora.id]: "https://explorer.zora.energy",
+};
+
 const Splits = () => {
-  const {
-    handleCreate,
-    handleDistribute,
-    isCreating,
-    isDistributing,
-    isSplit,
-    showPermissionModal,
-    closePermissionModal,
-  } = useManageSplits();
+  const { handleCreate, isCreating, isSplit, showPermissionModal, closePermissionModal } =
+    useManageSplits();
   const { showCreate, recipients } = useLoadSplitRecipients();
   const { isOwner, moment, saleConfig } = useMomentProvider();
 
-  const isBusy = isCreating || isDistributing;
+  const isBusy = isCreating;
   const isDisabled = isBusy || !isOwner;
-  const isDistributeDisabled = isDisabled || isSplit !== true;
+  const fundsRecipientAddress = saleConfig?.fundsRecipient;
+  const explorerBaseUrl = EXPLORER_BY_CHAIN_ID[moment.chainId] ?? "https://basescan.org";
+  const splitUrl =
+    fundsRecipientAddress && isSplit === true
+      ? `https://app.splits.org/accounts/${fundsRecipientAddress}`
+      : fundsRecipientAddress
+        ? `${explorerBaseUrl}/address/${fundsRecipientAddress}`
+        : undefined;
 
   return (
     <div className="rounded-lg border border-grey-moss-100 bg-white p-4 shadow-sm md:p-6">
@@ -37,17 +46,17 @@ const Splits = () => {
         <span className={FIELD_LABEL_CLASS}>splits</span>
       </div>
 
-      {isSplit === true && saleConfig?.fundsRecipient && (
+      {fundsRecipientAddress && splitUrl && (
         <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-grey-moss-100 bg-grey-moss-50/60 px-3.5 py-2.5">
-          <CopyButton text={saleConfig.fundsRecipient} className={SPLIT_ADDRESS_PILL_CLASS} />
-          <button
-            type="button"
-            onClick={handleDistribute}
-            disabled={isDistributeDisabled}
+          <CopyButton text={fundsRecipientAddress} className={SPLIT_ADDRESS_PILL_CLASS} />
+          <a
+            href={splitUrl}
+            target="_blank"
+            rel="noopener noreferrer"
             className="shrink-0 rounded-full border border-grey-moss-900 bg-white px-[18px] py-2 font-archivo-medium text-xs text-grey-moss-900 transition-colors hover:bg-grey-moss-50 disabled:opacity-50"
           >
-            {isDistributing ? "Distributing..." : "Distribute"}
-          </button>
+            {isSplit === true ? "View on 0xSplits" : "View on Explorer"}
+          </a>
         </div>
       )}
 

--- a/hooks/useManageSplits.ts
+++ b/hooks/useManageSplits.ts
@@ -4,20 +4,16 @@ import { toast } from "sonner";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { createSplit } from "@/lib/splits/createSplit";
-import { distributeSplit } from "@/lib/splits/distributeSplit";
 import { setSale } from "@/lib/moment/setSale";
 import { isPermissionError } from "@/lib/errors/isPermissionError";
-import { MomentType } from "@/types/moment";
-import { USDC_ADDRESS } from "@/lib/consts";
 import useIsSplitContract from "@/hooks/useIsSplitContract";
 
 const useManageSplits = () => {
-  const { moment, saleConfig, fetchMomentData } = useMomentProvider();
+  const { moment, fetchMomentData } = useMomentProvider();
   const { isSplit } = useIsSplitContract();
   const { form } = useMetadataFormProvider();
   const { getAccessToken } = usePrivy();
   const [isCreating, setIsCreating] = useState(false);
-  const [isDistributing, setIsDistributing] = useState(false);
   const [showPermissionModal, setShowPermissionModal] = useState(false);
 
   const handleCreate = async () => {
@@ -52,35 +48,9 @@ const useManageSplits = () => {
     }
   };
 
-  const handleDistribute = async () => {
-    const splitAddress = saleConfig?.fundsRecipient;
-    if (!splitAddress || isSplit !== true) {
-      toast.error("No split to distribute");
-      return;
-    }
-
-    setIsDistributing(true);
-    try {
-      const tokenAddress =
-        saleConfig.type === MomentType.Erc20Mint ? USDC_ADDRESS[moment.chainId] : undefined;
-      await distributeSplit({
-        splitAddress,
-        tokenAddress,
-        chainId: moment.chainId,
-      });
-      toast.success("Split distributed");
-    } catch (error: unknown) {
-      toast.error((error as Error)?.message || "Failed to distribute split");
-    } finally {
-      setIsDistributing(false);
-    }
-  };
-
   return {
     handleCreate,
-    handleDistribute,
     isCreating,
-    isDistributing,
     isSplit,
     showPermissionModal,
     closePermissionModal: () => setShowPermissionModal(false),

--- a/lib/chains/getExplorerBaseUrl.ts
+++ b/lib/chains/getExplorerBaseUrl.ts
@@ -1,0 +1,14 @@
+import { mainnet, optimism, base, baseSepolia, zora } from "viem/chains";
+
+const EXPLORER_BY_CHAIN_ID: Record<number, string> = {
+  [mainnet.id]: "https://etherscan.io",
+  [optimism.id]: "https://optimistic.etherscan.io",
+  [base.id]: "https://basescan.org",
+  [baseSepolia.id]: "https://sepolia.basescan.org",
+  [zora.id]: "https://explorer.zora.energy",
+};
+
+const getExplorerBaseUrl = (chainId: number): string =>
+  EXPLORER_BY_CHAIN_ID[chainId] ?? "https://basescan.org";
+
+export default getExplorerBaseUrl;


### PR DESCRIPTION
## Summary
- replace the manage splits `Distribute` action with an external view link
- route split contract addresses to 0xSplits and non-split funds recipients to the appropriate chain explorer
- remove now-unused distribute state and handler logic from `useManageSplits`

## Test plan
- not run (UI behavior and dead-code cleanup)

Made with [Cursor](https://cursor.com)