### PR TITLE
Clear create form after successful moment post

### DIFF
--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,9 +1,24 @@
 "use client";
 
+import { useEffect } from "react";
 import MetadataCreationLayout from "@/components/MetadataCreation/Layout";
 import MetadataCreation from "@/components/MetadataCreation";
+import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
+import { useBulkCreateProvider } from "@/providers/BulkCreateProvider";
+import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
 
 const Create = () => {
+  const { resetForm } = useMetadataFormProvider();
+  const { clearAll } = useBulkCreateProvider();
+  const { setCreatedTokenId } = useMomentCreateProvider();
+
+  // Provider spans /create + /create/success; clear leftovers when re-entering create
+  useEffect(() => {
+    resetForm();
+    clearAll();
+    setCreatedTokenId("");
+  }, [resetForm, clearAll, setCreatedTokenId]);
+
   return (
     <MetadataCreationLayout>
       <MetadataCreation />

--- a/components/CreateSuccess/CreateSuccess.tsx
+++ b/components/CreateSuccess/CreateSuccess.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/navigation";
 import { useMetadataFormProvider } from "@/providers/MetadataFormProvider";
 import { useCollectionsProvider } from "@/providers/CollectionsProvider";
 import { useMomentCreateProvider } from "@/providers/MomentCreateProvider/MomentCreateProvider";
-import { getCollectionTimelineUrl } from "@/lib/collection/getCollectionTimelineUrl";
 import CreatedMomentAirdrop from "./CreatedMomentAirdrop";
 import MomentCreatedHeader from "./MomentCreatedHeader";
 import Buttons from "./Buttons";
@@ -19,7 +18,7 @@ import getCreateSuccessDisplayState from "@/lib/createSuccess/getCreateSuccessDi
 import getCreateSuccessRequestState from "@/lib/createSuccess/getCreateSuccessRequestState";
 
 const CreateSuccess = () => {
-  const { name, description, price, priceUnit, writingText, resetForm } = useMetadataFormProvider();
+  const { name, description, price, priceUnit, writingText } = useMetadataFormProvider();
   const { selectedCollection, collections } = useCollectionsProvider();
   const { createdTokenId, setCreatedTokenId } = useMomentCreateProvider();
   const { push } = useRouter();
@@ -62,7 +61,6 @@ const CreateSuccess = () => {
   });
 
   const handleBackToCreate = () => {
-    resetForm();
     setCreatedTokenId("");
     push("/create");
   };

--- a/hooks/useMetadataForm.ts
+++ b/hooks/useMetadataForm.ts
@@ -82,9 +82,20 @@ const useMetadataForm = () => {
   }, []);
 
   const resetForm = useCallback(() => {
-    form.setValue("name", "", { shouldValidate: false });
-    form.setValue("description", undefined, { shouldValidate: false });
+    form.reset({
+      name: "",
+      price: "1",
+      priceUnit: "usdc" as Currency,
+      description: undefined,
+      startDate: undefined,
+      splits: undefined,
+      totalSupply: undefined,
+    });
     clearMediaState();
+    setIsOpenAdvanced(false);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
   }, [form, clearMediaState]);
 
   const resetFiles = useCallback(() => {


### PR DESCRIPTION
## Summary
- Reset create form fields, media, and bulk upload state whenever `/create` mounts again after success
- Expand `resetForm` to clear price, advanced options, splits, and the file input so subsequent moments start empty

## Test plan
- [ ] Create a moment with media + title, land on success
- [ ] Click **Back to create** — form and media are empty
- [ ] Create another moment, go to success, then use header **Create** (or browser back) — form is empty again
- [ ] Confirm success page still shows moment preview/details correctly before navigating away
- [ ] Bulk create → success → back to create — bulk items are cleared


Made with [Cursor](https://cursor.com)