### PR TITLE
Speed up feed image previews

### DIFF
--- a/components/BlurImage.tsx
+++ b/components/BlurImage.tsx
@@ -6,11 +6,13 @@ import getBlurUrl from "@/lib/media/getBlurUrl";
 
 type BlurImageProps = ImageProps & {
   src: string | undefined | null;
+  /** When true, fetch a tiny proxy preview first. Default false — LQIP doubles Arweave/proxy work. */
+  lqip?: boolean;
 };
 
-const BlurImage = ({ src, className = "", alt, ...props }: BlurImageProps) => {
+const BlurImage = ({ src, className = "", alt, lqip = false, ...props }: BlurImageProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
-  const blurUrl = getBlurUrl(src);
+  const blurUrl = lqip ? getBlurUrl(src) : null;
   const hasFill = "fill" in props && props.fill;
 
   // For local images or when blur URL can't be generated, use regular Image

--- a/components/MomentPage/MomentMediaFrame.tsx
+++ b/components/MomentPage/MomentMediaFrame.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ContentRenderer from "../Renderers";
+import { DETAIL_IMAGE_SIZES } from "../Renderers/ImageContent";
 import { useMomentProvider } from "@/providers/MomentProvider";
 import { Protocol } from "@/types/moment";
 
@@ -14,6 +15,7 @@ const MomentMediaFrame = () => {
         <ContentRenderer
           metadata={metadata}
           variant="natural"
+          sizes={DETAIL_IMAGE_SIZES}
           onRefresh={async () => {
             const result = await fetchMomentData();
             return result.data?.metadata?.animation_url;

--- a/components/Renderers/ContentRenderer.tsx
+++ b/components/Renderers/ContentRenderer.tsx
@@ -6,7 +6,7 @@ import AudioContent from "./AudioContent";
 import VideoContent from "./VideoContent";
 import HtmlContent from "./HtmlContent";
 import TextContent from "./TextContent";
-import ImageContent from "./ImageContent";
+import ImageContent, { FEED_IMAGE_SIZES } from "./ImageContent";
 import GlbContent from "./GlbContent";
 import { MomentMetadata } from "@/types/moment";
 import { getYoutubeVideoId } from "@/lib/url/getYoutubeVideoId";
@@ -16,10 +16,16 @@ import { isModelGltfMime } from "@/lib/media/isModelGltfMime";
 interface ContentRendererProps {
   metadata?: MomentMetadata;
   variant?: "fill" | "natural";
+  sizes?: string;
   onRefresh?: () => Promise<string | undefined | void>;
 }
 
-const ContentRenderer = ({ metadata, variant = "fill", onRefresh }: ContentRendererProps) => {
+const ContentRenderer = ({
+  metadata,
+  variant = "fill",
+  sizes = FEED_IMAGE_SIZES,
+  onRefresh,
+}: ContentRendererProps) => {
   const {
     mimeType,
     rawAnimationUri,
@@ -52,6 +58,7 @@ const ContentRenderer = ({ metadata, variant = "fill", onRefresh }: ContentRende
         rawAnimationUri={rawAnimationUri || rawContentUri}
         rawImageUri={rawImageUri}
         variant={variant}
+        sizes={sizes}
         onRefresh={onRefresh}
       />
     );
@@ -91,6 +98,7 @@ const ContentRenderer = ({ metadata, variant = "fill", onRefresh }: ContentRende
       rawImageUri={rawImageUri}
       alt={metadata?.name || metadata?.description || "Moment image"}
       variant={variant}
+      sizes={sizes}
     />
   );
 };

--- a/components/Renderers/ImageContent.tsx
+++ b/components/Renderers/ImageContent.tsx
@@ -1,13 +1,25 @@
 import BlurImage from "@/components/BlurImage";
 import NoPreview from "@/components/NoPreview";
 
+/** Masonry feeds are ~2–3 columns; avoid requesting 800px+ for every card. */
+export const FEED_IMAGE_SIZES = "(max-width: 768px) 100vw, (max-width: 1280px) 40vw, 420px";
+
+/** Moment detail / large single-image surfaces. */
+export const DETAIL_IMAGE_SIZES = "(max-width: 768px) 100vw, 1200px";
+
 interface ImageContentProps {
   rawImageUri: string;
   alt: string;
   variant: "fill" | "natural";
+  sizes?: string;
 }
 
-const ImageContent = ({ rawImageUri, alt, variant }: ImageContentProps) => {
+const ImageContent = ({
+  rawImageUri,
+  alt,
+  variant,
+  sizes = FEED_IMAGE_SIZES,
+}: ImageContentProps) => {
   const src = rawImageUri;
 
   if (!src) {
@@ -21,8 +33,9 @@ const ImageContent = ({ rawImageUri, alt, variant }: ImageContentProps) => {
         alt={alt}
         width={0}
         height={0}
-        sizes="(max-width: 768px) 100vw, 800px"
+        sizes={sizes}
         draggable={false}
+        className="bg-[#EDEAE2]"
         style={{ width: "100%", height: "auto" }}
       />
     );
@@ -33,8 +46,9 @@ const ImageContent = ({ rawImageUri, alt, variant }: ImageContentProps) => {
       src={src}
       alt={alt}
       fill
-      sizes="(max-width: 768px) 100vw, 800px"
+      sizes={sizes}
       draggable={false}
+      className="bg-[#EDEAE2]"
       style={{ objectFit: "contain", objectPosition: "center" }}
     />
   );

--- a/components/Renderers/VideoContent.tsx
+++ b/components/Renderers/VideoContent.tsx
@@ -8,10 +8,17 @@ interface VideoContentProps {
   rawAnimationUri: string;
   rawImageUri: string;
   variant: "fill" | "natural";
+  sizes?: string;
   onRefresh?: () => Promise<string | undefined | void>;
 }
 
-const VideoContent = ({ rawAnimationUri, rawImageUri, variant, onRefresh }: VideoContentProps) => {
+const VideoContent = ({
+  rawAnimationUri,
+  rawImageUri,
+  variant,
+  sizes,
+  onRefresh,
+}: VideoContentProps) => {
   const [videoUri, setVideoUri] = useState(rawAnimationUri);
 
   useEffect(() => {
@@ -34,6 +41,7 @@ const VideoContent = ({ rawAnimationUri, rawImageUri, variant, onRefresh }: Vide
       url={videoUri}
       thumbnail={rawImageUri || undefined}
       variant={variant}
+      sizes={sizes}
       onError={handleError}
     />
   );

--- a/components/VideoPlayer/VideoPlayer.tsx
+++ b/components/VideoPlayer/VideoPlayer.tsx
@@ -8,10 +8,11 @@ interface VideoPlayerProps {
   url: string;
   thumbnail?: string;
   variant?: "fill" | "natural";
+  sizes?: string;
   onError?: () => Promise<boolean>;
 }
 
-const VideoPlayer = ({ url, thumbnail, variant = "fill", onError }: VideoPlayerProps) => {
+const VideoPlayer = ({ url, thumbnail, variant = "fill", sizes, onError }: VideoPlayerProps) => {
   const {
     videoRef,
     isPlaying,
@@ -30,6 +31,7 @@ const VideoPlayer = ({ url, thumbnail, variant = "fill", onError }: VideoPlayerP
         onPlay={handlePlay}
         onStopPropagation={stopPropagation}
         variant={variant}
+        sizes={sizes}
       />
     );
   }
@@ -46,6 +48,7 @@ const VideoPlayer = ({ url, thumbnail, variant = "fill", onError }: VideoPlayerP
           isLoading={!isError}
           isError={isError}
           variant={variant}
+          sizes={sizes}
         />
       )}
       <video

--- a/components/VideoPlayer/VideoPreview.tsx
+++ b/components/VideoPlayer/VideoPreview.tsx
@@ -1,4 +1,5 @@
 import BlurImage from "@/components/BlurImage";
+import { FEED_IMAGE_SIZES } from "@/components/Renderers/ImageContent";
 import { type KeyboardEvent, type SyntheticEvent } from "react";
 import FilmPlaceholder from "./FilmPlaceholder";
 
@@ -9,6 +10,7 @@ interface VideoPreviewProps {
   isLoading?: boolean;
   isError?: boolean;
   variant?: "fill" | "natural";
+  sizes?: string;
 }
 
 const VideoPreview = ({
@@ -18,6 +20,7 @@ const VideoPreview = ({
   isLoading,
   isError,
   variant = "fill",
+  sizes = FEED_IMAGE_SIZES,
 }: VideoPreviewProps) => {
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -42,16 +45,23 @@ const VideoPreview = ({
     >
       {thumbnail ? (
         isFill ? (
-          <BlurImage src={thumbnail} alt="Video thumbnail" fill style={{ objectFit: "contain" }} />
+          <BlurImage
+            src={thumbnail}
+            alt="Video thumbnail"
+            fill
+            sizes={sizes}
+            className="bg-[#EDEAE2]"
+            style={{ objectFit: "contain" }}
+          />
         ) : (
           <BlurImage
             src={thumbnail}
             alt="Video thumbnail"
             width={0}
             height={0}
-            sizes="(max-width: 768px) 100vw, 800px"
+            sizes={sizes}
             style={{ width: "100%", height: "auto" }}
-            className="rounded-md"
+            className="rounded-md bg-[#EDEAE2]"
           />
         )
       ) : (


### PR DESCRIPTION
## Summary
- Disable BlurImage LQIP by default so feed cards do not hit `/media/image` twice
- Use smaller `sizes` for feed/card surfaces (~420px) to reduce proxy work
- Keep larger detail `sizes` (~1200px) on the moment page via `ContentRenderer` `sizes` prop
- Add a light placeholder background while images load

## Test plan
- [ ] Home / profile feed cards load with a single image request (no tiny LQIP fetch)
- [ ] Feed images look sharp enough in 2–3 column layout
- [ ] Moment detail image/video thumb remains sharp on large screens
- [ ] Create/bulk previews and collected cards still render


Made with [Cursor](https://cursor.com)